### PR TITLE
Use LLM factory for thread subjects

### DIFF
--- a/redis_sre_agent/api/threads.py
+++ b/redis_sre_agent/api/threads.py
@@ -26,6 +26,20 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 
+def _derive_thread_subject_source(req: ThreadCreateRequest) -> Optional[str]:
+    """Pick the best available user text to derive a generated thread subject."""
+    context = req.context or {}
+    original_query = context.get("original_query")
+    if isinstance(original_query, str) and original_query.strip():
+        return original_query.strip()
+
+    for message in req.messages or []:
+        if message.role == "user" and message.content.strip():
+            return message.content.strip()
+
+    return None
+
+
 @router.get("/threads")
 async def list_threads(
     user_id: Optional[str] = None, limit: int = 50, offset: int = 0
@@ -92,6 +106,10 @@ async def create_thread(req: ThreadCreateRequest) -> ThreadResponse:
             except Exception:
                 # Fallback for mocks/tests that patch update_thread_context only
                 await tm.update_thread_context(thread_id, {"subject": req.subject})
+        else:
+            subject_source = _derive_thread_subject_source(req)
+            if subject_source:
+                await tm.update_thread_subject(thread_id, subject_source)
 
         # Optionally append initial messages
         if req.messages:

--- a/redis_sre_agent/core/threads.py
+++ b/redis_sre_agent/core/threads.py
@@ -11,9 +11,8 @@ from redisvl.query import FilterQuery
 from redisvl.query.filter import Tag
 from ulid import ULID
 
-from redis_sre_agent.core.config import settings
 from redis_sre_agent.core.keys import RedisKeys
-from redis_sre_agent.core.llm_helpers import create_nano_async_openai_client
+from redis_sre_agent.core.llm_helpers import create_nano_llm
 from redis_sre_agent.core.redis import SRE_THREADS_INDEX, get_redis_client, get_threads_index
 
 logger = logging.getLogger(__name__)
@@ -85,13 +84,37 @@ class ThreadManager:
         """Get all Redis keys for a thread."""
         return RedisKeys.all_thread_keys(thread_id)
 
+    @staticmethod
+    def _thread_subject_fallback(original_message: str) -> str:
+        """Return a deterministic fallback subject when LLM generation fails."""
+        return original_message[:50].strip() + ("..." if len(original_message) > 50 else "")
+
+    @staticmethod
+    def _normalize_thread_subject(content: Any) -> str:
+        """Normalize string or block-style LLM content into a short subject."""
+        if isinstance(content, list):
+            parts: list[str] = []
+            for item in content:
+                if isinstance(item, dict):
+                    text = item.get("text")
+                    if isinstance(text, str) and text.strip():
+                        parts.append(text.strip())
+                elif isinstance(item, str) and item.strip():
+                    parts.append(item.strip())
+            content = " ".join(parts)
+
+        if not isinstance(content, str):
+            raise ValueError("LLM returned a non-text subject")
+
+        subject = content.strip()
+        if not subject:
+            raise ValueError("LLM returned an empty subject")
+
+        return subject.strip('"').strip("'")[:50]
+
     async def _generate_thread_subject(self, original_message: str) -> str:
         """Generate a concise subject for the thread based on the original message."""
-        try:
-            # Use a small, fast model for subject generation
-            client = create_nano_async_openai_client()
-
-            prompt = f"""Generate a concise, descriptive subject line (max 50 characters) for this SRE support request:
+        prompt = f"""Generate a concise, descriptive subject line (max 50 characters) for this SRE support request:
 
 "{original_message[:200]}..."
 
@@ -109,23 +132,15 @@ Examples:
 
 Subject:"""
 
-            response = await client.chat.completions.create(
-                model=settings.openai_model_nano,
-                messages=[{"role": "user", "content": prompt}],
-                max_completion_tokens=20,
-            )
-
-            subject = response.choices[0].message.content.strip()
-            # Remove quotes if present and truncate to 50 chars
-            subject = subject.strip('"').strip("'")[:50]
-
+        try:
+            llm = create_nano_llm()
+            response = await llm.ainvoke(prompt)
+            subject = self._normalize_thread_subject(response.content)
             logger.debug(f"Generated subject: {subject}")
             return subject
-
         except Exception as e:
             logger.warning(f"Failed to generate thread subject: {e}")
-            # Fallback to truncated original message
-            return original_message[:50].strip() + ("..." if len(original_message) > 50 else "")
+            return self._thread_subject_fallback(original_message)
 
     async def create_thread(
         self,

--- a/redis_sre_agent/core/threads.py
+++ b/redis_sre_agent/core/threads.py
@@ -133,7 +133,7 @@ Examples:
 Subject:"""
 
         try:
-            llm = create_nano_llm()
+            llm = create_nano_llm(max_tokens=20)
             response = await llm.ainvoke(prompt)
             subject = self._normalize_thread_subject(response.content)
             logger.debug(f"Generated subject: {subject}")

--- a/tests/unit/api/test_threads_api.py
+++ b/tests/unit/api/test_threads_api.py
@@ -28,6 +28,54 @@ class TestThreadsAPI:
         assert resp.status_code == 500
         assert "Redis connection failed" in resp.json()["detail"]
 
+    def test_create_thread_generates_subject_from_original_query(self, client):
+        """POST /api/v1/threads derives a subject when only original_query is provided."""
+        from redis_sre_agent.core.threads import Thread, ThreadMetadata
+
+        mock_tm = MagicMock()
+        mock_tm.create_thread = AsyncMock(return_value="th1")
+        mock_tm.update_thread_subject = AsyncMock(return_value=True)
+        mock_tm.get_thread = AsyncMock(
+            return_value=Thread(thread_id="th1", context={}, metadata=ThreadMetadata())
+        )
+
+        with patch("redis_sre_agent.api.threads.ThreadManager", return_value=mock_tm):
+            resp = client.post(
+                "/api/v1/threads",
+                json={"context": {"original_query": "Investigate Redis memory spike"}},
+            )
+
+        assert resp.status_code == 201
+        mock_tm.update_thread_subject.assert_awaited_once_with(
+            "th1", "Investigate Redis memory spike"
+        )
+
+    def test_create_thread_generates_subject_from_first_user_message(self, client):
+        """POST /api/v1/threads uses the first user message when no subject is provided."""
+        from redis_sre_agent.core.threads import Message, Thread, ThreadMetadata
+
+        mock_tm = MagicMock()
+        mock_tm.create_thread = AsyncMock(return_value="th1")
+        mock_tm.update_thread_subject = AsyncMock(return_value=True)
+        mock_tm.append_messages = AsyncMock(return_value=True)
+        mock_tm.get_thread = AsyncMock(
+            return_value=Thread(
+                thread_id="th1",
+                messages=[Message(role="user", content="Check Redis latency")],
+                context={},
+                metadata=ThreadMetadata(),
+            )
+        )
+
+        with patch("redis_sre_agent.api.threads.ThreadManager", return_value=mock_tm):
+            resp = client.post(
+                "/api/v1/threads",
+                json={"messages": [{"role": "user", "content": "Check Redis latency"}]},
+            )
+
+        assert resp.status_code == 201
+        mock_tm.update_thread_subject.assert_awaited_once_with("th1", "Check Redis latency")
+
     def test_get_thread_not_found(self, client):
         """GET /api/v1/threads/{id} returns 404 when ThreadManager returns None."""
         mock_tm = MagicMock()

--- a/tests/unit/core/test_thread_management.py
+++ b/tests/unit/core/test_thread_management.py
@@ -506,6 +506,7 @@ class TestGenerateThreadSubject:
             )
 
             assert subject == "Redis memory at 95%"
+            mock_create_nano_llm.assert_called_once_with(max_tokens=20)
             mock_llm.ainvoke.assert_awaited_once()
 
     @pytest.mark.asyncio

--- a/tests/unit/core/test_thread_management.py
+++ b/tests/unit/core/test_thread_management.py
@@ -492,37 +492,32 @@ class TestGenerateThreadSubject:
 
     @pytest.mark.asyncio
     async def test_generate_thread_subject_success(self, thread_manager):
-        """Test successful subject generation via OpenAI."""
+        """Test successful subject generation via the configured LLM factory."""
         mock_response = MagicMock()
-        mock_response.choices = [MagicMock()]
-        mock_response.choices[0].message.content = "Redis memory at 95%"
+        mock_response.content = "Redis memory at 95%"
 
-        with patch("redis_sre_agent.core.threads.create_nano_async_openai_client") as mock_openai:
-            mock_client = AsyncMock()
-            mock_openai.return_value = mock_client
-            mock_client.chat.completions.create.return_value = mock_response
+        with patch("redis_sre_agent.core.threads.create_nano_llm") as mock_create_nano_llm:
+            mock_llm = MagicMock()
+            mock_llm.ainvoke = AsyncMock(return_value=mock_response)
+            mock_create_nano_llm.return_value = mock_llm
 
             subject = await thread_manager._generate_thread_subject(
                 "My Redis server is running out of memory"
             )
 
             assert subject == "Redis memory at 95%"
-            mock_client.chat.completions.create.assert_called_once()
-            call_kwargs = mock_client.chat.completions.create.call_args.kwargs
-            assert call_kwargs.get("max_completion_tokens") == 20
-            assert "max_tokens" not in call_kwargs
+            mock_llm.ainvoke.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_generate_thread_subject_strips_quotes(self, thread_manager):
         """Test that quotes are stripped from generated subject."""
         mock_response = MagicMock()
-        mock_response.choices = [MagicMock()]
-        mock_response.choices[0].message.content = '"Redis memory issue"'
+        mock_response.content = '"Redis memory issue"'
 
-        with patch("redis_sre_agent.core.threads.create_nano_async_openai_client") as mock_openai:
-            mock_client = AsyncMock()
-            mock_openai.return_value = mock_client
-            mock_client.chat.completions.create.return_value = mock_response
+        with patch("redis_sre_agent.core.threads.create_nano_llm") as mock_create_nano_llm:
+            mock_llm = MagicMock()
+            mock_llm.ainvoke = AsyncMock(return_value=mock_response)
+            mock_create_nano_llm.return_value = mock_llm
 
             subject = await thread_manager._generate_thread_subject("test query")
             assert subject == "Redis memory issue"
@@ -531,13 +526,12 @@ class TestGenerateThreadSubject:
     async def test_generate_thread_subject_truncates_long_subject(self, thread_manager):
         """Test that subject is truncated to 50 characters."""
         mock_response = MagicMock()
-        mock_response.choices = [MagicMock()]
-        mock_response.choices[0].message.content = "A" * 100
+        mock_response.content = "A" * 100
 
-        with patch("redis_sre_agent.core.threads.create_nano_async_openai_client") as mock_openai:
-            mock_client = AsyncMock()
-            mock_openai.return_value = mock_client
-            mock_client.chat.completions.create.return_value = mock_response
+        with patch("redis_sre_agent.core.threads.create_nano_llm") as mock_create_nano_llm:
+            mock_llm = MagicMock()
+            mock_llm.ainvoke = AsyncMock(return_value=mock_response)
+            mock_create_nano_llm.return_value = mock_llm
 
             subject = await thread_manager._generate_thread_subject("test query")
             assert len(subject) == 50
@@ -545,22 +539,40 @@ class TestGenerateThreadSubject:
     @pytest.mark.asyncio
     async def test_generate_thread_subject_fallback_on_error(self, thread_manager):
         """Test fallback to truncated original message on error."""
-        with patch("redis_sre_agent.core.threads.create_nano_async_openai_client") as mock_openai:
-            mock_client = AsyncMock()
-            mock_openai.return_value = mock_client
-            mock_client.chat.completions.create.side_effect = Exception("API error")
+        with patch("redis_sre_agent.core.threads.create_nano_llm") as mock_create_nano_llm:
+            mock_llm = MagicMock()
+            mock_llm.ainvoke = AsyncMock(side_effect=Exception("LLM error"))
+            mock_create_nano_llm.return_value = mock_llm
 
             original = "This is a test query for Redis troubleshooting"
             subject = await thread_manager._generate_thread_subject(original)
             assert subject == original[:50].strip()
 
     @pytest.mark.asyncio
+    async def test_generate_thread_subject_blank_response_uses_original_fallback(
+        self, thread_manager
+    ):
+        """Test an empty LLM response falls back to the original message."""
+        mock_response = MagicMock()
+        mock_response.content = "   "
+
+        with patch("redis_sre_agent.core.threads.create_nano_llm") as mock_create_nano_llm:
+            mock_llm = MagicMock()
+            mock_llm.ainvoke = AsyncMock(return_value=mock_response)
+            mock_create_nano_llm.return_value = mock_llm
+
+            original = "This is a test query for Redis troubleshooting"
+            subject = await thread_manager._generate_thread_subject(original)
+
+            assert subject == original[:50].strip()
+
+    @pytest.mark.asyncio
     async def test_generate_thread_subject_long_original_fallback(self, thread_manager):
         """Test fallback adds ellipsis for long messages."""
-        with patch("redis_sre_agent.core.threads.create_nano_async_openai_client") as mock_openai:
-            mock_client = AsyncMock()
-            mock_openai.return_value = mock_client
-            mock_client.chat.completions.create.side_effect = Exception("API error")
+        with patch("redis_sre_agent.core.threads.create_nano_llm") as mock_create_nano_llm:
+            mock_llm = MagicMock()
+            mock_llm.ainvoke = AsyncMock(side_effect=Exception("LLM error"))
+            mock_create_nano_llm.return_value = mock_llm
 
             original = "A" * 100
             subject = await thread_manager._generate_thread_subject(original)


### PR DESCRIPTION
## Summary
- generate thread subjects through `create_nano_llm()` instead of a low-level async client
- auto-generate a subject for `POST /threads` when the request includes an original query or initial user message
- add regression coverage for factory-backed subject generation and API subject derivation

## Testing
- `uv run pytest tests/unit/core/test_thread_management.py tests/unit/api/test_threads_api.py`
- pre-commit hooks via `git commit` (`ruff format`, `ruff check`, `pytest tests/unit/`)

Fixes #115

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes thread subject generation logic and `POST /threads` behavior, which could affect user-visible thread metadata and introduce subtle differences in LLM responses/normalization.
> 
> **Overview**
> Thread subject generation now goes through the `create_nano_llm()` factory (instead of a direct async OpenAI client), with added normalization to handle non-string/block-style outputs and a deterministic fallback when generation fails.
> 
> `POST /api/v1/threads` now auto-generates a subject when none is provided by deriving source text from `context.original_query` or the first user message, and new unit tests cover both the API subject derivation and factory-backed subject generation (including blank-response fallback).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f185634ddc735ba375e3ba68e3635d74f53e9c31. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->