### PR TITLE
Pre-install GitHub MCP server in standard Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -98,6 +98,9 @@ RUN apt-get update && apt-get install -y \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
+# Pre-install MCP servers globally for faster startup (no npx download needed)
+RUN npm install -g @modelcontextprotocol/server-github
+
 # Create the application user and docker group before copying app files so we
 # can set ownership in a single COPY layer instead of a separate chown layer.
 RUN useradd --create-home --shell /bin/bash app && \

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -86,11 +86,10 @@ mcp_servers:
           {original}
 
   # GitHub MCP server for repository operations
+  # Pre-installed in Docker image via npm install -g
+  # For local development without Docker, use: npx -y @modelcontextprotocol/server-github
   github:
-    command: npx
-    args:
-      - -y
-      - "@modelcontextprotocol/server-github"
+    command: mcp-server-github
     env:
       # Set your GitHub Personal Access Token here or via environment variable
       GITHUB_PERSONAL_ACCESS_TOKEN: ${GITHUB_PERSONAL_ACCESS_TOKEN}


### PR DESCRIPTION
## Summary

Pre-install the GitHub MCP server in the standard Docker image for faster startup.

## Changes

- **Dockerfile**: Add `npm install -g @modelcontextprotocol/server-github` to pre-install the GitHub MCP server
- **config.yaml.example**: Update to use `mcp-server-github` command instead of `npx -y @modelcontextprotocol/server-github`

This matches the air-gap image behavior and eliminates the `npx` download delay on first use.
