### PR TITLE
Expose task tool calls in task status

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ curl -X POST http://localhost:8000/api/v1/tasks \\
 
 # Check task status
 curl http://localhost:8000/api/v1/tasks/{task_id}
+# Includes `tool_calls` when task status is `done`
 ```
 
 ## SRE Tools

--- a/docs/concepts/core.md
+++ b/docs/concepts/core.md
@@ -212,8 +212,8 @@ See `docs/how-to/tool-providers.md` for more on the tool system.
 
 ## Tasks vs. Threads
 
-- **Task**: How you interact with the agent. Create a task to run a query or triage. Each task has a `task_id` and tracks execution status (queued, running, completed, failed).
-- **Thread**: What happened during execution. Contains the conversation history, messages, tool calls, and results. Each thread has a `thread_id`.
+- **Task**: How you interact with the agent. Create a task to run a query or triage. Each task has a `task_id` and tracks execution status (queued, running, completed, failed). Completed task payloads include `tool_calls` for the final assistant message.
+- **Thread**: What happened during execution. Contains the conversation history, messages, and full decision traces (including tool call details) keyed by message ID. Each thread has a `thread_id`.
 
 When you create a task, the API creates or reuses a thread to store the execution history. You can:
 - Poll the task for status: `GET /api/v1/tasks/{task_id}`
@@ -233,7 +233,7 @@ sequenceDiagram
   Worker->>Redis: check instance
   Worker-->>API: stream updates to thread
   Client->>API: GET /api/v1/tasks/{task_id}
-  API-->>Client: status/result
+  API-->>Client: status/result/tool_calls
 ```
 
 ---

--- a/docs/how-to/api.md
+++ b/docs/how-to/api.md
@@ -133,6 +133,9 @@ curl -fsS http://localhost:8080/api/v1/tasks/<task_id> | jq
 # Get the thread state (messages, updates, result)
 curl -fsS http://localhost:8080/api/v1/threads/<thread_id> | jq
 ```
+When a task is `done`, `GET /api/v1/tasks/<task_id>` also includes a `tool_calls` field
+containing the JSON tool-call envelopes used to generate the final assistant message.
+
 Real-time updates via WebSocket:
 ```bash
 # Requires a thread_id; use any ws client (wscat, websocat)

--- a/docs/how-to/cli.md
+++ b/docs/how-to/cli.md
@@ -162,8 +162,9 @@ uv run redis-sre-agent thread sources <thread_id>
 Use these commands together when you want citation-level provenance for an answer:
 
 1. Run `thread get <thread_id>` to list messages in the thread and find assistant `message_id` values.
-2. Run `thread trace <message_id>` to inspect the decision trace for that assistant response, including tool calls and citations derived from knowledge-search tool results.
-3. Run `thread sources <thread_id>` to list retrieved knowledge fragments by thread or turn.
+2. Run `task get <task_id>` (or `GET /api/v1/tasks/<task_id>`) after completion to view `tool_calls` directly on the task payload.
+3. Run `thread trace <message_id>` to inspect the decision trace for that assistant response, including tool calls and citations derived from knowledge-search tool results.
+4. Run `thread sources <thread_id>` to list retrieved knowledge fragments by thread or turn.
 
 When a response uses knowledge search, citations are also added to the chat history as a follow-up system message (`Sources for previous response`) in the same thread.
 

--- a/docs/how-to/source-document-features.md
+++ b/docs/how-to/source-document-features.md
@@ -120,6 +120,7 @@ uv run redis-sre-agent query --agent chat --thread-id <thread_id> \
 # inspect tool envelopes and citations
 uv run redis-sre-agent thread trace <assistant_message_id> --json
 uv run redis-sre-agent thread get <thread_id> --json
+uv run redis-sre-agent task get <task_id> --json | jq '.tool_calls'
 ```
 
 ---

--- a/redis_sre_agent/api/schemas.py
+++ b/redis_sre_agent/api/schemas.py
@@ -94,6 +94,7 @@ class TaskResponse(BaseModel):
     status: TaskStatus
     updates: List[Dict[str, Any]] = Field(default_factory=list)
     result: Optional[Dict[str, Any]] = None
+    tool_calls: Optional[List[Dict[str, Any]]] = None
     error_message: Optional[str] = None
     subject: Optional[str] = None
     created_at: Optional[str] = None

--- a/redis_sre_agent/api/tasks.py
+++ b/redis_sre_agent/api/tasks.py
@@ -75,12 +75,15 @@ async def get_task(task_id: str) -> TaskResponse:
     if not state:
         raise HTTPException(status_code=404, detail="Task not found")
 
+    tool_calls = await task_manager.get_task_tool_calls(state)
+
     return TaskResponse(
         task_id=state.task_id,
         thread_id=state.thread_id,
         status=state.status,
         updates=[u.model_dump() for u in state.updates],
         result=state.result,
+        tool_calls=tool_calls,
         error_message=state.error_message,
         subject=state.metadata.subject if state.metadata else None,
         created_at=state.metadata.created_at if state.metadata else None,

--- a/redis_sre_agent/core/docket_tasks.py
+++ b/redis_sre_agent/core/docket_tasks.py
@@ -991,12 +991,17 @@ async def process_agent_turn(
                 logger.warning(f"Failed to record Q&A with citations: {e}")
 
         # Add agent response to conversation
+        assistant_message_id = str(ULID())
+        assistant_metadata = dict(agent_response.get("metadata", {}) or {})
+        assistant_metadata["task_id"] = task_id
+        assistant_metadata["message_id"] = assistant_message_id
         conversation_state["messages"].append(
             {
+                "message_id": assistant_message_id,
                 "role": "assistant",
                 "content": response_text,
                 "timestamp": datetime.now(timezone.utc).isoformat(),
-                "metadata": agent_response.get("metadata", {}),
+                "metadata": assistant_metadata,
             }
         )
 
@@ -1063,6 +1068,7 @@ async def process_agent_turn(
         # Convert clean_messages dicts to Message objects for thread storage
         thread.messages = [
             Message(
+                message_id=m.get("message_id"),
                 role=m.get("role", "user"),
                 content=m.get("content", ""),
                 metadata={k: v for k, v in m.items() if k not in ("role", "content")} or None,
@@ -1111,6 +1117,7 @@ async def process_agent_turn(
             "metadata": agent_response.get("metadata", {}),
             "thread_id": thread_id,
             "task_id": task_id,
+            "message_id": assistant_message_id,
             "turn_completed_at": datetime.now(timezone.utc).isoformat(),
         }
 
@@ -1118,31 +1125,22 @@ async def process_agent_turn(
         await task_manager.update_task_status(task_id, TaskStatus.DONE)
 
         # Store decision trace for this message (tool calls + citations)
-        # Find the last assistant message to get its message_id
         tool_envelopes = agent_response.get("tool_envelopes", [])
-        if tool_envelopes and thread.messages:
-            # Find the last assistant message's message_id
-            last_assistant_msg = None
-            for msg in reversed(thread.messages):
-                if msg.role == "assistant":
-                    last_assistant_msg = msg
-                    break
-
-            if last_assistant_msg and last_assistant_msg.message_id:
-                try:
-                    otel_trace_id = (
-                        format(_root_span.get_span_context().trace_id, "032x")
-                        if _root_span and _root_span.get_span_context().is_valid
-                        else None
-                    )
-                except Exception:
-                    otel_trace_id = None
-
-                await thread_manager.set_message_trace(
-                    message_id=last_assistant_msg.message_id,
-                    tool_envelopes=tool_envelopes,
-                    otel_trace_id=otel_trace_id,
+        if tool_envelopes and assistant_message_id:
+            try:
+                otel_trace_id = (
+                    format(_root_span.get_span_context().trace_id, "032x")
+                    if _root_span and _root_span.get_span_context().is_valid
+                    else None
                 )
+            except Exception:
+                otel_trace_id = None
+
+            await thread_manager.set_message_trace(
+                message_id=assistant_message_id,
+                tool_envelopes=tool_envelopes,
+                otel_trace_id=otel_trace_id,
+            )
 
         # Publish completion to stream for WebSocket updates
         await task_manager._publish_stream_update(

--- a/redis_sre_agent/core/tasks.py
+++ b/redis_sre_agent/core/tasks.py
@@ -301,6 +301,97 @@ class TaskManager:
             ),
         )
 
+    def _extract_message_id_from_result(self, result: Optional[Dict[str, Any]]) -> Optional[str]:
+        """Extract assistant message_id from task result if available."""
+        if not isinstance(result, dict):
+            return None
+        message_id = result.get("message_id")
+        return message_id if isinstance(message_id, str) and message_id else None
+
+    def _extract_message_id_from_updates(self, updates: List[TaskUpdate]) -> Optional[str]:
+        """Extract message_id from update metadata, preferring latest update."""
+        for update in reversed(updates or []):
+            metadata = update.metadata or {}
+            message_id = metadata.get("message_id")
+            if isinstance(message_id, str) and message_id:
+                return message_id
+        return None
+
+    async def _extract_message_id_from_thread(
+        self, *, thread_id: str, task_id: str
+    ) -> Optional[str]:
+        """Extract message_id from persisted thread messages for this task."""
+        if not thread_id:
+            return None
+
+        thread_manager = ThreadManager(redis_client=self._redis)
+        thread = await thread_manager.get_thread(thread_id)
+        if not thread or not thread.messages:
+            return None
+
+        # Prefer assistant messages tied to this task.
+        for message in reversed(thread.messages):
+            if message.role != "assistant":
+                continue
+            metadata = message.metadata or {}
+            nested_metadata = metadata.get("metadata", {})
+            if not isinstance(nested_metadata, dict):
+                nested_metadata = {}
+            if (
+                metadata.get("task_id") == task_id or nested_metadata.get("task_id") == task_id
+            ) and message.message_id:
+                return message.message_id
+
+        # Fallback to explicit message_id in assistant metadata, if present.
+        for message in reversed(thread.messages):
+            if message.role != "assistant":
+                continue
+            metadata = message.metadata or {}
+            nested_metadata = metadata.get("metadata", {})
+            if not isinstance(nested_metadata, dict):
+                nested_metadata = {}
+            metadata_message_id = metadata.get("message_id") or nested_metadata.get("message_id")
+            if isinstance(metadata_message_id, str) and metadata_message_id:
+                return metadata_message_id
+
+        # Last resort: use the most recent assistant message id.
+        for message in reversed(thread.messages):
+            if message.role == "assistant" and message.message_id:
+                return message.message_id
+
+        return None
+
+    async def get_task_tool_calls(self, task: TaskState) -> Optional[List[Dict[str, Any]]]:
+        """Return tool calls for a done task, otherwise None."""
+        if task.status != TaskStatus.DONE:
+            return None
+
+        # First, use trace data linked to the assistant message for this task.
+        message_id = (
+            self._extract_message_id_from_result(task.result)
+            or self._extract_message_id_from_updates(task.updates)
+            or await self._extract_message_id_from_thread(
+                thread_id=task.thread_id, task_id=task.task_id
+            )
+        )
+        if message_id:
+            thread_manager = ThreadManager(redis_client=self._redis)
+            trace = await thread_manager.get_message_trace(message_id)
+            if isinstance(trace, dict):
+                tool_envelopes = trace.get("tool_envelopes")
+                if isinstance(tool_envelopes, list):
+                    return tool_envelopes
+
+        # Backward-compatible fallback for older task result payloads.
+        if isinstance(task.result, dict):
+            response = task.result.get("response")
+            if isinstance(response, dict):
+                result_tool_envelopes = response.get("tool_envelopes")
+                if isinstance(result_tool_envelopes, list):
+                    return result_tool_envelopes
+
+        return []
+
 
 # TODO: Why do we need create_task() here and also in TaskManager?
 async def create_task(
@@ -374,12 +465,15 @@ async def get_task_by_id(*, task_id: str, redis_client=None) -> Dict[str, Any]:
         "subject": task.metadata.subject,
     }
 
+    tool_calls = await task_manager.get_task_tool_calls(task)
+
     return {
         "task_id": task.task_id,
         "thread_id": task.thread_id,
         "status": task.status,
         "updates": updates,
         "result": task.result,
+        "tool_calls": tool_calls,
         "error_message": task.error_message,
         "metadata": metadata,
         "context": {},

--- a/redis_sre_agent/mcp_server/server.py
+++ b/redis_sre_agent/mcp_server/server.py
@@ -976,6 +976,7 @@ async def redis_sre_get_task_status(task_id: str) -> Dict[str, Any]:
             "updated_at": metadata.get("updated_at"),
             "updates": task.get("updates", []),
             "result": task.get("result"),
+            "tool_calls": task.get("tool_calls"),
             "error_message": task.get("error_message"),
         }
 

--- a/tests/unit/api/test_tasks_api.py
+++ b/tests/unit/api/test_tasks_api.py
@@ -3,6 +3,7 @@
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from fastapi import HTTPException
 from fastapi.testclient import TestClient
 
 from redis_sre_agent.api.app import app
@@ -29,6 +30,7 @@ class TestTasksAPI:
         """GET /api/v1/tasks/{task_id} returns 404 when TaskManager returns None."""
         mock_tm = MagicMock()
         mock_tm.get_task_state = AsyncMock(return_value=None)
+        mock_tm.get_task_tool_calls = AsyncMock(return_value=None)
         with patch("redis_sre_agent.api.tasks.TaskManager", return_value=mock_tm):
             resp = client.get("/api/v1/tasks/abc123")
         assert resp.status_code == 404
@@ -51,6 +53,39 @@ class TestTasksAPI:
             data = resp.json()
             assert data["task_id"] == "t1"
             assert data["thread_id"] == "th1"
+
+    def test_create_task_missing_thread_id_returns_500(self, client):
+        """POST /api/v1/tasks returns 500 if core create_task omits thread_id."""
+        fake = {
+            "task_id": "t1",
+            "thread_id": "",
+            "status": "queued",
+            "message": "ok",
+        }
+        with (
+            patch("redis_sre_agent.api.tasks.get_redis_client"),
+            patch("redis_sre_agent.api.tasks.create_task", new=AsyncMock(return_value=fake)),
+            patch("redis_sre_agent.api.tasks.Docket") as mock_docket,
+        ):
+            resp = client.post("/api/v1/tasks", json={"message": "help"})
+
+        assert resp.status_code == 500
+        assert resp.json()["detail"] == "Failed to create thread for task"
+        mock_docket.assert_not_called()
+
+    def test_create_task_http_exception_passthrough(self, client):
+        """POST /api/v1/tasks preserves explicit HTTPException from dependencies."""
+        with (
+            patch("redis_sre_agent.api.tasks.get_redis_client"),
+            patch(
+                "redis_sre_agent.api.tasks.create_task",
+                new=AsyncMock(side_effect=HTTPException(status_code=429, detail="rate limited")),
+            ),
+        ):
+            resp = client.post("/api/v1/tasks", json={"message": "help"})
+
+        assert resp.status_code == 429
+        assert resp.json()["detail"] == "rate limited"
 
     def test_create_task_rejects_instance_and_cluster_together(self, client):
         """POST /api/v1/tasks returns 400 when both target IDs are provided."""
@@ -89,6 +124,7 @@ class TestTasksAPI:
 
         mock_tm = MagicMock()
         mock_tm.get_task_state = AsyncMock(return_value=S())
+        mock_tm.get_task_tool_calls = AsyncMock(return_value=None)
         with patch("redis_sre_agent.api.tasks.TaskManager", return_value=mock_tm):
             resp = client.get("/api/v1/tasks/t1")
         assert resp.status_code == 200
@@ -98,6 +134,34 @@ class TestTasksAPI:
         assert data["subject"] == "Test subject"
         assert data["created_at"] == "2024-01-01T00:00:00Z"
         assert data["updated_at"] == "2024-01-01T00:01:00Z"
+        assert data["tool_calls"] is None
+
+    def test_get_task_done_includes_tool_calls(self, client):
+        """GET /api/v1/tasks/{task_id} returns tool_calls for completed tasks."""
+
+        class Metadata:
+            subject = "Complete task"
+            created_at = "2024-01-01T00:00:00Z"
+            updated_at = "2024-01-01T00:01:00Z"
+
+        class S:
+            task_id = "t1"
+            thread_id = "th1"
+            status = "done"
+            updates = []
+            result = {"response": "ok"}
+            error_message = None
+            metadata = Metadata()
+
+        tool_calls = [{"name": "redis_info", "args": {"section": "memory"}, "status": "success"}]
+        mock_tm = MagicMock()
+        mock_tm.get_task_state = AsyncMock(return_value=S())
+        mock_tm.get_task_tool_calls = AsyncMock(return_value=tool_calls)
+        with patch("redis_sre_agent.api.tasks.TaskManager", return_value=mock_tm):
+            resp = client.get("/api/v1/tasks/t1")
+
+        assert resp.status_code == 200
+        assert resp.json()["tool_calls"] == tool_calls
 
     def test_delete_task_success(self, client):
         """DELETE /api/v1/tasks/{task_id} cancels Docket task and deletes core state."""

--- a/tests/unit/core/test_task_manager.py
+++ b/tests/unit/core/test_task_manager.py
@@ -1,6 +1,7 @@
 """Unit tests for TaskManager and task-related functions in core/tasks.py."""
 
 import json
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -491,6 +492,242 @@ class TestTaskManagerGetTaskState:
         assert state.updates[0].message == "Valid"
 
 
+class TestTaskManagerToolCalls:
+    """Test TaskManager.get_task_tool_calls helper."""
+
+    @pytest.fixture
+    def task_manager(self):
+        return TaskManager(redis_client=AsyncMock())
+
+    def test_extract_message_id_from_result_ignores_non_dict(self, task_manager):
+        assert task_manager._extract_message_id_from_result("not-a-dict") is None
+
+    @pytest.mark.asyncio
+    async def test_extract_message_id_from_thread_returns_none_without_thread_id(
+        self, task_manager
+    ):
+        assert (
+            await task_manager._extract_message_id_from_thread(thread_id="", task_id="task-1")
+            is None
+        )
+
+    @pytest.mark.asyncio
+    async def test_get_task_tool_calls_returns_none_for_non_done(self, task_manager):
+        task = TaskState(task_id="task-1", thread_id="thread-1", status=TaskStatus.IN_PROGRESS)
+
+        tool_calls = await task_manager.get_task_tool_calls(task)
+
+        assert tool_calls is None
+
+    @pytest.mark.asyncio
+    async def test_get_task_tool_calls_reads_trace_from_message_id(self, task_manager):
+        task = TaskState(
+            task_id="task-1",
+            thread_id="thread-1",
+            status=TaskStatus.DONE,
+            result={"message_id": "msg-1"},
+        )
+        trace = {"tool_envelopes": [{"name": "redis_info", "args": {"section": "memory"}}]}
+
+        mock_thread_manager = AsyncMock()
+        mock_thread_manager.get_message_trace = AsyncMock(return_value=trace)
+
+        with patch("redis_sre_agent.core.tasks.ThreadManager", return_value=mock_thread_manager):
+            tool_calls = await task_manager.get_task_tool_calls(task)
+
+        assert tool_calls == trace["tool_envelopes"]
+        mock_thread_manager.get_message_trace.assert_awaited_once_with("msg-1")
+
+    @pytest.mark.asyncio
+    async def test_get_task_tool_calls_uses_result_fallback(self, task_manager):
+        task = TaskState(
+            task_id="task-1",
+            thread_id="thread-1",
+            status=TaskStatus.DONE,
+            result={"response": {"tool_envelopes": [{"name": "knowledge_search"}]}},
+        )
+
+        mock_thread_manager = AsyncMock()
+        mock_thread_manager.get_message_trace = AsyncMock(return_value=None)
+        mock_thread_manager.get_thread = AsyncMock(return_value=None)
+
+        with patch("redis_sre_agent.core.tasks.ThreadManager", return_value=mock_thread_manager):
+            tool_calls = await task_manager.get_task_tool_calls(task)
+
+        assert tool_calls == [{"name": "knowledge_search"}]
+
+    @pytest.mark.asyncio
+    async def test_get_task_tool_calls_returns_empty_list_when_missing(self, task_manager):
+        task = TaskState(
+            task_id="task-1",
+            thread_id="thread-1",
+            status=TaskStatus.DONE,
+            result={},
+        )
+
+        mock_thread_manager = AsyncMock()
+        mock_thread_manager.get_message_trace = AsyncMock(return_value=None)
+        mock_thread_manager.get_thread = AsyncMock(return_value=None)
+
+        with patch("redis_sre_agent.core.tasks.ThreadManager", return_value=mock_thread_manager):
+            tool_calls = await task_manager.get_task_tool_calls(task)
+
+        assert tool_calls == []
+
+    @pytest.mark.asyncio
+    async def test_get_task_tool_calls_uses_update_message_id(self, task_manager):
+        task = TaskState(
+            task_id="task-1",
+            thread_id="thread-1",
+            status=TaskStatus.DONE,
+            updates=[
+                TaskUpdate(message="old", metadata={"message_id": "msg-old"}),
+                TaskUpdate(message="new", metadata={"message_id": "msg-new"}),
+            ],
+            result={},
+        )
+        trace = {"tool_envelopes": [{"name": "redis_info"}]}
+
+        mock_thread_manager = AsyncMock()
+        mock_thread_manager.get_message_trace = AsyncMock(return_value=trace)
+
+        with patch("redis_sre_agent.core.tasks.ThreadManager", return_value=mock_thread_manager):
+            tool_calls = await task_manager.get_task_tool_calls(task)
+
+        assert tool_calls == trace["tool_envelopes"]
+        mock_thread_manager.get_message_trace.assert_awaited_once_with("msg-new")
+
+    @pytest.mark.asyncio
+    async def test_get_task_tool_calls_extracts_message_id_from_thread_task_metadata(
+        self, task_manager
+    ):
+        task = TaskState(
+            task_id="task-1",
+            thread_id="thread-1",
+            status=TaskStatus.DONE,
+            result={},
+        )
+        thread_state = SimpleNamespace(
+            messages=[
+                SimpleNamespace(role="user", message_id="u-1", metadata={}),
+                SimpleNamespace(
+                    role="assistant",
+                    message_id="msg-from-thread",
+                    metadata={"task_id": "task-1"},
+                ),
+            ]
+        )
+        trace = {"tool_envelopes": [{"name": "redis_slowlog"}]}
+
+        mock_thread_manager = AsyncMock()
+        mock_thread_manager.get_thread = AsyncMock(return_value=thread_state)
+        mock_thread_manager.get_message_trace = AsyncMock(return_value=trace)
+
+        with patch("redis_sre_agent.core.tasks.ThreadManager", return_value=mock_thread_manager):
+            tool_calls = await task_manager.get_task_tool_calls(task)
+
+        assert tool_calls == trace["tool_envelopes"]
+        mock_thread_manager.get_thread.assert_awaited_once_with("thread-1")
+        mock_thread_manager.get_message_trace.assert_awaited_once_with("msg-from-thread")
+
+    @pytest.mark.asyncio
+    async def test_get_task_tool_calls_extracts_nested_or_fallback_message_id(self, task_manager):
+        task = TaskState(
+            task_id="task-1",
+            thread_id="thread-1",
+            status=TaskStatus.DONE,
+            result={},
+        )
+        thread_state = SimpleNamespace(
+            messages=[
+                # nested metadata fallback
+                SimpleNamespace(
+                    role="assistant",
+                    message_id=None,
+                    metadata={"metadata": {"message_id": "msg-from-nested"}},
+                ),
+                # final fallback to most recent assistant message_id
+                SimpleNamespace(
+                    role="assistant",
+                    message_id="msg-last-assistant",
+                    metadata={"task_id": "other-task"},
+                ),
+            ]
+        )
+
+        mock_thread_manager = AsyncMock()
+        mock_thread_manager.get_thread = AsyncMock(return_value=thread_state)
+        mock_thread_manager.get_message_trace = AsyncMock(return_value={"tool_envelopes": []})
+
+        with patch("redis_sre_agent.core.tasks.ThreadManager", return_value=mock_thread_manager):
+            tool_calls = await task_manager.get_task_tool_calls(task)
+
+        # nested metadata message_id is preferred before "last assistant" fallback
+        assert tool_calls == []
+        mock_thread_manager.get_message_trace.assert_awaited_once_with("msg-from-nested")
+
+    @pytest.mark.asyncio
+    async def test_get_task_tool_calls_falls_back_to_last_assistant_message_id(self, task_manager):
+        task = TaskState(
+            task_id="task-1",
+            thread_id="thread-1",
+            status=TaskStatus.DONE,
+            result={},
+        )
+        thread_state = SimpleNamespace(
+            messages=[
+                SimpleNamespace(
+                    role="assistant", message_id=None, metadata={"task_id": "other-task"}
+                ),
+                SimpleNamespace(
+                    role="assistant",
+                    message_id="msg-last-assistant",
+                    metadata={"task_id": "another-task"},
+                ),
+            ]
+        )
+        trace = {"tool_envelopes": [{"name": "knowledge_search"}]}
+
+        mock_thread_manager = AsyncMock()
+        mock_thread_manager.get_thread = AsyncMock(return_value=thread_state)
+        mock_thread_manager.get_message_trace = AsyncMock(return_value=trace)
+
+        with patch("redis_sre_agent.core.tasks.ThreadManager", return_value=mock_thread_manager):
+            tool_calls = await task_manager.get_task_tool_calls(task)
+
+        assert tool_calls == trace["tool_envelopes"]
+        mock_thread_manager.get_message_trace.assert_awaited_once_with("msg-last-assistant")
+
+    @pytest.mark.asyncio
+    async def test_get_task_tool_calls_returns_empty_when_thread_has_no_extractable_message_id(
+        self, task_manager
+    ):
+        task = TaskState(
+            task_id="task-1",
+            thread_id="thread-1",
+            status=TaskStatus.DONE,
+            result={},
+        )
+        thread_state = SimpleNamespace(
+            messages=[
+                SimpleNamespace(role="user", message_id=None, metadata={}),
+                SimpleNamespace(
+                    role="assistant", message_id=None, metadata={"metadata": "not-a-dict"}
+                ),
+            ]
+        )
+
+        mock_thread_manager = AsyncMock()
+        mock_thread_manager.get_thread = AsyncMock(return_value=thread_state)
+        mock_thread_manager.get_message_trace = AsyncMock(return_value=None)
+
+        with patch("redis_sre_agent.core.tasks.ThreadManager", return_value=mock_thread_manager):
+            tool_calls = await task_manager.get_task_tool_calls(task)
+
+        assert tool_calls == []
+        mock_thread_manager.get_message_trace.assert_not_awaited()
+
+
 class TestCreateTaskFunction:
     """Test module-level create_task function."""
 
@@ -576,6 +813,9 @@ class TestGetTaskByIdFunction:
 
         mock_task_manager = AsyncMock()
         mock_task_manager.get_task_state = AsyncMock(return_value=mock_state)
+        mock_task_manager.get_task_tool_calls = AsyncMock(
+            return_value=[{"name": "redis_info", "args": {"section": "stats"}}]
+        )
 
         with patch("redis_sre_agent.core.tasks.TaskManager", return_value=mock_task_manager):
             result = await get_task_by_id(task_id="task-123", redis_client=mock_redis)
@@ -585,6 +825,7 @@ class TestGetTaskByIdFunction:
             assert result["status"] == TaskStatus.DONE
             assert len(result["updates"]) == 1
             assert result["result"] == {"response": "Complete"}
+            assert result["tool_calls"] == [{"name": "redis_info", "args": {"section": "stats"}}]
 
     @pytest.mark.asyncio
     async def test_get_task_by_id_not_found(self):
@@ -593,6 +834,7 @@ class TestGetTaskByIdFunction:
 
         mock_task_manager = AsyncMock()
         mock_task_manager.get_task_state = AsyncMock(return_value=None)
+        mock_task_manager.get_task_tool_calls = AsyncMock(return_value=None)
 
         with patch("redis_sre_agent.core.tasks.TaskManager", return_value=mock_task_manager):
             with pytest.raises(ValueError, match="not found"):

--- a/tests/unit/core/test_tasks.py
+++ b/tests/unit/core/test_tasks.py
@@ -857,7 +857,11 @@ class TestProcessAgentTurn:
         mock_task_manager.set_task_error = AsyncMock()
 
         mock_knowledge_agent = AsyncMock()
-        mock_response = AgentResponse(response="Knowledge response", search_results=[])
+        mock_response = AgentResponse(
+            response="Knowledge response",
+            search_results=[],
+            tool_envelopes=[{"name": "redis_info", "status": "success"}],
+        )
         mock_knowledge_agent.process_query = AsyncMock(return_value=mock_response)
 
         with (
@@ -874,6 +878,9 @@ class TestProcessAgentTurn:
                 "redis_sre_agent.agent.knowledge_agent.KnowledgeOnlyAgent",
                 return_value=mock_knowledge_agent,
             ),
+            patch(
+                "redis_sre_agent.core.docket_tasks.ULID", return_value="01HXTESTMESSAGEID1234567890"
+            ),
             patch("opentelemetry.trace.get_tracer") as mock_tracer,
         ):
             mock_span = MagicMock()
@@ -881,7 +888,7 @@ class TestProcessAgentTurn:
             mock_span.set_attribute = MagicMock()
             mock_tracer.return_value.start_span.return_value = mock_span
 
-            _ = await process_agent_turn(
+            result = await process_agent_turn(
                 thread_id="thread-123",
                 message="What are Redis best practices?",
                 task_id="provided-task-123",  # Provide task_id
@@ -891,6 +898,28 @@ class TestProcessAgentTurn:
         mock_task_manager.create_task.assert_not_called()
         mock_task_manager.update_task_status.assert_any_call(
             "provided-task-123", TaskStatus.IN_PROGRESS
+        )
+        assert result["message_id"] == "01HXTESTMESSAGEID1234567890"
+
+        # Result payload should include the assistant message_id for trace lookup.
+        set_result_call = mock_task_manager.set_task_result.await_args
+        assert set_result_call.args[0] == "provided-task-123"
+        assert set_result_call.args[1]["message_id"] == "01HXTESTMESSAGEID1234567890"
+
+        # The assistant message persisted on thread should preserve message_id + task linkage metadata.
+        assistant_msgs = [m for m in mock_thread.messages if m.role == "assistant"]
+        assert assistant_msgs
+        assert assistant_msgs[-1].message_id == "01HXTESTMESSAGEID1234567890"
+        assert assistant_msgs[-1].metadata["metadata"]["task_id"] == "provided-task-123"
+        assert (
+            assistant_msgs[-1].metadata["metadata"]["message_id"] == "01HXTESTMESSAGEID1234567890"
+        )
+
+        # Tool envelopes are stored as decision trace for this assistant message_id.
+        mock_thread_manager.set_message_trace.assert_awaited_once_with(
+            message_id="01HXTESTMESSAGEID1234567890",
+            tool_envelopes=[{"name": "redis_info", "status": "success"}],
+            otel_trace_id=None,
         )
 
 

--- a/tests/unit/mcp_server/test_mcp_server.py
+++ b/tests/unit/mcp_server/test_mcp_server.py
@@ -1180,6 +1180,7 @@ class TestGetTaskStatusTool:
                 {"timestamp": "2024-01-01T00:00:30Z", "message": "Processing", "type": "progress"}
             ],
             "result": {"summary": "Complete"},
+            "tool_calls": [{"name": "redis_info", "args": {"section": "memory"}}],
             "error_message": None,
             "metadata": {
                 "subject": "Health check",
@@ -1206,6 +1207,7 @@ class TestGetTaskStatusTool:
             assert result["updated_at"] == "2024-01-01T00:01:00Z"
             assert result["updates"] == mock_task["updates"]
             assert result["result"] == {"summary": "Complete"}
+            assert result["tool_calls"] == mock_task["tool_calls"]
 
     @pytest.mark.asyncio
     async def test_get_task_status_not_found(self):

--- a/tests/unit/tools/metrics/test_prometheus_search_retry.py
+++ b/tests/unit/tools/metrics/test_prometheus_search_retry.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -11,21 +11,18 @@ async def test_search_metrics_retry_branch_returns_after_second_try():
     client_stub = MagicMock()
     client_stub.all_metrics = MagicMock(side_effect=[[], ["up", "prometheus_build_info"]])
 
-    # Patch get_client to return our stub and asyncio.sleep to be instant
-    with (
-        patch(
-            "redis_sre_agent.tools.metrics.prometheus.provider.PrometheusToolProvider.get_client",
-            return_value=client_stub,
-        ) as _gc_patch,
-        patch("asyncio.sleep") as sleep_patch,
-    ):
+    provider = PrometheusToolProvider()
+    provider.get_client = MagicMock(return_value=client_stub)
+    provider._http_get_json = AsyncMock(return_value={"status": "success", "data": []})
+
+    # Make asyncio.sleep instant.
+    with patch("asyncio.sleep") as sleep_patch:
 
         async def fast_sleep(*_args, **_kwargs):
             return None
 
         sleep_patch.side_effect = fast_sleep
-        async with PrometheusToolProvider() as provider:
-            result = await provider.search_metrics(pattern="up")
+        result = await provider.search_metrics(pattern="up")
 
     assert result["status"] == "success"
     assert "up" in result["metrics"]


### PR DESCRIPTION
## Summary
- add `tool_calls` to task status responses so citations are available directly from task data
- persist and reuse assistant `message_id` in task execution to reliably resolve message traces
- surface `tool_calls` through API and MCP task status endpoints
- add task-manager fallback logic to resolve message ids from result, updates, thread metadata, and assistant history
- update tests and docs for the task-level citation flow

Closes #88

## Validation
- `uv run pytest`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mkdocs build --strict`
- `uv run mfcqi analyze redis_sre_agent/api/schemas.py --metrics-only --silent --min-score 0.5`
- `uv run mfcqi analyze redis_sre_agent/api/tasks.py --metrics-only --silent --min-score 0.5`
- `uv run mfcqi analyze redis_sre_agent/core/docket_tasks.py --metrics-only --silent --min-score 0.5`
- `uv run mfcqi analyze redis_sre_agent/core/tasks.py --metrics-only --silent --min-score 0.5`
- `uv run mfcqi analyze redis_sre_agent/mcp_server/server.py --metrics-only --silent --min-score 0.5`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the task status response shape and adds new trace-resolution logic across task/thread storage paths, which could affect clients and tool-call retrieval for completed tasks if message IDs aren’t persisted as expected.
> 
> **Overview**
> Task status APIs now expose **`tool_calls`** (the tool-call envelopes used to generate the final assistant response) when a task is `done`, via `TaskResponse`/`GET /api/v1/tasks/{task_id}` and the MCP `redis_sre_get_task_status` tool.
> 
> To support this, task execution now generates and persists a stable assistant `message_id`, links it to the task/thread, stores decision traces keyed by that ID, and adds `TaskManager.get_task_tool_calls()` fallback logic to resolve tool calls from message traces (or older result payloads). Docs and tests were updated accordingly, plus a small Prometheus metrics retry test refactor.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 577f67252aa9d67e4ace71898972a80cd5d4f8ee. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->