### PR TITLE
Add TOML and JSON config file support

### DIFF
--- a/docs/concepts/core.md
+++ b/docs/concepts/core.md
@@ -188,7 +188,7 @@ redis-sre-agent mcp serve --transport stdio
 Add external MCP servers to give the agent additional capabilities:
 
 ```yaml
-# config.yaml
+# config.yaml (YAML shown; config.toml and config.json are also supported)
 mcp_servers:
   # GitHub MCP server
   github:

--- a/docs/how-to/configuration.md
+++ b/docs/how-to/configuration.md
@@ -8,7 +8,7 @@ Configuration values are loaded from these sources (highest precedence first):
 
 1. Environment variables (recommended for prod)
 2. `.env` file (loaded automatically in dev if present)
-3. **YAML config file** (for complex nested configurations like MCP servers)
+3. **Config file** (`.yaml`, `.yml`, `.toml`, or `.json`; useful for nested settings like `mcp_servers`)
 4. Code defaults in `redis_sre_agent/core/config.py`
 
 ```mermaid
@@ -17,35 +17,41 @@ flowchart TB
         direction TB
         ENV["1. Environment Variables<br><i>Highest priority</i>"]
         DOTENV["2. .env File<br><i>Auto-loaded in dev</i>"]
-        YAML["3. YAML Config File<br><i>config.yaml</i>"]
+        CFG["3. Config File<br><i>config.yaml / config.toml / config.json</i>"]
         CODE["4. Code Defaults<br><i>config.py</i>"]
     end
 
     ENV --> |overrides| DOTENV
-    DOTENV --> |overrides| YAML
-    YAML --> |overrides| CODE
+    DOTENV --> |overrides| CFG
+    CFG --> |overrides| CODE
 
     CODE --> FINAL["Final Settings"]
-    YAML --> FINAL
+    CFG --> FINAL
     DOTENV --> FINAL
     ENV --> FINAL
 ```
 
 For example, if `REDIS_URL` is set in both `.env` and as an environment variable, the environment variable wins.
 
-### YAML configuration
+### File-based configuration
 
-For complex nested settings like MCP server configurations, you can use a YAML config file. This is particularly useful for configuring multiple MCP servers with tool descriptions.
+The agent can load settings from YAML, TOML, or JSON config files. YAML is usually the easiest choice for complex nested settings like `mcp_servers`, while TOML and JSON are useful when your deployment tooling already emits those formats.
 
 **Config file discovery order:**
 
 1. Path specified in `SRE_AGENT_CONFIG` environment variable
 2. `config.yaml` in the current working directory
 3. `config.yml` in the current working directory
-4. `sre_agent_config.yaml` in the current working directory
-5. `sre_agent_config.yml` in the current working directory
+4. `config.toml` in the current working directory
+5. `config.json` in the current working directory
+6. `sre_agent_config.yaml` in the current working directory
+7. `sre_agent_config.yml` in the current working directory
+8. `sre_agent_config.toml` in the current working directory
+9. `sre_agent_config.json` in the current working directory
 
-**Example `config.yaml`:**
+When `SRE_AGENT_CONFIG` is set, the parser is selected by suffix: `.yaml` / `.yml`, `.toml`, or `.json`.
+
+**Example `config.yaml` (recommended for nested configuration):**
 
 ```yaml
 # Application settings
@@ -66,10 +72,30 @@ mcp_servers:
 
 See `config.yaml.example` for a complete example with all available options.
 
+**Example `config.toml` (simple flat settings):**
+
+```toml
+app_name = "Redis SRE Agent"
+debug = false
+log_level = "INFO"
+recursion_limit = 64
+```
+
+**Example `config.json` (simple flat settings):**
+
+```json
+{
+  "app_name": "Redis SRE Agent",
+  "debug": false,
+  "log_level": "INFO",
+  "recursion_limit": 64
+}
+```
+
 **Using a custom config path:**
 
 ```bash
-export SRE_AGENT_CONFIG=/path/to/my-config.yaml
+export SRE_AGENT_CONFIG=/path/to/my-config.toml
 ```
 
 ### Required
@@ -118,7 +144,7 @@ Override cache TTLs for specific tools by mapping tool name patterns to TTL valu
 TOOL_CACHE_TTL_OVERRIDES='{"info": 120, "slowlog": 30, "config_get": 600}'
 ```
 
-**YAML config:**
+**Config file (YAML shown):**
 
 ```yaml
 # Maps tool name patterns to TTL in seconds
@@ -185,7 +211,7 @@ Set `LLM_FACTORY` to a dot-path import string pointing to your factory function:
 LLM_FACTORY=mypackage.llm.anthropic_factory
 ```
 
-Or in `config.yaml`:
+Or in a config file (YAML shown):
 
 ```yaml
 llm_factory: mypackage.llm.anthropic_factory

--- a/docs/how-to/tool-providers.md
+++ b/docs/how-to/tool-providers.md
@@ -99,7 +99,7 @@ Add external MCP servers to give the agent additional tools. The agent connects 
 
 ### Configuration
 
-Add MCP servers in `config.yaml`:
+Add MCP servers in a config file. YAML is shown here because nested MCP configuration is easier to read in YAML:
 
 ```yaml
 mcp_servers:
@@ -151,4 +151,4 @@ tool_manager = ToolManager(
 )
 ```
 
-See `config.yaml.example` for full MCP configuration examples.
+See `config.yaml.example` for full YAML MCP configuration examples.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -2,13 +2,13 @@
 
 Use this page as the complete reference for settings loaded by [`redis_sre_agent/core/config.py`](https://github.com/redis-applied-ai/redis-sre-agent/blob/main/redis_sre_agent/core/config.py).
 
-For configuration precedence, `.env` behavior, YAML discovery order, and setup examples, see [Configuration How-to](../how-to/configuration.md).
+For configuration precedence, `.env` behavior, config-file discovery order, and setup examples, see [Configuration How-to](../how-to/configuration.md).
 
 ### Config File Selector
 
 | Setting | Environment Variable | Type | Default | Notes |
 |---|---|---|---|---|
-| YAML config path | `SRE_AGENT_CONFIG` | `str` | unset | Optional path to a YAML config file. If unset, the app checks `config.yaml`, `config.yml`, `sre_agent_config.yaml`, `sre_agent_config.yml`. |
+| Config file path | `SRE_AGENT_CONFIG` | `str` | unset | Optional path to a YAML, TOML, or JSON config file. If unset, the app checks `config.yaml`, `config.yml`, `config.toml`, `config.json`, `sre_agent_config.yaml`, `sre_agent_config.yml`, `sre_agent_config.toml`, `sre_agent_config.json`. |
 
 ### Application
 

--- a/redis_sre_agent/core/config.py
+++ b/redis_sre_agent/core/config.py
@@ -4,12 +4,16 @@ import os
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Type, Union
 
+import yaml
 from dotenv import load_dotenv
 from pydantic import BaseModel, Field, SecretStr
 from pydantic_settings import (
     BaseSettings,
+    InitSettingsSource,
+    JsonConfigSettingsSource,
     PydanticBaseSettingsSource,
     SettingsConfigDict,
+    TomlConfigSettingsSource,
     YamlConfigSettingsSource,
 )
 
@@ -131,27 +135,63 @@ except (FileNotFoundError, OSError):
 DEFAULT_CONFIG_PATHS = [
     "config.yaml",
     "config.yml",
+    "config.toml",
+    "config.json",
     "sre_agent_config.yaml",
     "sre_agent_config.yml",
+    "sre_agent_config.toml",
+    "sre_agent_config.json",
 ]
 
 
-def _get_yaml_config_path() -> str | list[str] | None:
-    """Get the YAML config file path to use.
+def _get_config_file_path() -> str | None:
+    """Get the config file path to use.
 
     Returns:
         - The path from SRE_AGENT_CONFIG env var if set
-        - Or the list of default paths to check
-        - Or None if SRE_AGENT_CONFIG is set to a nonexistent file
+        - Or the first existing supported default path
+        - Or None if no supported config file exists
     """
     config_path = os.environ.get("SRE_AGENT_CONFIG")
 
     if config_path:
-        # If explicitly specified, use it (pydantic will handle missing files)
+        # If explicitly specified, use it even if it does not exist.
+        # The underlying source will treat missing files as empty config.
         return config_path
 
-    # Return list of default paths - pydantic-settings will check each in order
-    return DEFAULT_CONFIG_PATHS
+    for default_path in DEFAULT_CONFIG_PATHS:
+        if Path(default_path).is_file():
+            return default_path
+
+    return None
+
+
+def _build_config_file_source(settings_cls: Type[BaseSettings]) -> PydanticBaseSettingsSource:
+    """Build the appropriate config-file settings source for the selected path."""
+    config_path = _get_config_file_path()
+    if config_path is None:
+        return InitSettingsSource(settings_cls, {})
+
+    config_suffix = Path(config_path).suffix.lower()
+
+    # Preserve compatibility for custom YAML paths that may not use a .yaml suffix.
+    if config_suffix in {".yaml", ".yml", ""}:
+        source_type = YamlConfigSettingsSource
+        source_kwargs = {"yaml_file": config_path}
+    elif config_suffix == ".toml":
+        source_type = TomlConfigSettingsSource
+        source_kwargs = {"toml_file": config_path}
+    elif config_suffix == ".json":
+        source_type = JsonConfigSettingsSource
+        source_kwargs = {"json_file": config_path}
+    else:
+        source_type = YamlConfigSettingsSource
+        source_kwargs = {"yaml_file": config_path}
+
+    try:
+        return source_type(settings_cls, **source_kwargs)
+    except (OSError, TypeError, ValueError, yaml.YAMLError):
+        return InitSettingsSource(settings_cls, {})
 
 
 class Settings(BaseSettings):
@@ -160,16 +200,17 @@ class Settings(BaseSettings):
     Loads settings from environment variables. In local development, these can be
     provided via a .env file. In Docker/production, they should be set directly.
 
-    Configuration can also be loaded from YAML files. The following paths are checked
-    (first match wins):
+    Configuration can also be loaded from YAML, TOML, or JSON files. The following paths are
+    checked (first match wins):
     - Path specified in SRE_AGENT_CONFIG environment variable
-    - config.yaml, config.yml, sre_agent_config.yaml, sre_agent_config.yml
+    - config.yaml, config.yml, config.toml, config.json
+    - sre_agent_config.yaml, sre_agent_config.yml, sre_agent_config.toml, sre_agent_config.json
 
     Priority (highest to lowest):
     1. Values passed to Settings() constructor
     2. Environment variables
     3. .env file
-    4. YAML config file
+    4. Config file
     5. Default values
     """
 
@@ -180,7 +221,7 @@ class Settings(BaseSettings):
         extra="ignore",
         # Don't error if .env file is missing (Docker/production use env vars directly)
         env_ignore_empty=True,
-        # Note: yaml_file is set dynamically in settings_customise_sources
+        # Note: config file selection is done dynamically in settings_customise_sources
         # to support SRE_AGENT_CONFIG env var being set after module import
     )
 
@@ -372,7 +413,7 @@ class Settings(BaseSettings):
 
     # MCP Server Configuration
     # No external MCP servers are enabled by default.
-    # Configure MCP_SERVERS or config.yaml explicitly for any MCP integrations.
+    # Configure MCP_SERVERS or a config file explicitly for any MCP integrations.
     mcp_servers: Dict[str, Union[MCPServerConfig, Dict[str, Any]]] = Field(
         default_factory=dict,
         description="MCP (Model Context Protocol) servers to connect to. "
@@ -390,24 +431,20 @@ class Settings(BaseSettings):
         dotenv_settings: PydanticBaseSettingsSource,
         file_secret_settings: PydanticBaseSettingsSource,
     ) -> Tuple[PydanticBaseSettingsSource, ...]:
-        """Customize settings sources to include YAML config file.
+        """Customize settings sources to include file-based config.
 
         Priority (highest to lowest):
         1. init_settings (passed to Settings())
         2. env_settings (environment variables)
         3. dotenv_settings (.env file)
-        4. yaml_settings (config.yaml file)
+        4. config_file_settings (yaml, toml, or json)
         5. file_secret_settings (Docker secrets)
         """
-        # Use the built-in YamlConfigSettingsSource from pydantic-settings
-        # Get the yaml_file path dynamically to respect SRE_AGENT_CONFIG env var
-        # set after module import
-        yaml_file = _get_yaml_config_path()
         return (
             init_settings,
             env_settings,
             dotenv_settings,
-            YamlConfigSettingsSource(settings_cls, yaml_file=yaml_file),
+            _build_config_file_source(settings_cls),
             file_secret_settings,
         )
 

--- a/tests/unit/core/test_cluster_admin_defaults.py
+++ b/tests/unit/core/test_cluster_admin_defaults.py
@@ -72,6 +72,9 @@ def test_resolve_enterprise_admin_fields_accepts_tools_alias_env_vars():
     with patch.dict(
         os.environ,
         {
+            "REDIS_ENTERPRISE_ADMIN_URL": "",
+            "REDIS_ENTERPRISE_ADMIN_USERNAME": "",
+            "REDIS_ENTERPRISE_ADMIN_PASSWORD": "",
             "TOOLS_REDIS_ENTERPRISE_ADMIN_URL": "https://tools-env.example.com:9443",
             "TOOLS_REDIS_ENTERPRISE_ADMIN_USERNAME": "tools-admin@example.com",
             "TOOLS_REDIS_ENTERPRISE_ADMIN_PASSWORD": "tools-secret",

--- a/tests/unit/core/test_config.py
+++ b/tests/unit/core/test_config.py
@@ -1,7 +1,9 @@
 """Unit tests for configuration management."""
 
+import json
 import os
 import tempfile
+from pathlib import Path
 from typing import Optional
 from unittest.mock import patch
 
@@ -64,6 +66,37 @@ def get_clean_settings(**kwargs):
         allowed_hosts: list[str] = Field(default=["*"], description="Allowed hosts for CORS")
 
     return TestSettings(**kwargs)
+
+
+def _to_toml_value(value: object) -> str:
+    """Serialize simple test values into TOML literals."""
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, int):
+        return str(value)
+    if isinstance(value, str):
+        return json.dumps(value)
+    raise TypeError(f"Unsupported TOML test value: {value!r}")
+
+
+def write_config_file(path: Path, config_format: str, values: dict[str, object]) -> None:
+    """Write supported test config formats without extra dependencies."""
+    if config_format == "yaml":
+        path.write_text(yaml.safe_dump(values), encoding="utf-8")
+        return
+
+    if config_format == "json":
+        path.write_text(json.dumps(values), encoding="utf-8")
+        return
+
+    if config_format == "toml":
+        content = "\n".join(
+            f"{key} = {_to_toml_value(value)}" for key, value in values.items()
+        )
+        path.write_text(f"{content}\n", encoding="utf-8")
+        return
+
+    raise ValueError(f"Unsupported config format: {config_format}")
 
 
 class TestSettings:
@@ -628,13 +661,19 @@ class TestYamlConfigLoading:
             os.unlink(config_path)
 
     def test_default_config_paths_are_checked(self):
-        """Test that default config paths are checked when SRE_AGENT_CONFIG is not set."""
+        """Test that default config paths include supported formats in order."""
         from redis_sre_agent.core.config import DEFAULT_CONFIG_PATHS
 
-        # Verify the default paths exist in the module
-        assert "config.yaml" in DEFAULT_CONFIG_PATHS
-        assert "config.yml" in DEFAULT_CONFIG_PATHS
-        assert "sre_agent_config.yaml" in DEFAULT_CONFIG_PATHS
+        assert DEFAULT_CONFIG_PATHS == [
+            "config.yaml",
+            "config.yml",
+            "config.toml",
+            "config.json",
+            "sre_agent_config.yaml",
+            "sre_agent_config.yml",
+            "sre_agent_config.toml",
+            "sre_agent_config.json",
+        ]
 
     def test_yaml_with_simple_settings(self):
         """Test loading simple settings from YAML.
@@ -732,3 +771,158 @@ class TestYamlConfigLoading:
                 assert data == {}
         finally:
             os.unlink(config_path)
+
+
+class TestMultiFormatConfigLoading:
+    """Test YAML, TOML, and JSON configuration loading."""
+
+    @pytest.mark.parametrize("config_format", ["yaml", "toml", "json"])
+    def test_supported_config_formats_load_via_explicit_path(self, tmp_path, config_format):
+        """Test that SRE_AGENT_CONFIG can point at any supported config format."""
+        from redis_sre_agent.core.config import Settings
+
+        config_path = tmp_path / f"settings.{config_format}"
+        write_config_file(
+            config_path,
+            config_format,
+            {
+                "app_name": f"{config_format}-app",
+                "debug": True,
+                "recursion_limit": 200,
+            },
+        )
+
+        with patch.dict(
+            os.environ,
+            {"SRE_AGENT_CONFIG": str(config_path), "OPENAI_API_KEY": "test-key"},
+            clear=True,
+        ):
+            settings = Settings(_env_file=None)
+
+            assert settings.app_name == f"{config_format}-app"
+            assert settings.debug is True
+            assert settings.recursion_limit == 200
+
+    @pytest.mark.parametrize("config_format", ["yaml", "toml", "json"])
+    def test_env_vars_override_supported_config_formats(self, tmp_path, config_format):
+        """Test that env vars keep higher precedence than file-based config."""
+        from redis_sre_agent.core.config import Settings
+
+        config_path = tmp_path / f"settings.{config_format}"
+        write_config_file(
+            config_path,
+            config_format,
+            {
+                "debug": False,
+                "log_level": "WARNING",
+            },
+        )
+
+        with patch.dict(
+            os.environ,
+            {
+                "SRE_AGENT_CONFIG": str(config_path),
+                "OPENAI_API_KEY": "test-key",
+                "DEBUG": "true",
+                "LOG_LEVEL": "DEBUG",
+            },
+            clear=True,
+        ):
+            settings = Settings(_env_file=None)
+
+            assert settings.debug is True
+            assert settings.log_level == "DEBUG"
+
+    def test_default_config_path_loads_json_when_no_yaml_or_toml_exists(self, tmp_path, monkeypatch):
+        """Test that default-path discovery falls through to later supported formats."""
+        from redis_sre_agent.core.config import Settings
+
+        write_config_file(
+            tmp_path / "config.json",
+            "json",
+            {
+                "app_name": "json-default",
+                "recursion_limit": 321,
+            },
+        )
+
+        monkeypatch.chdir(tmp_path)
+        with patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"}, clear=True):
+            settings = Settings(_env_file=None)
+
+            assert settings.app_name == "json-default"
+            assert settings.recursion_limit == 321
+
+    def test_first_existing_default_config_path_wins_across_formats(self, tmp_path, monkeypatch):
+        """Test that the configured default-path order is respected."""
+        from redis_sre_agent.core.config import Settings
+
+        write_config_file(tmp_path / "config.toml", "toml", {"app_name": "toml-default"})
+        write_config_file(tmp_path / "config.json", "json", {"app_name": "json-default"})
+
+        monkeypatch.chdir(tmp_path)
+        with patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"}, clear=True):
+            settings = Settings(_env_file=None)
+
+            assert settings.app_name == "toml-default"
+
+    def test_sre_agent_config_override_beats_default_path(self, tmp_path, monkeypatch):
+        """Test that an explicit path overrides discovered default config files."""
+        from redis_sre_agent.core.config import Settings
+
+        write_config_file(tmp_path / "config.yaml", "yaml", {"app_name": "yaml-default"})
+        explicit_path = tmp_path / "custom.json"
+        write_config_file(explicit_path, "json", {"app_name": "json-explicit"})
+
+        monkeypatch.chdir(tmp_path)
+        with patch.dict(
+            os.environ,
+            {"SRE_AGENT_CONFIG": str(explicit_path), "OPENAI_API_KEY": "test-key"},
+            clear=True,
+        ):
+            settings = Settings(_env_file=None)
+
+            assert settings.app_name == "json-explicit"
+
+    @pytest.mark.parametrize("config_filename", ["missing.yaml", "missing.toml", "missing.json"])
+    def test_missing_explicit_config_file_is_ignored(self, tmp_path, config_filename):
+        """Test that a missing explicit config file does not break settings creation."""
+        from redis_sre_agent.core.config import Settings
+
+        config_path = tmp_path / config_filename
+        with patch.dict(
+            os.environ,
+            {"SRE_AGENT_CONFIG": str(config_path), "OPENAI_API_KEY": "test-key"},
+            clear=True,
+        ):
+            settings = Settings(_env_file=None)
+
+            assert settings.app_name == "Redis SRE Agent"
+            assert settings.debug is False
+
+    @pytest.mark.parametrize(
+        ("config_format", "invalid_content"),
+        [
+            ("yaml", "invalid: yaml: content: [[[\n"),
+            ("toml", "invalid = [\n"),
+            ("json", "{invalid json\n"),
+        ],
+    )
+    def test_invalid_explicit_config_file_is_ignored(
+        self, tmp_path, config_format, invalid_content
+    ):
+        """Test that invalid config files do not break settings construction."""
+        from redis_sre_agent.core.config import Settings
+
+        config_path = tmp_path / f"invalid.{config_format}"
+        config_path.write_text(invalid_content, encoding="utf-8")
+
+        with patch.dict(
+            os.environ,
+            {"SRE_AGENT_CONFIG": str(config_path), "OPENAI_API_KEY": "test-key"},
+            clear=True,
+        ):
+            settings = Settings(_env_file=None)
+
+            assert settings.app_name == "Redis SRE Agent"
+            assert settings.debug is False

--- a/tests/unit/core/test_config.py
+++ b/tests/unit/core/test_config.py
@@ -90,9 +90,7 @@ def write_config_file(path: Path, config_format: str, values: dict[str, object])
         return
 
     if config_format == "toml":
-        content = "\n".join(
-            f"{key} = {_to_toml_value(value)}" for key, value in values.items()
-        )
+        content = "\n".join(f"{key} = {_to_toml_value(value)}" for key, value in values.items())
         path.write_text(f"{content}\n", encoding="utf-8")
         return
 
@@ -833,7 +831,9 @@ class TestMultiFormatConfigLoading:
             assert settings.debug is True
             assert settings.log_level == "DEBUG"
 
-    def test_default_config_path_loads_json_when_no_yaml_or_toml_exists(self, tmp_path, monkeypatch):
+    def test_default_config_path_loads_json_when_no_yaml_or_toml_exists(
+        self, tmp_path, monkeypatch
+    ):
         """Test that default-path discovery falls through to later supported formats."""
         from redis_sre_agent.core.config import Settings
 


### PR DESCRIPTION
## Summary
- add TOML and JSON support to the settings config-file loader while preserving YAML compatibility
- extend config tests for explicit-path loading, default-path discovery, env-over-file precedence, and missing/invalid file handling across YAML, TOML, and JSON
- update configuration and MCP-related docs to describe supported config formats and discovery order

Closes #111


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the settings loading path selection and source initialization for all runs, so config precedence/discovery bugs could affect startup behavior. Error-handling now silently ignores missing/invalid config files, which may mask misconfiguration.
> 
> **Overview**
> **Adds multi-format config-file support** by extending settings loading to accept `.toml` and `.json` (in addition to YAML) via `SRE_AGENT_CONFIG` and expanded default discovery order (`config.*` and `sre_agent_config.*`).
> 
> **Refactors config source selection** to dynamically choose the appropriate `pydantic-settings` source by file suffix and to fall back to an empty config on missing/invalid files.
> 
> Updates docs to describe the new supported formats and discovery order, and expands unit tests to cover TOML/JSON explicit-path loading, default-path selection, env-over-file precedence, and missing/invalid file handling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f3520fd648064ae741cff1d51b0b7bf7ea452db6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->