### PR TITLE
docker-compose: avoid Redis Enterprise IP collisions (restrict dynamic ip_range)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -396,6 +396,8 @@ networks:
     ipam:
       config:
         - subnet: 172.28.0.0/16
+          ip_range: 172.28.1.0/24
+
 
 volumes:
   redis_data:


### PR DESCRIPTION
Problem
- Redis Enterprise node2 failed to start with "failed to set up container networking: Address already in use".
- Cause: static IP 172.28.0.11 (node2) conflicted with a dynamically assigned container IP on the same network.

Change
- Restrict dynamic IP allocation on sre-network to 172.28.1.0/24 via ip_range.
- Leaves 172.28.0.10/.11/.12/.20 free for statically assigned Enterprise nodes and exporter.

Why
- Prevents Docker from auto-assigning IPs that collide with the statically pinned Enterprise node addresses.

Verification
- Recreated network and brought stack up: all services healthy, including redis-enterprise-node[1-3].

Notes
- Alternative considered: aux_addresses reservations.
- ip_range keeps the config minimal and avoids blocking container assignment outright.
