### PR TITLE
Align precise search with exact identifiers

### DIFF
--- a/docs/how-to/cli.md
+++ b/docs/how-to/cli.md
@@ -86,6 +86,26 @@ uv run redis-sre-agent knowledge fragments --doc-hash <hash>
 uv run redis-sre-agent knowledge related --doc-hash <hash> --chunk-index 0
 ```
 
+#### Exact-match search notes
+- Wrap a query in quotes to force the precise-search path for exact names, document hashes, source filenames, or literal phrases.
+- Unquoted single-token identifiers that contain digits or punctuation also trigger exact matching automatically.
+- Exact-looking queries first check identifier-style fields such as `name` and `source`, then run a literal phrase search across `title`, `summary`, and `content` before semantic results are merged in.
+- General knowledge search excludes pinned docs, skills, and support tickets. Use the support-ticket tools for historical ticket lookups.
+
+Examples:
+```bash
+# Exact source filename match
+uv run redis-sre-agent knowledge search '"redis-enterprise-rladmin-cli.md"'
+
+# Exact document hash or other identifier-like value
+uv run redis-sre-agent knowledge search '"<document_hash>"'
+```
+
+For support-ticket IDs such as `RET-4421`, use the ticket workflow instead of general knowledge search:
+```bash
+uv run redis-sre-agent query --agent chat "Find support tickets for RET-4421"
+```
+
 ### 6) Schedule recurring checks
 Create a schedule that enqueues a triage with optional instance context.
 ```bash

--- a/docs/how-to/source-document-features.md
+++ b/docs/how-to/source-document-features.md
@@ -83,6 +83,22 @@ Startup instructions explicitly tell agents to:
 2. Search tickets with identifiers + symptoms.
 3. Fetch and summarize best matching ticket(s).
 
+Exact-match behavior:
+
+- `search_support_tickets("<ticket-id>")` performs exact matching on stable identifier fields before merging semantic results.
+- Exact-looking queries also run a literal phrase search across `title`, `summary`, and `content`, which lets ticket searches find documents that mention the ticket ID in their body text.
+- `get_support_ticket("<ticket-id>")` also accepts indexed chunk IDs like `sre_support_tickets:<document_hash>:chunk:<n>` and normalizes them back to the canonical ticket/document hash.
+
+Examples:
+
+```text
+search_support_tickets("RET-4421")
+get_support_ticket("RET-4421")
+get_support_ticket("sre_support_tickets:RET-4421:chunk:0")
+```
+
+For general knowledge documents, quoted queries trigger the same precise-search path. Use quotes when you need an exact name, source match, or literal phrase search over the document text.
+
 ---
 
 ## Shared System-Prompt Behavior Across Agents

--- a/redis_sre_agent/api/knowledge.py
+++ b/redis_sre_agent/api/knowledge.py
@@ -22,7 +22,14 @@ _active_jobs: Dict[str, Dict] = {}
 class SearchRequest(BaseModel):
     """Request model for knowledge base search."""
 
-    query: str = Field(..., description="Search query")
+    query: str = Field(
+        ...,
+        description=(
+            "Search query. Wrap exact identifiers such as names, document hashes, source "
+            "filenames, or literal phrases in quotes to trigger precise matching plus literal "
+            "text search before semantic results are merged."
+        ),
+    )
     category: Optional[str] = Field(None, description="Filter by category")
     doc_type: Optional[str] = Field(None, description="Filter by document type")
     limit: int = Field(10, ge=1, le=50, description="Number of results to return")
@@ -147,7 +154,14 @@ class UpdateKnowledgeSettingsRequest(BaseModel):
 
 @router.get("/search", response_model=SearchResponse)
 async def search_knowledge(
-    query: str = Query(..., description="Search query"),
+    query: str = Query(
+        ...,
+        description=(
+            "Search query. Wrap exact identifiers such as names, document hashes, source "
+            "filenames, or literal phrases in quotes to trigger precise matching plus literal "
+            "text search before semantic results are merged."
+        ),
+    ),
     category: Optional[str] = Query(None, description="Filter by category"),
     doc_type: Optional[str] = Query(None, description="Filter by document type"),
     product_labels: Optional[str] = Query(
@@ -164,7 +178,18 @@ async def search_knowledge(
         ),
     ),
 ):
-    """Search the knowledge base for relevant documents."""
+    """Search the knowledge base for relevant documents.
+
+    Notes:
+    - Quoted queries trigger a precise-search path for exact identifiers, sources,
+      and literal phrases before semantic results are merged.
+    - Unquoted single-token identifiers with digits or punctuation can also trigger
+      the precise-search path automatically.
+    - The precise-search path combines identifier equality with literal phrase
+      search across title, summary, and content.
+    - General knowledge search excludes support tickets; use the support-ticket tools
+      for historical incident lookups.
+    """
     try:
         logger.info(f"Knowledge base search: {query}")
 

--- a/redis_sre_agent/core/knowledge_helpers.py
+++ b/redis_sre_agent/core/knowledge_helpers.py
@@ -38,7 +38,6 @@ _INDEX_TYPE_TO_PREFIX = {
 _SEARCH_RETURN_FIELDS = [
     "id",
     "document_hash",
-    "content_hash",
     "chunk_index",
     "title",
     "content",
@@ -56,7 +55,7 @@ _SEARCH_RETURN_FIELDS = [
     "severity",
     "version",
 ]
-_EXACT_MATCH_TAG_FIELDS = ("name", "document_hash", "content_hash", "source")
+_EXACT_MATCH_TAG_FIELDS = ("name", "document_hash", "source")
 _SUPPORT_TICKET_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{1,127}$")
 _TEXT_PHRASE_QUERY_FIELDS = ("title", "summary", "content")
 
@@ -311,19 +310,16 @@ def _exact_match_sort_key(doc: Dict[str, Any], normalized_query: str) -> tuple[i
     lowered_query = normalized_query.lower()
     normalized_name = _doc_name(doc).strip().lower()
     document_hash = str(doc.get("document_hash") or "").strip().lower()
-    content_hash = str(doc.get("content_hash") or "").strip().lower()
     source = str(doc.get("source") or "").strip().lower()
 
     if normalized_name == lowered_query:
         rank = 0
     elif document_hash == lowered_query:
         rank = 1
-    elif content_hash == lowered_query:
-        rank = 2
     elif source == lowered_query:
-        rank = 3
+        rank = 2
     else:
-        rank = 4
+        rank = 3
 
     return (rank, normalized_name, source, _doc_chunk_index(doc))
 
@@ -422,7 +418,7 @@ def _result_score(doc: Dict[str, Any]) -> float:
     return 0.0
 
 
-async def _find_quoted_text_matches(
+async def _find_precise_text_matches(
     query: str,
     *,
     index_type: str,
@@ -431,10 +427,11 @@ async def _find_quoted_text_matches(
     doc_type: Optional[str] = None,
     config: Optional[Settings] = None,
     include_special_document_types: bool = False,
+    force_literal_phrase: bool = False,
 ) -> List[Dict[str, Any]]:
     """Find literal quoted-phrase matches on TEXT fields."""
     phrase, was_quoted = _strip_outer_quotes(query)
-    if not was_quoted or not phrase:
+    if not phrase or not (was_quoted or force_literal_phrase):
         return []
 
     normalized_index_type = index_type.strip().lower()
@@ -1125,7 +1122,8 @@ async def search_knowledge_base_helper(
 
     query_vector = vectors[0] if vectors else []
 
-    precise_search = hybrid_search or _looks_like_precise_search_query(query, normalized_index_type)
+    exact_match_search = _looks_like_precise_search_query(query, normalized_index_type)
+    precise_search = hybrid_search or exact_match_search
     exact_matches = (
         await _find_exact_document_matches(
             query=query,
@@ -1136,11 +1134,11 @@ async def search_knowledge_base_helper(
             config=config,
             include_special_document_types=include_special_document_types,
         )
-        if precise_search
+        if exact_match_search
         else []
     )
-    quoted_text_matches = (
-        await _find_quoted_text_matches(
+    precise_text_matches = (
+        await _find_precise_text_matches(
             query=query,
             index_type=normalized_index_type,
             version=version,
@@ -1148,8 +1146,9 @@ async def search_knowledge_base_helper(
             doc_type=normalized_doc_type,
             config=config,
             include_special_document_types=include_special_document_types,
+            force_literal_phrase=exact_match_search,
         )
-        if precise_search
+        if exact_match_search
         else []
     )
     effective_hybrid_search = hybrid_search or precise_search
@@ -1214,7 +1213,7 @@ async def search_knowledge_base_helper(
         _span.set_attribute("query.filtered", bool(filter_expr is not None))
     _t3 = time.monotonic()
 
-    merged_results = _dedupe_docs([*exact_matches, *quoted_text_matches, *all_results])
+    merged_results = _dedupe_docs([*exact_matches, *precise_text_matches, *all_results])
     filtered_results = [
         doc
         for doc in merged_results
@@ -1258,8 +1257,8 @@ async def search_knowledge_base_helper(
             if precise_search
             else []
         )
-        fallback_quoted_text_matches = (
-            await _find_quoted_text_matches(
+        fallback_precise_text_matches = (
+            await _find_precise_text_matches(
                 query=query,
                 index_type=normalized_index_type,
                 version=version,
@@ -1267,12 +1266,13 @@ async def search_knowledge_base_helper(
                 doc_type=normalized_doc_type,
                 config=config,
                 include_special_document_types=include_special_document_types,
+                force_literal_phrase=exact_match_search,
             )
-            if precise_search
+            if exact_match_search
             else []
         )
         merged_fallback_results = _dedupe_docs(
-            [*fallback_exact_matches, *fallback_quoted_text_matches, *category_fallback_results]
+            [*fallback_exact_matches, *fallback_precise_text_matches, *category_fallback_results]
         )
         filtered_results = [
             doc

--- a/redis_sre_agent/mcp_server/server.py
+++ b/redis_sre_agent/mcp_server/server.py
@@ -448,7 +448,10 @@ async def redis_sre_knowledge_search(
     instead, which creates a task that uses the Knowledge Agent to analyze and answer.
 
     Args:
-        query: Search query (e.g., "redis memory eviction policies")
+        query: Search query (e.g., "redis memory eviction policies"). Wrap exact
+            identifiers such as names, document hashes, source filenames, or literal
+            phrases in quotes to trigger precise matching plus literal text search
+            before semantic results are merged.
         limit: Maximum number of results (1-50, default 10)
         offset: Number of results to skip for pagination (default 0)
         category: Optional filter by category ('incident', 'maintenance', 'monitoring', etc.)
@@ -527,7 +530,8 @@ async def redis_sre_search_support_tickets(
     Uses the dedicated support-ticket index and returns ticket-scoped results.
 
     Args:
-        query: Search query text
+        query: Search query text. Exact ticket IDs such as RET-4421 are matched
+            directly before semantic results are merged.
         limit: Maximum results to return (1-50, default 10)
         offset: Number of results to skip for pagination (default 0)
         version: Redis documentation version filter. Defaults to "latest".

--- a/tests/integration/test_knowledge_search_helper_integration.py
+++ b/tests/integration/test_knowledge_search_helper_integration.py
@@ -508,10 +508,10 @@ class TestKnowledgeSearchHelper:
 
         index = await get_support_tickets_index(config=test_settings)
         exact_content = "Orthogonal ticket body"
-        semantic_content = "Failover investigation notes"
+        semantic_content = "Follow-up for RET-4421 after failover investigation"
         exact_vec = _vec(1)
         semantic_vec = _vec(0)
-        query_vec = semantic_vec[:]
+        query_vec = exact_vec[:]
         mock_vec = MockVectorizer(
             query_vec,
             {
@@ -554,7 +554,6 @@ class TestKnowledgeSearchHelper:
             search_result = await search_support_tickets_helper(
                 query="RET-4421",
                 limit=2,
-                distance_threshold=None,
                 config=test_settings,
             )
 

--- a/tests/unit/core/test_knowledge_helpers.py
+++ b/tests/unit/core/test_knowledge_helpers.py
@@ -8,6 +8,7 @@ import pytest
 from redis_sre_agent.core.knowledge_helpers import (
     _dedupe_docs,
     _doc_matches_requested_version,
+    _exact_match_sort_key,
     _quoted_text_phrase_query,
     _RawTextQuery,
     get_all_document_fragments,
@@ -54,6 +55,22 @@ class TestKnowledgeHelpers:
         assert get_related_document_fragments.__doc__ is not None
         assert "retrieve all fragments" in get_all_document_fragments.__doc__.lower()
         assert "related fragments" in get_related_document_fragments.__doc__.lower()
+
+    def test_exact_match_sort_key_ranks_source_and_non_match_after_name_and_hash(self):
+        """Source equality should outrank unrelated rows in exact-match ordering."""
+        source_match = {
+            "document_hash": "hash-1",
+            "chunk_index": 0,
+            "source": "ticket-ret-4421.md",
+        }
+        non_match = {
+            "document_hash": "hash-2",
+            "chunk_index": 1,
+            "source": "other.md",
+        }
+
+        assert _exact_match_sort_key(source_match, "ticket-ret-4421.md")[0] == 2
+        assert _exact_match_sort_key(non_match, "ticket-ret-4421.md")[0] == 3
 
 
 class TestSearchKnowledgeBaseHelper:
@@ -125,6 +142,7 @@ class TestSearchKnowledgeBaseHelper:
                         "version": "latest",
                     }
                 ],
+                [],
                 [
                     {
                         "id": "doc-semantic",
@@ -163,7 +181,8 @@ class TestSearchKnowledgeBaseHelper:
         assert result["results"][0]["id"] == "doc-exact"
         assert result["results"][0]["name"] == "ret-4421"
         assert result["results"][1]["id"] == "doc-semantic"
-        assert mock_index.query.await_args_list[1].args[0].__class__.__name__ == "HybridQuery"
+        assert mock_index.query.await_args_list[1].args[0].__class__.__name__ == "_RawTextQuery"
+        assert mock_index.query.await_args_list[2].args[0].__class__.__name__ == "HybridQuery"
 
     @pytest.mark.asyncio
     async def test_search_knowledge_base_promotes_exact_document_hash_match(self):
@@ -184,6 +203,7 @@ class TestSearchKnowledgeBaseHelper:
                         "version": "latest",
                     }
                 ],
+                [],
                 [
                     {
                         "id": "doc-semantic",
@@ -219,6 +239,68 @@ class TestSearchKnowledgeBaseHelper:
 
         assert result["results_count"] == 2
         assert result["results"][0]["document_hash"] == "abc123def456"
+        assert result["results"][1]["id"] == "doc-semantic"
+
+    @pytest.mark.asyncio
+    async def test_search_knowledge_base_identifier_query_runs_literal_text_query(self):
+        """Identifier-like queries should search TEXT fields even without wrapping quotes."""
+        mock_index = AsyncMock()
+        mock_index.query = AsyncMock(
+            side_effect=[
+                [],
+                [
+                    {
+                        "id": "doc-phrase",
+                        "document_hash": "hash-phrase",
+                        "chunk_index": 0,
+                        "title": "Follow-up incident",
+                        "content": "See RET-4421 for the original incident timeline.",
+                        "source": "alerts",
+                        "category": "incident",
+                        "doc_type": "runbook",
+                        "version": "latest",
+                        "score": 5.0,
+                    }
+                ],
+                [
+                    {
+                        "id": "doc-semantic",
+                        "document_hash": "hash-semantic",
+                        "chunk_index": 0,
+                        "title": "Memory pressure",
+                        "content": "Related semantic result",
+                        "source": "docs",
+                        "category": "incident",
+                        "doc_type": "runbook",
+                        "version": "latest",
+                        "score": 0.2,
+                    }
+                ],
+            ]
+        )
+
+        mock_vectorizer = MagicMock()
+        mock_vectorizer.aembed_many = AsyncMock(return_value=[[0.1, 0.2, 0.3]])
+
+        with (
+            patch(
+                "redis_sre_agent.core.knowledge_helpers.get_knowledge_index",
+                new_callable=AsyncMock,
+                return_value=mock_index,
+            ),
+            patch(
+                "redis_sre_agent.core.knowledge_helpers.get_vectorizer",
+                return_value=mock_vectorizer,
+            ),
+        ):
+            result = await search_knowledge_base_helper(query="RET-4421", limit=10)
+
+        literal_query = str(mock_index.query.await_args_list[1].args[0])
+        assert '@title:("ret-4421")' in literal_query
+        assert '@summary:("ret-4421")' in literal_query
+        assert '@content:("ret-4421")' in literal_query
+        assert result["results_count"] == 2
+        assert result["results"][0]["id"] == "doc-phrase"
         assert result["results"][1]["id"] == "doc-semantic"
 
     @pytest.mark.asyncio
@@ -500,9 +582,9 @@ class TestSearchKnowledgeBaseHelper:
 
     @pytest.mark.asyncio
     async def test_search_knowledge_base_hybrid_search(self):
-        """Test knowledge base hybrid search."""
+        """Hybrid search alone should not trigger exact/literal prequeries."""
         mock_index = AsyncMock()
-        mock_index.query = AsyncMock(side_effect=[[], []])
+        mock_index.query = AsyncMock(return_value=[])
 
         mock_vectorizer = MagicMock()
         mock_vectorizer.aembed_many = AsyncMock(return_value=[[0.1, 0.2, 0.3]])
@@ -525,7 +607,8 @@ class TestSearchKnowledgeBaseHelper:
             )
 
         assert result["results_count"] == 0
-        assert mock_index.query.call_count == 2
+        assert mock_index.query.call_count == 1
+        assert mock_index.query.await_args_list[0].args[0].__class__.__name__ == "HybridQuery"
 
     @pytest.mark.asyncio
     async def test_search_knowledge_base_natural_language_query_skips_exact_prequery(self):
@@ -554,6 +637,62 @@ class TestSearchKnowledgeBaseHelper:
 
         assert result["results_count"] == 0
         mock_index.query.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_search_knowledge_base_category_fallback_runs_precise_text_query_for_identifier(
+        self,
+    ):
+        """Category fallback should retry literal TEXT matching for exact-looking queries."""
+        mock_index = AsyncMock()
+        mock_index.query = AsyncMock(
+            side_effect=[
+                [],
+                [],
+                [],
+                [],
+                [],
+                [
+                    {
+                        "id": "doc-fallback-phrase",
+                        "document_hash": "hash-fallback",
+                        "chunk_index": 0,
+                        "title": "Follow-up incident",
+                        "content": "RET-4421 shows the linked failover issue.",
+                        "source": "alerts",
+                        "category": "incident",
+                        "doc_type": "runbook",
+                        "version": "latest",
+                        "score": 5.0,
+                    }
+                ],
+            ]
+        )
+
+        mock_vectorizer = MagicMock()
+        mock_vectorizer.aembed_many = AsyncMock(return_value=[[0.1, 0.2, 0.3]])
+
+        with (
+            patch(
+                "redis_sre_agent.core.knowledge_helpers.get_knowledge_index",
+                new_callable=AsyncMock,
+                return_value=mock_index,
+            ),
+            patch(
+                "redis_sre_agent.core.knowledge_helpers.get_vectorizer",
+                return_value=mock_vectorizer,
+            ),
+        ):
+            result = await search_knowledge_base_helper(
+                query="RET-4421",
+                category="incident",
+                version=None,
+                limit=10,
+            )
+
+        assert result["results_count"] == 1
+        assert result["results"][0]["id"] == "doc-fallback-phrase"
+        assert mock_index.query.call_count == 6
+        assert mock_index.query.await_args_list[5].args[0].__class__.__name__ == "_RawTextQuery"
 
     @pytest.mark.asyncio
     async def test_search_knowledge_base_with_offset(self):


### PR DESCRIPTION
## Summary
- align exact-looking knowledge queries with identifier equality plus literal text search over `title`, `summary`, and `content`
- remove `content_hash` from the public search surface while leaving `document_hash` behavior unchanged
- document the exact-match search behavior in the CLI, API, and MCP docs and add regression coverage for source ranking and category fallback

## Validation
- `uv run pytest -q tests/test_docs_snippets.py`
- `uv run pytest tests/unit/ -v --cov=redis_sre_agent --cov-report=term-missing --cov-report=xml`
- `uv run pytest -q tests/unit/core/test_knowledge_helpers.py tests/unit/api/test_knowledge_api.py tests/unit/mcp_server/test_mcp_server.py --cov=redis_sre_agent --cov-report=term-missing --cov-report=xml`
- `uvx diff-cover coverage.xml --compare-branch=origin/main` (`100%` diff coverage)
- `uv run pytest --no-cov tests/integration/test_knowledge_search_helper_integration.py -k 'support_ticket_search_and_lookup_resolve_stable_ticket_id or exact_document_hash_match_beats_semantic_result or quoted_phrase_matches_title_summary_and_content_before_semantic_result' -q` (`2 skipped` in this environment)
- `uv run ruff format --check redis_sre_agent/core/knowledge_helpers.py redis_sre_agent/api/knowledge.py redis_sre_agent/mcp_server/server.py tests/unit/core/test_knowledge_helpers.py tests/integration/test_knowledge_search_helper_integration.py`
- `uv run ruff check redis_sre_agent/core/knowledge_helpers.py redis_sre_agent/api/knowledge.py redis_sre_agent/mcp_server/server.py tests/unit/core/test_knowledge_helpers.py tests/integration/test_knowledge_search_helper_integration.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes knowledge/support-ticket search ordering and query strategy (exact-id + literal phrase prequeries) which can affect retrieval results and performance across API/CLI/MCP consumers.
> 
> **Overview**
> **Improves “precise” search behavior for identifier-like queries.** Exact-looking searches (quoted phrases or single-token IDs with digits/punctuation) now first run exact TAG matches on stable fields (`name`, `document_hash`, `source`) and a literal phrase TEXT search over `title`/`summary`/`content`, then merge those results ahead of semantic/vector matches (including in category-fallback retries).
> 
> **Removes `content_hash` from the search surface.** `content_hash` is no longer returned in search results nor used for exact-match ranking, while `document_hash` behavior is preserved.
> 
> **Documents and tests the new behavior.** Updates CLI/API/MCP docs and API parameter descriptions to explain quoting/identifier matching and support-ticket separation, and adds/adjusts unit+integration tests to cover source ranking, identifier-triggered literal text search, hybrid-search skipping prequeries, and support-ticket ID resolution.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f2dc1d11bd5b25b586cd82382e93dd59ce6a27de. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->