### PR TITLE
Extract Redis Enterprise into separate compose file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ docs-gen-check: docs-gen ## Generate reference docs and fail if files changed
 # --- Local services ---
 
 local-services: ## Start local services with docker-compose up -d
-	docker-compose up -d
+	docker compose up -d
 	@echo ""
 	@echo "Local services started:"
 	@echo "  - SRE Agent API:       http://localhost:8000"
@@ -58,12 +58,27 @@ local-services: ## Start local services with docker-compose up -d
 	@echo "  - Redis (agent):       redis://localhost:7843"
 	@echo "  - Redis (demo):        redis://localhost:7844"
 	@echo "  - Redis (replica):     redis://localhost:7845"
+	@echo ""
+	@echo "Tips:"
+	@echo "  docker compose logs -f sre-agent"
+	@echo "  docker compose logs -f grafana prometheus redis redis-demo"
+	@echo ""
+
+local-services-enterprise: ## Start local services with Redis Enterprise cluster
+	docker compose -f docker-compose.yml -f docker-compose.enterprise.yml up -d
+	@echo ""
+	@echo "Local services started (with Redis Enterprise):"
+	@echo "  - SRE Agent API:       http://localhost:8000"
+	@echo "  - SRE Agent UI:        http://localhost:3002"
+	@echo "  - Grafana:             http://localhost:3001  (login: admin / admin)"
+	@echo "  - Prometheus:          http://localhost:9090"
+	@echo "  - Redis (agent):       redis://localhost:7843"
+	@echo "  - Redis (demo):        redis://localhost:7844"
 	@echo "  - Redis Enterprise UI: https://localhost:8443  (self-signed cert)"
 	@echo "  - Redis Enterprise API:https://localhost:9443"
 	@echo ""
 	@echo "Tips:"
-	@echo "  docker-compose logs -f sre-agent"
-	@echo "  docker-compose logs -f grafana prometheus redis redis-demo"
+	@echo "  docker compose -f docker-compose.yml -f docker-compose.enterprise.yml logs -f"
 	@echo ""
 
 # --- Testing ---
@@ -123,9 +138,13 @@ redis-docs-index: sync redis-docs-sync ## Scrape and index redis docs locally (f
 
 # --- Local services management ---
 
-local-services-down: ## Stop local services (docker-compose down)
-	docker-compose down
+local-services-down: ## Stop local services (docker compose down)
+	docker compose down
 	@echo "Local services stopped."
+
+local-services-enterprise-down: ## Stop local services including Redis Enterprise
+	docker compose -f docker-compose.yml -f docker-compose.enterprise.yml down
+	@echo "Local services (with Redis Enterprise) stopped."
 
 # Usage:
 #   make local-services-logs            # follow default services
@@ -136,4 +155,4 @@ local-services-logs: ## Tail logs for key services (set SERVICES="..." to overri
 	  services="sre-agent sre-ui grafana prometheus redis redis-demo redis-demo-replica"; \
 	fi; \
 	echo "Following logs for: $$services"; \
-	docker-compose logs -f --tail=100 $$services
+	docker compose logs -f --tail=100 $$services

--- a/docker-compose.enterprise.yml
+++ b/docker-compose.enterprise.yml
@@ -1,0 +1,133 @@
+# Redis Enterprise Software - Multi-node cluster for testing enterprise runbooks
+# Use: docker compose -f docker-compose.yml -f docker-compose.enterprise.yml up
+#
+# This file contains the Redis Enterprise 3-node cluster which requires
+# significant resources (4GB memory per node). Keep it separate from the
+# default compose file for developers who don't need enterprise testing.
+
+services:
+  redis-enterprise-node1:
+    image: kurtfm/rs:latest
+    container_name: redis-enterprise-node1
+    hostname: redis-enterprise-node1
+    ports:
+      - "8443:8443"   # HTTPS Cluster Manager UI
+      - "9443:9443"   # REST API
+      - "12000:12000" # Database port
+      - "12001:12001" # Additional database port
+      - "12002:12002" # Additional database port
+    cap_add:
+      - sys_resource
+    volumes:
+      - redis_enterprise_node1_data:/opt/redislabs/persist
+    environment:
+      - CLUSTER_FQDN=cluster.local
+    deploy:
+      resources:
+        limits:
+          memory: 4G
+        reservations:
+          memory: 2G
+    healthcheck:
+      test: ["CMD", "curl", "-k", "-f", "https://localhost:8443/"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 60s
+    networks:
+      sre-network:
+        ipv4_address: 172.28.0.10
+        aliases:
+          - redis-enterprise  # Add alias for backward compatibility
+
+  redis-enterprise-node2:
+    image: kurtfm/rs:latest
+    container_name: redis-enterprise-node2
+    hostname: redis-enterprise-node2
+    ports:
+      - "8444:8443"   # HTTPS Cluster Manager UI
+      - "9444:9443"   # REST API
+      - "12003:12000" # Database port
+    cap_add:
+      - sys_resource
+    volumes:
+      - redis_enterprise_node2_data:/opt/redislabs/persist
+    environment:
+      - CLUSTER_FQDN=cluster.local
+    deploy:
+      resources:
+        limits:
+          memory: 4G
+        reservations:
+          memory: 2G
+    healthcheck:
+      test: ["CMD", "curl", "-k", "-f", "https://localhost:8443/"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 60s
+    networks:
+      sre-network:
+        ipv4_address: 172.28.0.11
+    depends_on:
+      - redis-enterprise-node1
+
+  redis-enterprise-node3:
+    image: kurtfm/rs:latest
+    container_name: redis-enterprise-node3
+    hostname: redis-enterprise-node3
+    ports:
+      - "8445:8443"   # HTTPS Cluster Manager UI
+      - "9445:9443"   # REST API
+      - "12004:12000" # Database port
+    cap_add:
+      - sys_resource
+    volumes:
+      - redis_enterprise_node3_data:/opt/redislabs/persist
+    environment:
+      - CLUSTER_FQDN=cluster.local
+    deploy:
+      resources:
+        limits:
+          memory: 4G
+        reservations:
+          memory: 2G
+    healthcheck:
+      test: ["CMD", "curl", "-k", "-f", "https://localhost:8443/"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 60s
+    networks:
+      sre-network:
+        ipv4_address: 172.28.0.12
+    depends_on:
+      - redis-enterprise-node1
+
+  # Alias for backward compatibility
+  redis-enterprise:
+    image: kurtfm/rs:latest
+    container_name: redis-enterprise
+    network_mode: "service:redis-enterprise-node1"
+    depends_on:
+      - redis-enterprise-node1
+    entrypoint: ["tail", "-f", "/dev/null"]
+
+  # Redis Enterprise database exporter (expects a DB on 12000)
+  redis-enterprise-exporter:
+    image: oliver006/redis_exporter:latest
+    ports:
+      - "9123:9121"
+    environment:
+      - REDIS_ADDR=redis://redis-enterprise-node1:12000
+      - REDIS_EXPORTER_LOG_FORMAT=txt
+    depends_on:
+      - redis-enterprise-node1
+    networks:
+      sre-network:
+        ipv4_address: 172.28.0.20
+
+volumes:
+  redis_enterprise_node1_data:
+  redis_enterprise_node2_data:
+  redis_enterprise_node3_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,114 +56,6 @@ services:
     networks:
       - sre-network
 
-  # Redis Enterprise Software - Multi-node cluster for testing enterprise runbooks
-  redis-enterprise-node1:
-    image: kurtfm/rs:latest
-    container_name: redis-enterprise-node1
-    hostname: redis-enterprise-node1
-    ports:
-      - "8443:8443"   # HTTPS Cluster Manager UI
-      - "9443:9443"   # REST API
-      - "12000:12000" # Database port
-      - "12001:12001" # Additional database port
-      - "12002:12002" # Additional database port
-    cap_add:
-      - sys_resource
-    volumes:
-      - redis_enterprise_node1_data:/opt/redislabs/persist
-    environment:
-      - CLUSTER_FQDN=cluster.local
-    deploy:
-      resources:
-        limits:
-          memory: 4G
-        reservations:
-          memory: 2G
-    healthcheck:
-      test: ["CMD", "curl", "-k", "-f", "https://localhost:8443/"]
-      interval: 30s
-      timeout: 10s
-      retries: 5
-      start_period: 60s
-    networks:
-      sre-network:
-        ipv4_address: 172.28.0.10
-        aliases:
-          - redis-enterprise  # Add alias for backward compatibility
-
-  redis-enterprise-node2:
-    image: kurtfm/rs:latest
-    container_name: redis-enterprise-node2
-    hostname: redis-enterprise-node2
-    ports:
-      - "8444:8443"   # HTTPS Cluster Manager UI
-      - "9444:9443"   # REST API
-      - "12003:12000" # Database port
-    cap_add:
-      - sys_resource
-    volumes:
-      - redis_enterprise_node2_data:/opt/redislabs/persist
-    environment:
-      - CLUSTER_FQDN=cluster.local
-    deploy:
-      resources:
-        limits:
-          memory: 4G
-        reservations:
-          memory: 2G
-    healthcheck:
-      test: ["CMD", "curl", "-k", "-f", "https://localhost:8443/"]
-      interval: 30s
-      timeout: 10s
-      retries: 5
-      start_period: 60s
-    networks:
-      sre-network:
-        ipv4_address: 172.28.0.11
-    depends_on:
-      - redis-enterprise-node1
-
-  redis-enterprise-node3:
-    image: kurtfm/rs:latest
-    container_name: redis-enterprise-node3
-    hostname: redis-enterprise-node3
-    ports:
-      - "8445:8443"   # HTTPS Cluster Manager UI
-      - "9445:9443"   # REST API
-      - "12004:12000" # Database port
-    cap_add:
-      - sys_resource
-    volumes:
-      - redis_enterprise_node3_data:/opt/redislabs/persist
-    environment:
-      - CLUSTER_FQDN=cluster.local
-    deploy:
-      resources:
-        limits:
-          memory: 4G
-        reservations:
-          memory: 2G
-    healthcheck:
-      test: ["CMD", "curl", "-k", "-f", "https://localhost:8443/"]
-      interval: 30s
-      timeout: 10s
-      retries: 5
-      start_period: 60s
-    networks:
-      sre-network:
-        ipv4_address: 172.28.0.12
-    depends_on:
-      - redis-enterprise-node1
-
-  # Alias for backward compatibility
-  redis-enterprise:
-    image: kurtfm/rs:latest
-    container_name: redis-enterprise
-    network_mode: "service:redis-enterprise-node1"
-    depends_on:
-      - redis-enterprise-node1
-    entrypoint: ["tail", "-f", "/dev/null"]
-
   # Redis Exporter for Redis demo metrics
   redis-exporter:
     image: oliver006/redis_exporter:latest
@@ -192,21 +84,6 @@ services:
         condition: service_healthy
     networks:
       - sre-network
-
-  # OPTIONAL: Redis Enterprise database exporter (expects a DB on 12000)
-  # Enable if you create a database on the cluster
-  redis-enterprise-exporter:
-    image: oliver006/redis_exporter:latest
-    ports:
-      - "9123:9121"
-    environment:
-      - REDIS_ADDR=redis://redis-enterprise-node1:12000
-      - REDIS_EXPORTER_LOG_FORMAT=txt
-    depends_on:
-      - redis-enterprise-node1
-    networks:
-      sre-network:
-        ipv4_address: 172.28.0.20
 
   # Pushgateway for demo metrics (Prometheus pulls from here; demos can push)
   pushgateway:
@@ -546,10 +423,6 @@ volumes:
   redis_data:
   redis_demo_data:
   redis_demo_replica_data:
-
-  redis_enterprise_node1_data:
-  redis_enterprise_node2_data:
-  redis_enterprise_node3_data:
   prometheus_data:
   grafana_data:
   loki_data:


### PR DESCRIPTION
Extract Redis Enterprise 3-node cluster into a separate compose file to reduce default resource usage.

## Changes
- Create `docker-compose.enterprise.yml` with RE nodes + exporter
- Remove RE services from main `docker-compose.yml` (558 → 430 lines)
- Add Makefile targets: `local-services-enterprise`, `local-services-enterprise-down`

## Usage
```bash
# Default (no Redis Enterprise)
make local-services

# With Redis Enterprise cluster
make local-services-enterprise
```

Saves ~12GB memory for developers who don't need enterprise testing.
