### PR TITLE
Fix Docker entrypoint for air-gapped deployments

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -222,7 +222,7 @@ services:
       - uv_cache:/root/.cache/uv  # Persist UV cache for MCP server deps
     # Run the worker directly from the project virtualenv instead of via
     # `uv run` to avoid querying /app/.venv/bin/python3 at runtime.
-    command: redis-sre-agent worker
+    command: redis-sre-agent worker start
     # Disable healthcheck for worker (it doesn't run a web server)
     healthcheck:
       disable: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "redis-sre-agent"
-version = "0.2.4"
+version = "0.2.5"
 description = "A LangGraph-based Redis SRE Agent for infrastructure monitoring and incident response"
 readme = "README.md"
 license = {file = "LICENSE.txt"}

--- a/redis_sre_agent/cli/pipeline.py
+++ b/redis_sre_agent/cli/pipeline.py
@@ -402,7 +402,7 @@ def prepare_sources(source_dir: str, batch_date: str, prepare_only: bool, artifa
             click.echo(f"❌ Source directory does not exist: {source_path}")
             return
 
-        # Set batch date and storage
+        # Set batch date and storage (don't create dirs yet - will be created on save)
         storage = ArtifactStorage(artifacts_path)
         if batch_date:
             try:
@@ -410,12 +410,7 @@ def prepare_sources(source_dir: str, batch_date: str, prepare_only: bool, artifa
                 # Override the storage's current_date and batch path
                 storage.current_date = batch_date
                 storage.current_batch_path = storage.base_path / batch_date
-                storage.current_batch_path.mkdir(parents=True, exist_ok=True)
-                # Create category subdirectories
-                from ..pipelines.scraper.base import DocumentCategory
-
-                for category in DocumentCategory:
-                    (storage.current_batch_path / category.value).mkdir(exist_ok=True)
+                storage._dirs_created = False  # Reset so dirs are created on first save
                 batch_date_to_use = batch_date
             except ValueError:
                 click.echo(f"❌ Invalid batch date format: {batch_date}. Use YYYY-MM-DD")


### PR DESCRIPTION
## Summary

Fixes Docker image startup issues, particularly for air-gapped deployments where no external network access is available.

## Changes

### Entrypoint Script (`scripts/docker-entrypoint.sh`)
- **Remove `set -e`**: Knowledge base initialization is optional and should not prevent the application from starting
- **Use `redis-sre-agent` directly**: Changed from `uv run redis-sre-agent` to avoid PyPI lookups in air-gapped environments
- **Validate batch directories**: Only select batches that have a valid `batch_manifest.json` file
- **Filter by date format**: Only consider directories matching `YYYY-MM-DD` pattern

### Lazy Directory Creation (`redis_sre_agent/pipelines/scraper/base.py`)
- `ArtifactStorage` now creates directories lazily (on first document save) instead of eagerly on instantiation
- Prevents empty batch directories from being created when no documents are scraped

### Docker Compose (`docker-compose.yml`)
- Fixed worker command to include `start` subcommand: `redis-sre-agent worker start`

## Testing

Validated with two test scenarios:

### Test 1: Fresh SRE Agent with Empty Knowledge Base
- ✅ Agent starts without errors
- ✅ Worker starts without errors  
- ✅ KB auto-ingestion works
- ✅ Health endpoint reports all components healthy

### Test 2: Air-Gap Image with Network Isolation
- ✅ External network blocked (verified with curl to google.com, api.openai.com)
- ✅ Redis connectivity works (internal network only)
- ✅ Local HuggingFace embeddings work (`sentence-transformers/all-MiniLM-L6-v2`)
- ✅ KB ingestion succeeds in fully isolated environment
- ✅ Health endpoint reports all components healthy

## Version

Bumps version from 0.2.4 → 0.2.5
