### PR TITLE
Add redis_kb scraper to airgap build

### DIFF
--- a/Dockerfile.airgap
+++ b/Dockerfile.airgap
@@ -76,6 +76,11 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     --docs-path /app/redis-docs \
     --artifacts-path /app/artifacts || \
     echo "Warning: Could not scrape redis-docs at build time") && \
+    # Scrape redis.io/kb articles (requires web access, must be done at build time)
+    (uv run --no-sync redis-sre-agent pipeline scrape \
+    --scrapers redis_kb \
+    --artifacts-path /app/artifacts || \
+    echo "Warning: Could not scrape redis KB articles at build time") && \
     # Prepare source documents if available
     (uv run --no-sync redis-sre-agent pipeline prepare-sources \
     --source-dir /app/source_documents \

--- a/docs/operations/airgap-deployment.md
+++ b/docs/operations/airgap-deployment.md
@@ -89,9 +89,9 @@ Bundle contents:
 - `README.md` (quick start guide)
 
 !!! note "Pre-built Knowledge Base"
-    The airgap image includes pre-scraped Redis documentation and SRE runbooks in
-    `/app/artifacts`. You only need to run the **ingest** command after deployment
-    to index them into Redis.
+    The airgap image includes pre-scraped Redis documentation, Knowledge Base articles
+    (from redis.io/kb), and SRE runbooks in `/app/artifacts`. You only need to run the
+    **ingest** command after deployment to index them into Redis.
 
 #### Build Options
 


### PR DESCRIPTION
Scrapes redis.io/kb articles at build time so they are included in the airgap image alongside Redis docs.

## Changes
- Add KB scraper step to build process
- Update airgap deployment docs to mention KB articles are included

The KB articles are scraped during the Docker build (when network is available) and saved to disk. They get ingested into Redis along with the docs when running `pipeline ingest` after deployment.