### PR TITLE
Move release tutorial into release docs section

### DIFF
--- a/docs/how-to/release-tutorials/v0.2.8.md
+++ b/docs/how-to/release-tutorials/v0.2.8.md
@@ -274,7 +274,7 @@ Use the updated connection guide for:
 - Env-default credential fallback for enterprise cluster creation in CLI and API
 
 Reference:
-- [How to connect to Redis](./connect-to-redis.md)
+- [How to connect to Redis](../connect-to-redis.md)
 
 ## Known Caveats from Real Validation
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -47,13 +47,14 @@ nav:
       - Tool Providers: how-to/tool-providers.md
       - Using the CLI & API: how-to/cli.md
       - Using the API: how-to/api.md
-      - v0.2.8 release tutorial: how-to/release-v0.2.8-tutorial.md
       - Local development & testing: how-to/local-dev.md
       - Pipelines & ingestion: how-to/pipelines.md
       - Source document features: how-to/source-document-features.md
       - Configuration (Advanced):
           - Encryption: how-to/configuration/encryption.md
       - Scheduling flows: how-to/scheduling-flows.md
+      - Release tutorials:
+          - v0.2.8 release tutorial: how-to/release-tutorials/v0.2.8.md
   - UI (Experimental): ui/experimental.md
   - Concepts:
       - Overview: concepts/core.md


### PR DESCRIPTION
## Summary
- add a nested  subsection at the end of the How-to nav
- move the v0.2.8 release tutorial into that subsection
- fix the moved page's relative link to the Redis connection guide

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that updates MkDocs navigation and a relative link; main risk is broken docs navigation if paths are incorrect.
> 
> **Overview**
> Moves the `v0.2.8` release tutorial into a new **How-to → Release tutorials** subsection in `mkdocs.yml`, replacing the previous single flat nav entry.
> 
> Updates the tutorial’s Redis connection guide reference to the correct relative path after the move (`./connect-to-redis.md` → `../connect-to-redis.md`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 66175f2a7df16b33bd05da32a14e864b31fbe137. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->