### PR TITLE
Remove redundant test_redis_connection function

### DIFF
--- a/TASK_MEMORY.md
+++ b/TASK_MEMORY.md
@@ -1,0 +1,86 @@
+# Task Memory
+
+**Created:** 2025-10-08 21:52:11
+**Branch:** feature/examine-the-purpose
+
+## Requirements
+
+Examine the purpose of the function test_redis_connection and remove it and all tests that use it if it's pointless
+
+## Development Notes
+
+*Update this section as you work on the task. Include:*
+- *Progress updates*
+- *Key decisions made*
+- *Challenges encountered*
+- *Solutions implemented*
+- *Files modified*
+- *Testing notes*
+
+### Work Log
+
+- [2025-10-08 21:52:11] Task setup completed, TASK_MEMORY.md created
+- [2025-10-08 21:55:00] Analysis of test_redis_connection function completed
+
+## Analysis Findings
+
+### Function Purpose
+`test_redis_connection()` in `redis_sre_agent/core/redis.py:221-229`:
+- Simple Redis connectivity test using ping()
+- Returns boolean (True=connected, False=failed)
+- Used for health checks and infrastructure initialization
+
+### Current Usage
+1. **API Metrics** (`redis_sre_agent/api/metrics.py:54`): Provides connection status for Prometheus metrics
+2. **Infrastructure Init** (`redis_sre_agent/core/redis.py:277`): Tests Redis before creating indices
+3. **Integration Test** (`tests/integration/test_retrieval_evaluation.py:35`): Pre-test Redis validation
+
+### Redundancy Analysis
+**Superior Alternative Exists**: `RedisDiagnostics._test_connection()` in `redis_sre_agent/tools/redis_diagnostics.py:70-89`:
+- More comprehensive (ping + duration + basic operations test)
+- Returns detailed metrics (ping_duration_ms, basic_operations_test)
+- Already used by diagnostic tools and SRE functions
+- Better error handling and logging
+
+### Tests That Use test_redis_connection
+1. **Direct tests** (`tests/unit/test_redis.py:108-127`): Test success/failure scenarios
+2. **Mocked usage** in infrastructure tests (lines 204, 225, 238)
+3. **Integration test** that should use real Redis connection instead
+
+## Decision
+**REMOVE**: Function is redundant and inferior to existing diagnostic tools.
+
+## Implementation Summary
+
+### Changes Made
+1. **Removed function definition** from `redis_sre_agent/core/redis.py:221-229`
+2. **Updated imports**:
+   - Removed from `redis_sre_agent/api/metrics.py:11`
+   - Removed from `tests/unit/test_redis.py:15`
+3. **Replaced usage** with direct `ping()` calls:
+   - `redis_sre_agent/api/metrics.py:54`: Replaced with `get_redis_client().ping()`
+   - `redis_sre_agent/core/redis.py:277`: Replaced with try/except block using `get_redis_client().ping()`
+   - `tests/integration/test_retrieval_evaluation.py:35`: Replaced with direct ping call
+4. **Removed direct tests** (`tests/unit/test_redis.py:108-127`):
+   - `test_redis_connection_success`
+   - `test_redis_connection_failure`
+5. **Updated infrastructure tests** to mock `get_redis_client().ping()` instead of `test_redis_connection()`:
+   - `test_initialize_redis_infrastructure_success`
+   - `test_initialize_redis_infrastructure_redis_failure`
+   - `test_initialize_redis_infrastructure_vectorizer_failure`
+
+### Testing Results
+- ✅ All unit tests pass (358 tests)
+- ✅ All Redis infrastructure tests pass (13 tests)
+- ✅ No regressions detected
+- ✅ Coverage maintained at acceptable levels
+
+### Benefits
+- **Reduced redundancy**: Eliminated duplicate Redis connection testing logic
+- **Improved consistency**: All connection tests now use the same underlying mechanism
+- **Better diagnostics**: Superior `RedisDiagnostics._test_connection()` method remains available for detailed analysis
+- **Simplified codebase**: Removed 19 lines of redundant code and tests
+
+---
+
+*This file serves as your working memory for this task. Keep it updated as you progress through the implementation.*

--- a/redis_sre_agent/api/metrics.py
+++ b/redis_sre_agent/api/metrics.py
@@ -8,7 +8,7 @@ from fastapi import APIRouter
 from fastapi.responses import PlainTextResponse
 
 from redis_sre_agent.core.config import settings
-from redis_sre_agent.core.redis import get_redis_client, test_redis_connection
+from redis_sre_agent.core.redis import get_redis_client
 
 logger = logging.getLogger(__name__)
 
@@ -51,9 +51,10 @@ async def get_application_metrics() -> Dict[str, Any]:
 
     # Redis connection status
     try:
-        redis_ok = await test_redis_connection()
+        client = get_redis_client()
+        await client.ping()
         metrics["sre_agent_redis_connection_status"] = {
-            "value": 1 if redis_ok else 0,
+            "value": 1,
             "help": "Redis connection status (1=connected, 0=disconnected)",
         }
     except Exception as e:

--- a/tests/integration/test_retrieval_evaluation.py
+++ b/tests/integration/test_retrieval_evaluation.py
@@ -30,12 +30,11 @@ async def run_retrieval_evaluation():
 
     # Check Redis connection
     try:
-        from redis_sre_agent.core.redis import test_redis_connection
+        from redis_sre_agent.core.redis import get_redis_client
 
-        redis_ok = await test_redis_connection()
-        if not redis_ok:
-            print("❌ Redis connection failed. Please ensure Redis is running.")
-            return
+        client = get_redis_client()
+        await client.ping()
+        print("✅ Redis connection successful.")
     except Exception as e:
         print(f"❌ Redis connection error: {e}")
         return


### PR DESCRIPTION
## Summary
- Remove redundant `test_redis_connection()` function and its associated tests
- Replace all usages with direct `ping()` calls for consistency  
- Update infrastructure tests to use proper mocking instead of function mocks

## Motivation
The `test_redis_connection()` function was redundant with superior functionality already available in `RedisDiagnostics._test_connection()`. The diagnostic method provides:
- Comprehensive ping testing with duration metrics
- Basic operations validation (set/get/delete)
- Better error handling and logging
- Detailed diagnostic information

## Changes
- **Removed**: Function definition from `redis_sre_agent/core/redis.py`
- **Updated**: 3 usage sites to use direct `get_redis_client().ping()` calls
- **Removed**: 2 dedicated test methods for the function
- **Updated**: 3 infrastructure tests to mock the underlying ping method
- **Cleaned**: Import statements from affected files

## Test Plan
- [x] All unit tests pass (358 tests)
- [x] All Redis infrastructure tests pass (13 tests) 
- [x] No regressions detected
- [x] Coverage maintained at acceptable levels

🤖 Generated with [Claude Code](https://claude.ai/code)