### PR TITLE
Fix issue #99: record pinned startup context in citations

### DIFF
--- a/redis_sre_agent/agent/chat_agent.py
+++ b/redis_sre_agent/agent/chat_agent.py
@@ -36,7 +36,7 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 from .helpers import build_result_envelope
-from .knowledge_context import build_startup_knowledge_context
+from .knowledge_context import build_startup_knowledge_context, merge_internal_tool_envelopes
 from .models import AgentResponse
 
 logger = logging.getLogger(__name__)
@@ -436,6 +436,7 @@ class ChatAgent:
             iteration_count = state.get("iteration_count", 0)
             startup_system_prompt = state.get("startup_system_prompt")
             startup_prompt_initialized = state.get("startup_prompt_initialized", False)
+            signals_envelopes = list(state.get("signals_envelopes") or [])
 
             if (
                 startup_system_prompt is None
@@ -460,6 +461,10 @@ class ChatAgent:
                         version="latest",
                         available_tools=list(tooldefs_by_name.values()),
                     )
+                    signals_envelopes = merge_internal_tool_envelopes(
+                        signals_envelopes,
+                        getattr(startup_context, "internal_tool_envelopes", []),
+                    )
                     startup_system_prompt = (
                         f"{startup_context}\n\n{CHAT_SYSTEM_PROMPT}"
                         if startup_context.strip()
@@ -480,6 +485,7 @@ class ChatAgent:
                 "iteration_count": iteration_count + 1,
                 "startup_system_prompt": startup_system_prompt,
                 "startup_prompt_initialized": startup_prompt_initialized,
+                "signals_envelopes": signals_envelopes,
                 "current_tool_calls": response.tool_calls
                 if hasattr(response, "tool_calls")
                 else [],
@@ -716,7 +722,10 @@ User Query: {query}"""
                 "max_iterations": max_iterations,
                 "startup_system_prompt": system_prompt,
                 "startup_prompt_initialized": True,
-                "signals_envelopes": [],  # Track tool outputs - citations derived via extract_citations()
+                "signals_envelopes": merge_internal_tool_envelopes(
+                    [],
+                    getattr(startup_context, "internal_tool_envelopes", []),
+                ),
             }
 
             thread_config = {"configurable": {"thread_id": session_id}}

--- a/redis_sre_agent/agent/helpers.py
+++ b/redis_sre_agent/agent/helpers.py
@@ -11,6 +11,13 @@ from typing import Any, Dict, List, Optional
 import jmespath
 from jmespath.exceptions import JMESPathError
 
+KNOWLEDGE_SEARCH_RETRIEVAL_KIND = "knowledge_search"
+KNOWLEDGE_SEARCH_RETRIEVAL_LABEL = "Knowledge search"
+STARTUP_CONTEXT_CITATION_GROUP = "startup_context_loaded"
+STARTUP_CONTEXT_CITATION_GROUP_LABEL = "Startup context loaded"
+DISCOVERED_CONTEXT_CITATION_GROUP = "discovered_context"
+DISCOVERED_CONTEXT_CITATION_GROUP_LABEL = "Discovered context"
+
 
 def parse_json_maybe_fenced(text: str) -> Any:
     """Parse JSON that may be wrapped in markdown code fences (``` or ```json).
@@ -309,6 +316,7 @@ def extract_citations(envelopes: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
 
     for envelope in envelopes:
         tool_key = envelope.get("tool_key", "")
+        name = str(envelope.get("name", ""))
 
         # Match knowledge search tools by tool_key containing "knowledge"
         if "knowledge" not in tool_key.lower():
@@ -323,12 +331,75 @@ def extract_citations(envelopes: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
         if not isinstance(results, list):
             continue
 
+        default_retrieval_kind = str(data.get("retrieval_kind", "")).strip()
+        default_retrieval_label = str(data.get("retrieval_label", "")).strip()
+        if not default_retrieval_kind:
+            if "pinned_context" in tool_key.lower() or "pinned_context" in name.lower():
+                default_retrieval_kind = "pinned_context"
+                default_retrieval_label = default_retrieval_label or "Pinned context"
+            elif "search" in tool_key.lower() or "search" in name.lower():
+                default_retrieval_kind = KNOWLEDGE_SEARCH_RETRIEVAL_KIND
+                default_retrieval_label = default_retrieval_label or KNOWLEDGE_SEARCH_RETRIEVAL_LABEL
+
         # Add each result as a citation (preserving all fields)
         for result in results:
             if isinstance(result, dict):
-                citations.append(result)
+                citation = dict(result)
+                if default_retrieval_kind:
+                    citation.setdefault("retrieval_kind", default_retrieval_kind)
+                if default_retrieval_label:
+                    citation.setdefault("retrieval_label", default_retrieval_label)
+                citations.append(citation)
 
     return citations
+
+
+def build_citation_groups(citations: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Group citations into startup context and discovered context buckets."""
+    grouped = {
+        DISCOVERED_CONTEXT_CITATION_GROUP: {
+            "group_key": DISCOVERED_CONTEXT_CITATION_GROUP,
+            "label": DISCOVERED_CONTEXT_CITATION_GROUP_LABEL,
+            "citations": [],
+        },
+        STARTUP_CONTEXT_CITATION_GROUP: {
+            "group_key": STARTUP_CONTEXT_CITATION_GROUP,
+            "label": STARTUP_CONTEXT_CITATION_GROUP_LABEL,
+            "citations": [],
+        },
+    }
+
+    for citation in citations or []:
+        retrieval_kind = str(citation.get("retrieval_kind", "")).strip().lower()
+        group_key = (
+            STARTUP_CONTEXT_CITATION_GROUP
+            if retrieval_kind == "pinned_context"
+            else DISCOVERED_CONTEXT_CITATION_GROUP
+        )
+        grouped[group_key]["citations"].append(citation)
+
+    ordered_groups: List[Dict[str, Any]] = []
+    for group_key in (
+        DISCOVERED_CONTEXT_CITATION_GROUP,
+        STARTUP_CONTEXT_CITATION_GROUP,
+    ):
+        group = grouped[group_key]
+        citations_for_group = list(group["citations"])
+        if not citations_for_group:
+            continue
+        ordered_groups.append(
+            {
+                **group,
+                "count": len(citations_for_group),
+            }
+        )
+
+    return ordered_groups
+
+
+def extract_citation_groups(envelopes: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Extract and group citations from tool envelopes."""
+    return build_citation_groups(extract_citations(envelopes))
 
 
 def query_tool_data(envelopes: List[Dict[str, Any]], tool_key: str, query: str) -> Any:

--- a/redis_sre_agent/agent/helpers.py
+++ b/redis_sre_agent/agent/helpers.py
@@ -339,7 +339,9 @@ def extract_citations(envelopes: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
                 default_retrieval_label = default_retrieval_label or "Pinned context"
             elif "search" in tool_key.lower() or "search" in name.lower():
                 default_retrieval_kind = KNOWLEDGE_SEARCH_RETRIEVAL_KIND
-                default_retrieval_label = default_retrieval_label or KNOWLEDGE_SEARCH_RETRIEVAL_LABEL
+                default_retrieval_label = (
+                    default_retrieval_label or KNOWLEDGE_SEARCH_RETRIEVAL_LABEL
+                )
 
         # Add each result as a citation (preserving all fields)
         for result in results:

--- a/redis_sre_agent/agent/knowledge_agent.py
+++ b/redis_sre_agent/agent/knowledge_agent.py
@@ -25,8 +25,8 @@ from redis_sre_agent.core.progress import (
 )
 from redis_sre_agent.tools.manager import ToolManager
 
-from .helpers import build_result_envelope
-from .knowledge_context import build_startup_knowledge_context
+from .helpers import build_result_envelope, extract_citations
+from .knowledge_context import build_startup_knowledge_context, merge_internal_tool_envelopes
 from .models import AgentResponse
 
 logger = logging.getLogger(__name__)
@@ -140,6 +140,7 @@ class KnowledgeOnlyAgent:
             iteration_count = state.get("iteration_count", 0)
             startup_system_prompt = state.get("startup_system_prompt")
             startup_prompt_initialized = state.get("startup_prompt_initialized", False)
+            signals_envelopes = list(state.get("signals_envelopes") or [])
 
             # Cache and reuse startup prompt for this workflow execution to avoid repeated
             # knowledge-context lookups in tool-call loops.
@@ -165,6 +166,10 @@ class KnowledgeOnlyAgent:
                         query=context_query,
                         version="latest",
                         available_tools=list(tooldefs_by_name.values()),
+                    )
+                    signals_envelopes = merge_internal_tool_envelopes(
+                        signals_envelopes,
+                        getattr(startup_context, "internal_tool_envelopes", []),
                     )
                     startup_system_prompt = (
                         f"{startup_context}\n\n{KNOWLEDGE_SYSTEM_PROMPT}"
@@ -265,6 +270,7 @@ class KnowledgeOnlyAgent:
                 # No per-iteration progress message; providers will emit status updates
                 state["startup_system_prompt"] = startup_system_prompt
                 state["startup_prompt_initialized"] = startup_prompt_initialized
+                state["signals_envelopes"] = signals_envelopes
                 return state
 
             except Exception as e:
@@ -276,6 +282,7 @@ class KnowledgeOnlyAgent:
                 state["current_tool_calls"] = []
                 state["startup_system_prompt"] = startup_system_prompt
                 state["startup_prompt_initialized"] = startup_prompt_initialized
+                state["signals_envelopes"] = signals_envelopes
                 return state
 
         async def safe_tool_node(state: KnowledgeAgentState) -> KnowledgeAgentState:
@@ -558,7 +565,10 @@ class KnowledgeOnlyAgent:
                 "startup_prompt_initialized": True,
                 "tool_calls_executed": 0,
                 "knowledge_search_results": [],
-                "signals_envelopes": [],
+                "signals_envelopes": merge_internal_tool_envelopes(
+                    [],
+                    getattr(startup_context, "internal_tool_envelopes", []),
+                ),
             }
 
             # Create MemorySaver for this query
@@ -581,11 +591,9 @@ class KnowledgeOnlyAgent:
                 # Run the workflow (with recursion limit to match settings)
                 final_state = await app.ainvoke(initial_state, config=thread_config)
 
-                # Extract knowledge search results for citation tracking
-                search_results = final_state.get("knowledge_search_results", [])
-
                 # Get tool envelopes for decision traces
                 tool_envelopes = final_state.get("signals_envelopes", [])
+                search_results = extract_citations(tool_envelopes)
 
                 # Extract the final response
                 messages = final_state.get("messages", [])

--- a/redis_sre_agent/agent/knowledge_context.py
+++ b/redis_sre_agent/agent/knowledge_context.py
@@ -10,6 +10,37 @@ from redis_sre_agent.core.knowledge_helpers import (
 
 logger = logging.getLogger(__name__)
 
+PINNED_CONTEXT_TOOL_KEY = "knowledge.pinned_context"
+PINNED_CONTEXT_RETRIEVAL_KIND = "pinned_context"
+PINNED_CONTEXT_RETRIEVAL_LABEL = "Pinned context"
+
+
+class StartupKnowledgeContext(str):
+    """String startup context that also carries internal tool envelopes."""
+
+    internal_tool_envelopes: List[Dict[str, Any]]
+
+    def __new__(
+        cls,
+        context: str,
+        internal_tool_envelopes: Optional[List[Dict[str, Any]]] = None,
+    ) -> "StartupKnowledgeContext":
+        obj = super().__new__(cls, context)
+        obj.internal_tool_envelopes = list(internal_tool_envelopes or [])
+        return obj
+
+
+def merge_internal_tool_envelopes(
+    existing: Optional[List[Dict[str, Any]]],
+    new: Optional[List[Dict[str, Any]]],
+) -> List[Dict[str, Any]]:
+    """Append internal envelopes while avoiding duplicate dict entries."""
+    merged = list(existing or [])
+    for envelope in new or []:
+        if envelope not in merged:
+            merged.append(envelope)
+    return merged
+
 
 def _skills_toc_lines(skills: List[Dict[str, Any]]) -> List[str]:
     """Render the ADR skills table of contents lines."""
@@ -105,6 +136,57 @@ def _tool_instruction_lines_for_categories(
     return lines
 
 
+def _build_internal_pinned_context_envelope(
+    pinned_docs: List[Dict[str, Any]],
+    *,
+    version: Optional[str],
+    pinned_limit: int,
+    pinned_content_char_budget: int,
+) -> Optional[Dict[str, Any]]:
+    """Build an internal knowledge envelope for pinned startup documents."""
+    if not pinned_docs:
+        return None
+
+    results: List[Dict[str, Any]] = []
+    for document in pinned_docs:
+        document_hash = str(document.get("document_hash", "")).strip()
+        name = str(document.get("name", "")).strip() or document_hash or "Pinned document"
+        results.append(
+            {
+                "id": document_hash or name,
+                "title": name,
+                "source": str(document.get("source", "")).strip(),
+                "document_hash": document_hash,
+                "doc_type": str(document.get("doc_type", "")).strip(),
+                "priority": str(document.get("priority", "normal")).strip().lower(),
+                "summary": str(document.get("summary", "")).strip(),
+                "pinned": True,
+                "truncated": bool(document.get("truncated")),
+                "retrieval_kind": PINNED_CONTEXT_RETRIEVAL_KIND,
+                "retrieval_label": PINNED_CONTEXT_RETRIEVAL_LABEL,
+            }
+        )
+
+    return {
+        "tool_key": PINNED_CONTEXT_TOOL_KEY,
+        "name": "pinned_context",
+        "description": "Internal pinned-context retrieval recorded during startup grounding.",
+        "args": {
+            "version": version,
+            "limit": pinned_limit,
+            "content_char_budget": pinned_content_char_budget,
+        },
+        "status": "success",
+        "data": {
+            "results": results,
+            "results_count": len(results),
+            "retrieval_kind": PINNED_CONTEXT_RETRIEVAL_KIND,
+            "retrieval_label": PINNED_CONTEXT_RETRIEVAL_LABEL,
+        },
+        "summary": f"Loaded {len(results)} pinned document{'s' if len(results) != 1 else ''} into startup context.",
+    }
+
+
 async def build_startup_knowledge_context(
     query: str,
     version: Optional[str] = "latest",
@@ -115,6 +197,7 @@ async def build_startup_knowledge_context(
 ) -> str:
     """Build first-turn context in ADR order: pinned, skills, tools."""
     sections: List[str] = []
+    internal_tool_envelopes: List[Dict[str, Any]] = []
 
     try:
         pinned_result = await get_pinned_documents_helper(
@@ -143,6 +226,15 @@ async def build_startup_knowledge_context(
             pinned_lines.append(str(document.get("full_content", "")).strip())
         sections.append("\n".join(pinned_lines))
 
+        pinned_envelope = _build_internal_pinned_context_envelope(
+            pinned_docs,
+            version=version,
+            pinned_limit=pinned_limit,
+            pinned_content_char_budget=pinned_content_char_budget,
+        )
+        if pinned_envelope:
+            internal_tool_envelopes.append(pinned_envelope)
+
     try:
         skills_result = await skills_check_helper(
             query=query,
@@ -162,4 +254,7 @@ async def build_startup_knowledge_context(
     if tool_lines:
         sections.append("\n".join(tool_lines))
 
-    return "\n\n".join(section for section in sections if section.strip())
+    return StartupKnowledgeContext(
+        "\n\n".join(section for section in sections if section.strip()),
+        internal_tool_envelopes=internal_tool_envelopes,
+    )

--- a/redis_sre_agent/agent/langgraph_agent.py
+++ b/redis_sre_agent/agent/langgraph_agent.py
@@ -43,7 +43,7 @@ from ..tools.manager import ToolManager
 from .cluster_diagnostics import cluster_query_requests_db_diagnostics
 from .helpers import build_adapters_for_tooldefs as _build_adapters
 from .helpers import log_preflight_messages
-from .knowledge_context import build_startup_knowledge_context
+from .knowledge_context import build_startup_knowledge_context, merge_internal_tool_envelopes
 from .models import AgentResponse
 from .prompts import SRE_SYSTEM_PROMPT
 from .subgraphs.safety_fact_corrector import build_safety_fact_corrector
@@ -1092,6 +1092,7 @@ Nodes with `accept_servers=false` are in MAINTENANCE MODE and won't accept new s
             iteration_count = state.get("iteration_count", 0)
             startup_system_prompt = state.get("startup_system_prompt")
             startup_prompt_initialized = state.get("startup_prompt_initialized", False)
+            signals_envelopes = list(state.get("signals_envelopes") or [])
             # max_iterations = state.get("max_iterations", 10)  # Not used in this function
 
             if (
@@ -1119,6 +1120,10 @@ Nodes with `accept_servers=false` are in MAINTENANCE MODE and won't accept new s
                         query=context_query,
                         version="latest",
                         available_tools=list(tooldefs_by_name.values()),
+                    )
+                    signals_envelopes = merge_internal_tool_envelopes(
+                        signals_envelopes,
+                        getattr(startup_context, "internal_tool_envelopes", []),
                     )
                     system_prompt = (
                         f"{startup_context}\n\n{SRE_SYSTEM_PROMPT}"
@@ -1247,6 +1252,7 @@ Nodes with `accept_servers=false` are in MAINTENANCE MODE and won't accept new s
 
             state["startup_system_prompt"] = startup_system_prompt
             state["startup_prompt_initialized"] = startup_prompt_initialized
+            state["signals_envelopes"] = signals_envelopes
             return state
 
         async def tool_node(state: AgentState) -> AgentState:
@@ -2272,7 +2278,10 @@ For now, I can still perform basic Redis diagnostics using the database connecti
                 "startup_system_prompt": None,
                 "startup_prompt_initialized": False,
                 "instance_context": initial_instance_context,
-                "signals_envelopes": [],
+                "signals_envelopes": merge_internal_tool_envelopes(
+                    [],
+                    getattr(startup_context, "internal_tool_envelopes", []),
+                ),
             }
 
             adapters = await _build_adapters(tool_mgr, tools)

--- a/redis_sre_agent/cli/query.py
+++ b/redis_sre_agent/cli/query.py
@@ -16,7 +16,7 @@ from redis_sre_agent.agent.knowledge_agent import get_knowledge_agent
 from redis_sre_agent.agent.langgraph_agent import get_sre_agent
 from redis_sre_agent.agent.router import AgentType, route_to_appropriate_agent
 from redis_sre_agent.core.citation_message import (
-    format_citation_message,
+    build_citation_message_payloads,
     should_include_citations,
 )
 from redis_sre_agent.core.clusters import get_cluster_by_id
@@ -260,8 +260,14 @@ def query(
 
             # Add citation system message if there are search results
             if should_include_citations(search_results):
-                citation_msg = format_citation_message(search_results)
-                messages_to_save.append({"role": "system", "content": citation_msg})
+                for citation_msg in build_citation_message_payloads(search_results):
+                    messages_to_save.append(
+                        {
+                            "role": "system",
+                            "content": citation_msg["content"],
+                            "metadata": citation_msg["metadata"],
+                        }
+                    )
 
             # Save messages to thread
             await thread_manager.append_messages(active_thread_id, messages_to_save)

--- a/redis_sre_agent/cli/threads.py
+++ b/redis_sre_agent/cli/threads.py
@@ -10,6 +10,7 @@ import click
 from rich.console import Console
 from rich.table import Table
 
+from redis_sre_agent.agent.helpers import extract_citation_groups
 from redis_sre_agent.core.keys import RedisKeys
 from redis_sre_agent.core.redis import (
     SRE_THREADS_INDEX,
@@ -822,28 +823,21 @@ def thread_trace(message_id: str, as_json: bool, show_data: bool):
 
         console.print()
 
-        # Derive citations from knowledge tool envelopes
-        citations = []
-        for envelope in tool_envelopes:
-            tool_key = envelope.get("tool_key", "")
-            name = envelope.get("name", "")
-            if "knowledge" in tool_key.lower() and "search" in name.lower():
-                data = envelope.get("data", {})
-                results = data.get("results", [])
-                for result in results:
-                    citations.append(
-                        {
-                            "title": result.get("title"),
-                            "source": result.get("source"),
-                            "score": result.get("score"),
-                            "document_id": result.get("id"),
-                        }
-                    )
+        citation_groups = extract_citation_groups(tool_envelopes)
+        citations = [
+            {
+                **citation,
+                "group_label": citation_group["label"],
+            }
+            for citation_group in citation_groups
+            for citation in citation_group.get("citations", [])
+        ]
 
         if citations:
             ct_table = Table(title=f"Citations ({len(citations)})")
             ct_table.add_column("#", no_wrap=True)
             ct_table.add_column("Title", overflow="fold")
+            ct_table.add_column("Group", no_wrap=True)
             ct_table.add_column("Source", no_wrap=True)
             ct_table.add_column("Score", no_wrap=True)
 
@@ -851,10 +845,11 @@ def thread_trace(message_id: str, as_json: bool, show_data: bool):
                 title = ct.get("title") or ct.get("document_id") or "Untitled"
                 if len(title) > 50:
                     title = title[:47] + "..."
+                group_label = ct.get("group_label") or "-"
                 source = ct.get("source") or "-"
                 score = ct.get("score")
                 score_str = f"{score:.3f}" if score is not None else "-"
-                ct_table.add_row(str(i), title, source, score_str)
+                ct_table.add_row(str(i), title, group_label, source, score_str)
 
             console.print(ct_table)
         else:

--- a/redis_sre_agent/core/citation_message.py
+++ b/redis_sre_agent/core/citation_message.py
@@ -42,22 +42,25 @@ def format_citation_message(search_results: Optional[List[Dict[str, Any]]]) -> s
         return ""
 
     lines = ["**Sources for previous response**"]
+    lines.extend(_format_citation_lines(list(search_results or [])))
+    return "\n".join(lines)
 
-    for result in search_results:
+
+def _format_citation_lines(citations: List[Dict[str, Any]]) -> List[str]:
+    """Format citation entries into display lines shared by message renderers."""
+    lines: List[str] = []
+    for result in citations:
         title = result.get("title", "Untitled")
         source = result.get("source", "Unknown source")
         doc_hash = result.get("document_hash", "")
         score = result.get("score")
 
-        # Format the citation line
         if score is not None:
-            line = f'• "{title}" ({source}) [hash:{doc_hash}] - relevance: {score}'
+            lines.append(f'• "{title}" ({source}) [hash:{doc_hash}] - relevance: {score}')
         else:
-            line = f'• "{title}" ({source}) [hash:{doc_hash}]'
+            lines.append(f'• "{title}" ({source}) [hash:{doc_hash}]')
 
-        lines.append(line)
-
-    return "\n".join(lines)
+    return lines
 
 
 def format_citation_group_message(citation_group: Dict[str, Any]) -> str:
@@ -67,19 +70,7 @@ def format_citation_group_message(citation_group: Dict[str, Any]) -> str:
         return ""
 
     lines = [f"**{citation_group.get('label', 'Sources')}**"]
-    for result in citations:
-        title = result.get("title", "Untitled")
-        source = result.get("source", "Unknown source")
-        doc_hash = result.get("document_hash", "")
-        score = result.get("score")
-
-        if score is not None:
-            line = f'• "{title}" ({source}) [hash:{doc_hash}] - relevance: {score}'
-        else:
-            line = f'• "{title}" ({source}) [hash:{doc_hash}]'
-
-        lines.append(line)
-
+    lines.extend(_format_citation_lines(citations))
     return "\n".join(lines)
 
 

--- a/redis_sre_agent/core/citation_message.py
+++ b/redis_sre_agent/core/citation_message.py
@@ -7,6 +7,8 @@ in previous responses.
 
 from typing import Any, Dict, List, Optional
 
+from redis_sre_agent.agent.helpers import build_citation_groups
+
 
 def should_include_citations(search_results: Optional[List[Dict[str, Any]]]) -> bool:
     """Determine if citations should be included in the thread.
@@ -56,3 +58,50 @@ def format_citation_message(search_results: Optional[List[Dict[str, Any]]]) -> s
         lines.append(line)
 
     return "\n".join(lines)
+
+
+def format_citation_group_message(citation_group: Dict[str, Any]) -> str:
+    """Format one citation group as a system message body."""
+    citations = list(citation_group.get("citations") or [])
+    if not citations:
+        return ""
+
+    lines = [f"**{citation_group.get('label', 'Sources')}**"]
+    for result in citations:
+        title = result.get("title", "Untitled")
+        source = result.get("source", "Unknown source")
+        doc_hash = result.get("document_hash", "")
+        score = result.get("score")
+
+        if score is not None:
+            line = f'• "{title}" ({source}) [hash:{doc_hash}] - relevance: {score}'
+        else:
+            line = f'• "{title}" ({source}) [hash:{doc_hash}]'
+
+        lines.append(line)
+
+    return "\n".join(lines)
+
+
+def build_citation_message_payloads(
+    search_results: Optional[List[Dict[str, Any]]],
+) -> List[Dict[str, Any]]:
+    """Build separate system-message payloads for each citation group."""
+    if not should_include_citations(search_results):
+        return []
+
+    payloads: List[Dict[str, Any]] = []
+    for citation_group in build_citation_groups(list(search_results or [])):
+        payloads.append(
+            {
+                "content": format_citation_group_message(citation_group),
+                "metadata": {
+                    "message_type": "citations",
+                    "citation_group": citation_group["group_key"],
+                    "citation_group_label": citation_group["label"],
+                    "citations": citation_group["citations"],
+                    "count": citation_group["count"],
+                },
+            }
+        )
+    return payloads

--- a/redis_sre_agent/core/docket_tasks.py
+++ b/redis_sre_agent/core/docket_tasks.py
@@ -16,7 +16,7 @@ from redis_sre_agent.agent.langgraph_agent import (
 )
 from redis_sre_agent.agent.router import AgentType, route_to_appropriate_agent
 from redis_sre_agent.core.citation_message import (
-    format_citation_message,
+    build_citation_message_payloads,
     should_include_citations,
 )
 from redis_sre_agent.core.clusters import get_cluster_by_id
@@ -1028,14 +1028,16 @@ async def process_agent_turn(
         # Add citation system message if there are search results
         # This allows the LLM to see which sources were used and retrieve more info
         if should_include_citations(search_results):
-            citation_msg = format_citation_message(search_results)
-            conversation_state["messages"].append(
-                {
-                    "role": "system",
-                    "content": citation_msg,
-                    "timestamp": datetime.now(timezone.utc).isoformat(),
-                }
-            )
+            citation_timestamp = datetime.now(timezone.utc).isoformat()
+            for citation_msg in build_citation_message_payloads(search_results):
+                conversation_state["messages"].append(
+                    {
+                        "role": "system",
+                        "content": citation_msg["content"],
+                        "timestamp": citation_timestamp,
+                        "metadata": citation_msg["metadata"],
+                    }
+                )
 
         # Update thread context with new conversation state
         # Only save user/assistant/system messages - tool messages are internal to LangGraph

--- a/tests/unit/agent/test_extract_citations.py
+++ b/tests/unit/agent/test_extract_citations.py
@@ -4,7 +4,11 @@ This module tests the extract_citations function that derives citation data
 from knowledge tool envelopes, replacing the separate CitationTrace tracking.
 """
 
-from redis_sre_agent.agent.helpers import extract_citations
+from redis_sre_agent.agent.helpers import (
+    build_citation_groups,
+    extract_citation_groups,
+    extract_citations,
+)
 from redis_sre_agent.agent.models import AgentResponse
 
 
@@ -191,6 +195,87 @@ class TestExtractCitations:
         assert len(citations) == 1
         assert citations[0]["title"] == "Dict-based Doc"
 
+    def test_extract_citations_marks_pinned_context_results(self):
+        """Pinned startup envelopes should round-trip as citations."""
+        envelopes = [
+            {
+                "tool_key": "knowledge.pinned_context",
+                "name": "pinned_context",
+                "status": "success",
+                "data": {
+                    "retrieval_kind": "pinned_context",
+                    "results": [
+                        {
+                            "title": "Pinned Runbook",
+                            "source": "file:///tmp/pinned.md",
+                            "document_hash": "hash123",
+                        }
+                    ],
+                },
+            }
+        ]
+
+        citations = extract_citations(envelopes)
+
+        assert len(citations) == 1
+        assert citations[0]["title"] == "Pinned Runbook"
+        assert citations[0]["retrieval_kind"] == "pinned_context"
+
+    def test_extract_citation_groups_splits_startup_and_discovered_context(self):
+        """Citations should be grouped by how they entered context."""
+        envelopes = [
+            {
+                "tool_key": "knowledge.pinned_context",
+                "name": "pinned_context",
+                "status": "success",
+                "data": {
+                    "retrieval_kind": "pinned_context",
+                    "results": [
+                        {
+                            "title": "Pinned Runbook",
+                            "source": "file:///tmp/pinned.md",
+                            "document_hash": "hash123",
+                        }
+                    ],
+                },
+            },
+            {
+                "tool_key": "knowledge_search",
+                "name": "search",
+                "status": "success",
+                "data": {
+                    "results": [
+                        {
+                            "title": "Redis Memory Management",
+                            "source": "redis.io",
+                            "document_hash": "abc123",
+                            "score": 0.92,
+                        }
+                    ]
+                },
+            },
+        ]
+
+        citation_groups = extract_citation_groups(envelopes)
+
+        assert [group["group_key"] for group in citation_groups] == [
+            "discovered_context",
+            "startup_context_loaded",
+        ]
+        assert citation_groups[0]["citations"][0]["title"] == "Redis Memory Management"
+        assert citation_groups[1]["citations"][0]["title"] == "Pinned Runbook"
+
+    def test_build_citation_groups_preserves_group_counts(self):
+        citation_groups = build_citation_groups(
+            [
+                {"title": "Doc A", "retrieval_kind": "knowledge_search"},
+                {"title": "Doc B", "retrieval_kind": "pinned_context"},
+            ]
+        )
+
+        assert citation_groups[0]["count"] == 1
+        assert citation_groups[1]["count"] == 1
+
 
 class TestAgentResponseSearchResults:
     """Test AgentResponse search_results derivation from tool_envelopes."""
@@ -217,6 +302,31 @@ class TestAgentResponseSearchResults:
 
         assert len(response.search_results) == 1
         assert response.search_results[0]["title"] == "Doc 1"
+
+    def test_search_results_include_pinned_context_when_derived_from_envelopes(self):
+        response = AgentResponse(
+            response="Test response",
+            tool_envelopes=[
+                {
+                    "tool_key": "knowledge.pinned_context",
+                    "name": "pinned_context",
+                    "status": "success",
+                    "data": {
+                        "retrieval_kind": "pinned_context",
+                        "results": [
+                            {
+                                "title": "Pinned Runbook",
+                                "source": "file:///tmp/pinned.md",
+                                "document_hash": "hash123",
+                            }
+                        ],
+                    },
+                }
+            ],
+        )
+
+        assert len(response.search_results) == 1
+        assert response.search_results[0]["retrieval_kind"] == "pinned_context"
 
     def test_search_results_empty_when_no_knowledge_tools(self):
         """Test that search_results is empty when no knowledge tools used."""

--- a/tests/unit/agent/test_knowledge_context.py
+++ b/tests/unit/agent/test_knowledge_context.py
@@ -147,3 +147,42 @@ async def test_startup_context_extracts_capability_from_tool_definition():
         )
 
     assert "Available tool categories: tickets." in context
+
+
+@pytest.mark.asyncio
+async def test_startup_context_carries_internal_pinned_context_envelope():
+    with (
+        patch(
+            "redis_sre_agent.agent.knowledge_context.get_pinned_documents_helper",
+            new=AsyncMock(
+                return_value={
+                    "pinned_documents": [
+                        {
+                            "document_hash": "hash-123",
+                            "name": "Pinned Runbook",
+                            "summary": "Pinned memory triage guidance.",
+                            "priority": "high",
+                            "source": "file:///tmp/pinned.md",
+                            "doc_type": "runbook",
+                            "truncated": False,
+                            "full_content": "Pinned guidance content",
+                        }
+                    ]
+                }
+            ),
+        ),
+        patch(
+            "redis_sre_agent.agent.knowledge_context.skills_check_helper",
+            new=AsyncMock(return_value={"skills": []}),
+        ),
+    ):
+        context = await build_startup_knowledge_context(query="memory issue", version="latest")
+
+    envelopes = getattr(context, "internal_tool_envelopes", [])
+    assert len(envelopes) == 1
+    envelope = envelopes[0]
+    assert envelope["tool_key"] == "knowledge.pinned_context"
+    assert envelope["name"] == "pinned_context"
+    assert envelope["data"]["retrieval_kind"] == "pinned_context"
+    assert envelope["data"]["results"][0]["title"] == "Pinned Runbook"
+    assert envelope["data"]["results"][0]["retrieval_kind"] == "pinned_context"

--- a/tests/unit/cli/test_cli_threads.py
+++ b/tests/unit/cli/test_cli_threads.py
@@ -228,9 +228,48 @@ class TestThreadTrace:
         assert result.exit_code == 0, result.output
         # Should show citations section
         assert "Citations" in result.output
+        assert "Group" in result.output
         # Should show citation details
         assert "Memory Best Practices" in result.output
         assert "redis.io" in result.output
+        assert "Discovered context" in result.output
+
+    def test_thread_trace_shows_startup_context_group(self):
+        """Pinned startup envelopes should appear in their own citation group."""
+        runner = CliRunner()
+        trace = _make_decision_trace()
+        trace["tool_envelopes"].append(
+            {
+                "tool_key": "knowledge.pinned_context",
+                "name": "pinned_context",
+                "description": "Pinned startup context",
+                "args": {},
+                "status": "success",
+                "data": {
+                    "retrieval_kind": "pinned_context",
+                    "results": [
+                        {
+                            "title": "Pinned Runbook",
+                            "source": "file:///tmp/pinned.md",
+                            "document_hash": "hash123",
+                        }
+                    ],
+                },
+            }
+        )
+
+        async def fake_get_message_trace(_self, message_id: str):  # noqa: ARG001
+            return trace
+
+        with patch(
+            "redis_sre_agent.core.threads.ThreadManager.get_message_trace",
+            new=fake_get_message_trace,
+        ):
+            result = runner.invoke(cli_main, ["thread", "trace", "01HX9876543210ZYXWVUTSRQ"])
+
+        assert result.exit_code == 0, result.output
+        assert "Pinned Runbook" in result.output
+        assert "Startup context loaded" in result.output
 
     def test_thread_trace_with_show_data(self):
         """Test thread trace with --show-data flag."""

--- a/tests/unit/core/test_citation_message.py
+++ b/tests/unit/core/test_citation_message.py
@@ -4,6 +4,7 @@ Tests written first for the feature that appends citation messages to threads.
 """
 
 from redis_sre_agent.core.citation_message import (
+    build_citation_message_payloads,
     format_citation_message,
     should_include_citations,
 )
@@ -123,3 +124,28 @@ class TestFormatCitationMessage:
 
         # Hash should be present in the message
         assert "a" * 64 in message
+
+    def test_builds_separate_payloads_for_discovered_and_startup_context(self):
+        results = [
+            {
+                "title": "Redis Memory Management",
+                "source": "redis.io/docs/memory",
+                "document_hash": "abc123def",
+                "score": 0.95,
+                "retrieval_kind": "knowledge_search",
+            },
+            {
+                "title": "Pinned Runbook",
+                "source": "file:///tmp/pinned.md",
+                "document_hash": "pinned123",
+                "retrieval_kind": "pinned_context",
+            },
+        ]
+
+        payloads = build_citation_message_payloads(results)
+
+        assert len(payloads) == 2
+        assert payloads[0]["metadata"]["citation_group"] == "discovered_context"
+        assert payloads[0]["content"].startswith("**Discovered context**")
+        assert payloads[1]["metadata"]["citation_group"] == "startup_context_loaded"
+        assert payloads[1]["content"].startswith("**Startup context loaded**")

--- a/tests/unit/core/test_thread_management.py
+++ b/tests/unit/core/test_thread_management.py
@@ -357,9 +357,11 @@ class TestProcessAgentTurn:
 
             # Find the system message and verify it contains citation info
             system_msg = next(msg for msg in test_thread.messages if msg.role == "system")
-            assert "Sources for previous response" in system_msg.content
+            assert "Discovered context" in system_msg.content
             assert "Redis Memory Guide" in system_msg.content
             assert "abc123def456" in system_msg.content
+            assert system_msg.metadata is not None
+            assert system_msg.metadata["metadata"]["citation_group"] == "discovered_context"
 
     @pytest.mark.asyncio
     async def test_process_agent_turn_no_citation_message_when_no_search_results(self):

--- a/ui/src/pages/Triage.tsx
+++ b/ui/src/pages/Triage.tsx
@@ -107,8 +107,19 @@ const Triage = () => {
   };
 
   const isCitationMessage = (content: string) => {
-    return content.startsWith("**Sources for previous response**");
+    return /^\*\*(Sources for previous response|Discovered context|Startup context loaded)\*\*/.test(
+      content,
+    );
   };
+  const citationHeading = (content: string) => {
+    const match = content.match(/^\*\*([^*]+)\*\*/);
+    return match?.[1] || "Sources";
+  };
+  const citationBody = (content: string) =>
+    content.replace(
+      /^\*\*(Sources for previous response|Discovered context|Startup context loaded)\*\*\n?/,
+      "",
+    );
   const pollingIntervalRef = useRef<number | null>(null);
 
   const userId = "sre-user-1"; // In a real app, this would come from auth
@@ -1073,7 +1084,7 @@ const Triage = () => {
                                   className="w-full px-3 py-2 flex items-center justify-between text-left text-redis-dusk-03 hover:text-redis-dusk-02 transition-colors"
                                 >
                                   <span className="font-semibold">
-                                    📚 Sources for previous response
+                                    📚 {citationHeading(msg.content)}
                                   </span>
                                   <span
                                     className={`transform transition-transform ${expandedCitations.has(msg.id) ? "rotate-180" : ""}`}
@@ -1104,10 +1115,7 @@ const Triage = () => {
                                           ),
                                         }}
                                       >
-                                        {msg.content.replace(
-                                          /^\*\*Sources for previous response\*\*\n?/,
-                                          "",
-                                        )}
+                                        {citationBody(msg.content)}
                                       </ReactMarkdown>
                                     </div>
                                   </div>


### PR DESCRIPTION
## Summary
- record pinned startup documents as internal knowledge envelopes so they appear in traces and citations
- split user-facing citations into `Discovered context` and `Startup context loaded` across API, CLI, and UI
- add regression coverage for citation grouping, startup context envelopes, and thread rendering

## Validation
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check`
- `UV_CACHE_DIR=/tmp/uv-cache uv run pytest`

Closes #99.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes how agents persist `signals_envelopes` and how citations are derived/stored across agent, CLI, tasks, and UI; regressions could affect trace/citation display but not core Redis operations.
> 
> **Overview**
> Records pinned startup documents as **internal tool envelopes** (`knowledge.pinned_context`) via a new `StartupKnowledgeContext`, and carries/merges these envelopes into `signals_envelopes` across the chat, knowledge, and LangGraph SRE agents so startup grounding appears in decision traces and citation derivation.
> 
> Overhauls citation extraction/rendering to **label and group sources** into `Discovered context` vs `Startup context loaded` (new grouping helpers and per-group system-message payloads), updating CLI thread trace output, thread persistence paths (`cli/query.py`, `core/docket_tasks.py`), and the UI citations accordion to display the group heading. Adds unit tests covering pinned-context envelopes, citation grouping, and updated thread/CLI rendering behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 00d8aa306f2ef2ebc23aa6a26b043a88636c2c18. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->