### PR TITLE
Fix exact search compatibility on older Redis Search

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,16 @@ Redis SRE Agent is an AI teammate for Redis operations. It answers questions fro
 ## Quick Start
 
 ### Prerequisites
-- Python 3.12+, Redis 8+ or 7.x with RediSearch module, `uv` package manager
+- Python 3.12+, Redis with Redis Search / Redis Query Engine 2.4+, `uv` package manager
 - OpenAI API key or OpenAI-compatible proxy
 - Optional: Prometheus, Loki, and Grafana access for monitoring integration
+
+### Redis Compatibility
+
+- Minimum supported search engine: Redis Search / Redis Query Engine 2.4+
+- Redis 8.x is recommended; Redis 7.x is supported when the deployed Redis Search module is 2.4 or newer
+
+For more details on Redis/Search compatibility and fallback behavior, see [Operational Gotchas](docs/operations/gotchas.md#redis-enterprise-vs-redis-oss).
 
 ### Development Setup
 ```bash
@@ -39,8 +46,8 @@ uv sync
 cp .env.example .env
 # Edit .env with your API keys and configuration
 
-# Start Redis 8
-docker run -d -p 7843:6379 redis:8-alpine
+# Start Redis with Redis Search
+docker run -d -p 7843:6379 redis/redis-stack-server:latest
 
 # Start worker
 uv run redis-sre-agent worker

--- a/docs/operations/gotchas.md
+++ b/docs/operations/gotchas.md
@@ -92,6 +92,16 @@ The agent requires Redis with the RediSearch module for vector search. Options:
 
 Redis 8.x is recommended. Redis 7.x works but may have different module versions.
 
+Minimum supported search engine version:
+- **Redis Search / Redis Query Engine 2.4+** is the effective minimum requirement for this agent's knowledge retrieval path
+- Exact identifier lookup uses `DIALECT 2` TAG queries, and vector retrieval also depends on Redis Search 2.4+ features
+
+Hybrid search compatibility:
+- On newer Redis/Search releases, the agent uses native server-side hybrid retrieval when available
+- On older or partially compatible releases, native hybrid retrieval may be unavailable even though text and vector search still work
+- In those cases, the agent falls back to client-side **reciprocal rank fusion (RRF)**, which runs separate text and vector queries and merges the ranked results in the application
+- The RRF fallback is a compatibility path, not a legacy path: it still requires Redis Search 2.4+ because it depends on Redis Search text and vector queries
+
 ---
 
 ## Configuration

--- a/redis_sre_agent/core/knowledge_helpers.py
+++ b/redis_sre_agent/core/knowledge_helpers.py
@@ -69,9 +69,7 @@ _HYBRID_QUERY_UNSUPPORTED_MARKERS = (
     "not supported",
 )
 _HYBRID_MISSING_COMMAND_MARKERS = ("unknown command", "no such command")
-_TAG_EXACT_MATCH_ESCAPER = TokenEscaper(
-    re.compile(r"[,.<>{}\[\]\\\"\':;!@#$%^&*()\-+=~\/ \?\|]")
-)
+_TAG_EXACT_MATCH_ESCAPER = TokenEscaper(re.compile(r"[,.<>{}\[\]\\\"\':;!@#$%^&*()\-+=~\/ \?\|]"))
 
 
 def _coerce_non_negative_int(value: Any, *, default: int) -> int:

--- a/redis_sre_agent/core/knowledge_helpers.py
+++ b/redis_sre_agent/core/knowledge_helpers.py
@@ -61,6 +61,17 @@ _SUPPORT_TICKET_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{1,127}$")
 _TEXT_PHRASE_QUERY_FIELDS = ("title", "summary", "content")
 _RRF_K = 60
 _HYBRID_UNSUPPORTED_INDEX_TYPES: set[str] = set()
+_HYBRID_QUERY_UNSUPPORTED_MARKERS = (
+    "syntax error",
+    "unknown argument",
+    "unknown keyword",
+    "unsupported",
+    "not supported",
+)
+_HYBRID_MISSING_COMMAND_MARKERS = ("unknown command", "no such command")
+_TAG_EXACT_MATCH_ESCAPER = TokenEscaper(
+    re.compile(r"[,.<>{}\[\]\\\"\':;!@#$%^&*()\-+=~\/ \?\|]")
+)
 
 
 def _coerce_non_negative_int(value: Any, *, default: int) -> int:
@@ -295,14 +306,31 @@ def _normalize_exact_match_value(value: str, index_type: str) -> str:
     return str(value or "").strip()
 
 
-def _quote_tag_value(value: str) -> str:
-    """Quote a RediSearch TAG value so punctuation is treated literally."""
-    return '"' + value.replace("\\", "\\\\").replace('"', '\\"') + '"'
-
-
 def _tag_equals_expression(field_name: str, value: str) -> FilterExpression:
-    """Build an exact TAG match expression that survives punctuation like `|`."""
-    return FilterExpression(f"@{field_name}:{{{_quote_tag_value(value)}}}")
+    """Build a canonical TAG equality expression with explicit escaping."""
+    escaped_value = _TAG_EXACT_MATCH_ESCAPER.escape(str(value or ""))
+    return FilterExpression(f"@{field_name}:{{{escaped_value}}}")
+
+
+def _exact_match_filter_expression(
+    field_name: str,
+    normalized_query: str,
+    *,
+    version: Optional[str],
+    category: Optional[str],
+    doc_type: Optional[str],
+) -> FilterExpression:
+    """Build a field-scoped exact-match filter with the shared TAG constraints."""
+    filter_expr = _tag_equals_expression(field_name, normalized_query)
+
+    if version is not None:
+        filter_expr = filter_expr & _tag_equals_expression("version", version)
+    if category is not None:
+        filter_expr = filter_expr & _tag_equals_expression("category", category)
+    if doc_type is not None:
+        filter_expr = filter_expr & _tag_equals_expression("doc_type", doc_type.strip().lower())
+
+    return filter_expr
 
 
 def _looks_like_precise_search_query(query: str, index_type: str) -> bool:
@@ -365,28 +393,24 @@ async def _find_exact_document_matches(
 
     index = await _get_index_for_type(normalized_index_type, config=config)
 
-    filter_expr = None
+    rows: List[Dict[str, Any]] = []
     for field_name in _EXACT_MATCH_TAG_FIELDS:
-        field_expr = _tag_equals_expression(field_name, normalized_query)
-        filter_expr = field_expr if filter_expr is None else (filter_expr | field_expr)
-
-    if version is not None:
-        version_expr = _tag_equals_expression("version", version)
-        filter_expr = version_expr if filter_expr is None else (filter_expr & version_expr)
-    if category is not None:
-        category_expr = _tag_equals_expression("category", category)
-        filter_expr = category_expr if filter_expr is None else (filter_expr & category_expr)
-    if doc_type is not None:
-        doc_type_expr = _tag_equals_expression("doc_type", doc_type.strip().lower())
-        filter_expr = doc_type_expr if filter_expr is None else (filter_expr & doc_type_expr)
-
-    rows = await index.query(
-        FilterQuery(
-            filter_expression=filter_expr,
-            return_fields=_SEARCH_RETURN_FIELDS,
-            num_results=50,
+        rows.extend(
+            await index.query(
+                FilterQuery(
+                    filter_expression=_exact_match_filter_expression(
+                        field_name,
+                        normalized_query,
+                        version=version,
+                        category=category,
+                        doc_type=doc_type,
+                    ),
+                    return_fields=_SEARCH_RETURN_FIELDS,
+                    num_results=50,
+                    dialect=2,
+                )
+            )
         )
-    )
 
     candidates = [
         doc
@@ -508,16 +532,11 @@ def _reciprocal_rank_fuse(
 def _is_hybrid_query_unsupported_error(exc: Exception) -> bool:
     """Whether Redis rejected the HybridQuery syntax/capability."""
     message = str(exc or "").lower()
-    return any(
-        marker in message
-        for marker in (
-            "syntax error",
-            "unknown argument",
-            "unsupported",
-            "not supported",
-            "unknown keyword",
-            "no such",
-        )
+    if any(marker in message for marker in _HYBRID_QUERY_UNSUPPORTED_MARKERS):
+        return True
+
+    return "ft.hybrid" in message and any(
+        marker in message for marker in _HYBRID_MISSING_COMMAND_MARKERS
     )
 
 
@@ -1666,13 +1685,8 @@ async def get_all_document_fragments(
         normalized_index_type = index_type.strip().lower()
         index = await _get_index_for_type(normalized_index_type, config=config)
 
-        # Use FT.SEARCH to find all chunks for this document
-        # document_hash is indexed as a TAG field, so we can filter on it.
-        # Tag values that include punctuation (e.g., '-') must be quoted.
-        from redisvl.query import FilterQuery
-
         filter_query = FilterQuery(
-            filter_expression=str(_tag_equals_expression("document_hash", document_hash)),
+            filter_expression=_tag_equals_expression("document_hash", document_hash),
             return_fields=[
                 "title",
                 "content",
@@ -1691,6 +1705,7 @@ async def get_all_document_fragments(
                 "version",
             ],
             num_results=1000,  # Set high limit to get all chunks
+            dialect=2,
         )
 
         # Execute search

--- a/tests/unit/core/test_knowledge_helpers.py
+++ b/tests/unit/core/test_knowledge_helpers.py
@@ -73,6 +73,30 @@ class TestKnowledgeHelpers:
         assert _exact_match_sort_key(source_match, "ticket-ret-4421.md")[0] == 2
         assert _exact_match_sort_key(non_match, "ticket-ret-4421.md")[0] == 3
 
+    def test_tag_equals_expression_uses_canonical_tag_syntax(self):
+        """Exact TAG filters should use escaped canonical syntax, not quoted values."""
+        assert str(knowledge_helpers._tag_equals_expression("name", "INC432323")) == (
+            "@name:{INC432323}"
+        )
+        assert str(knowledge_helpers._tag_equals_expression("name", "foo|bar/baz[prod]")) == (
+            r"@name:{foo\|bar\/baz\[prod\]}"
+        )
+
+    def test_hybrid_unsupported_error_detector_avoids_generic_ft_hybrid_mentions(self):
+        """Only explicit capability/command failures should trip the fallback detector."""
+        assert knowledge_helpers._is_hybrid_query_unsupported_error(
+            RuntimeError("ERR unknown command 'FT.HYBRID'")
+        )
+        assert knowledge_helpers._is_hybrid_query_unsupported_error(
+            RuntimeError("ERR no such command 'FT.HYBRID'")
+        )
+        assert not knowledge_helpers._is_hybrid_query_unsupported_error(
+            RuntimeError("transport failure while issuing FT.HYBRID request")
+        )
+        assert not knowledge_helpers._is_hybrid_query_unsupported_error(
+            RuntimeError("ERR no such index")
+        )
+
 
 class TestSearchKnowledgeBaseHelper:
     """Test search_knowledge_base_helper function."""
@@ -189,6 +213,8 @@ class TestSearchKnowledgeBaseHelper:
                     }
                 ],
                 [],
+                [],
+                [],
                 [
                     {
                         "id": "doc-semantic",
@@ -227,8 +253,8 @@ class TestSearchKnowledgeBaseHelper:
         assert result["results"][0]["id"] == "doc-exact"
         assert result["results"][0]["name"] == "ret-4421"
         assert result["results"][1]["id"] == "doc-semantic"
-        assert mock_index.query.await_args_list[1].args[0].__class__.__name__ == "_RawTextQuery"
-        assert mock_index.query.await_args_list[2].args[0].__class__.__name__ == "HybridQuery"
+        assert mock_index.query.await_args_list[3].args[0].__class__.__name__ == "_RawTextQuery"
+        assert mock_index.query.await_args_list[4].args[0].__class__.__name__ == "HybridQuery"
 
     @pytest.mark.asyncio
     async def test_search_knowledge_base_promotes_exact_document_hash_match(self):
@@ -236,6 +262,7 @@ class TestSearchKnowledgeBaseHelper:
         mock_index = AsyncMock()
         mock_index.query = AsyncMock(
             side_effect=[
+                [],
                 [
                     {
                         "id": "doc-exact",
@@ -249,6 +276,7 @@ class TestSearchKnowledgeBaseHelper:
                         "version": "latest",
                     }
                 ],
+                [],
                 [],
                 [
                     {
@@ -293,6 +321,8 @@ class TestSearchKnowledgeBaseHelper:
         mock_index = AsyncMock()
         mock_index.query = AsyncMock(
             side_effect=[
+                [],
+                [],
                 [],
                 [
                     {
@@ -341,7 +371,7 @@ class TestSearchKnowledgeBaseHelper:
         ):
             result = await search_knowledge_base_helper(query="RET-4421", limit=10)
 
-        literal_query = str(mock_index.query.await_args_list[1].args[0])
+        literal_query = str(mock_index.query.await_args_list[3].args[0])
         assert '@title:("ret-4421")' in literal_query
         assert '@summary:("ret-4421")' in literal_query
         assert '@content:("ret-4421")' in literal_query
@@ -355,6 +385,8 @@ class TestSearchKnowledgeBaseHelper:
         mock_index = AsyncMock()
         mock_index.query = AsyncMock(
             side_effect=[
+                [],
+                [],
                 [],
                 [
                     {
@@ -403,13 +435,13 @@ class TestSearchKnowledgeBaseHelper:
         ):
             result = await search_knowledge_base_helper(query='"DB memory full"', limit=10)
 
-        literal_query = str(mock_index.query.await_args_list[1].args[0])
+        literal_query = str(mock_index.query.await_args_list[3].args[0])
         assert '@title:("db memory full")' in literal_query
         assert '@summary:("db memory full")' in literal_query
         assert '@content:("db memory full")' in literal_query
         assert result["results_count"] == 2
         assert result["results"][0]["id"] == "doc-phrase"
-        assert mock_index.query.await_args_list[2].args[0].__class__.__name__ == "HybridQuery"
+        assert mock_index.query.await_args_list[4].args[0].__class__.__name__ == "HybridQuery"
 
     def test_quoted_text_phrase_query_uses_implicit_and_for_filters(self):
         """Phrase queries should only contain the literal TEXT search expression."""
@@ -725,6 +757,74 @@ class TestSearchKnowledgeBaseHelper:
         assert mock_index.query.await_args_list[2].args[0].__class__.__name__ == "VectorQuery"
 
     @pytest.mark.asyncio
+    async def test_search_knowledge_base_hybrid_falls_back_to_rrf_on_unknown_command(self):
+        """Servers that reject FT.HYBRID outright should still fall back cleanly."""
+        knowledge_helpers._HYBRID_UNSUPPORTED_INDEX_TYPES.clear()
+        mock_index = AsyncMock()
+        mock_index.query = AsyncMock(
+            side_effect=[
+                RuntimeError("ERR unknown command 'FT.HYBRID'"),
+                [
+                    {
+                        "id": "doc-text",
+                        "document_hash": "hash-text",
+                        "chunk_index": 0,
+                        "title": "Redis memory guide",
+                        "content": "Tune memory fragmentation first.",
+                        "source": "docs",
+                        "category": "monitoring",
+                        "doc_type": "runbook",
+                        "version": "latest",
+                        "score": 5.0,
+                    }
+                ],
+                [
+                    {
+                        "id": "doc-vector",
+                        "document_hash": "hash-vector",
+                        "chunk_index": 0,
+                        "title": "Latency checklist",
+                        "content": "Check allocator pressure and swap activity.",
+                        "source": "docs",
+                        "category": "monitoring",
+                        "doc_type": "runbook",
+                        "version": "latest",
+                        "vector_distance": 0.15,
+                    }
+                ],
+            ]
+        )
+
+        mock_vectorizer = MagicMock()
+        mock_vectorizer.aembed_many = AsyncMock(return_value=[[0.1, 0.2, 0.3]])
+
+        try:
+            with (
+                patch(
+                    "redis_sre_agent.core.knowledge_helpers.get_knowledge_index",
+                    new_callable=AsyncMock,
+                    return_value=mock_index,
+                ),
+                patch(
+                    "redis_sre_agent.core.knowledge_helpers.get_vectorizer",
+                    return_value=mock_vectorizer,
+                ),
+            ):
+                result = await search_knowledge_base_helper(
+                    query="redis memory",
+                    hybrid_search=True,
+                    limit=10,
+                )
+        finally:
+            knowledge_helpers._HYBRID_UNSUPPORTED_INDEX_TYPES.clear()
+
+        assert result["results_count"] == 2
+        assert [doc["id"] for doc in result["results"]] == ["doc-text", "doc-vector"]
+        assert mock_index.query.await_args_list[0].args[0].__class__.__name__ == "HybridQuery"
+        assert mock_index.query.await_args_list[1].args[0].__class__.__name__ == "_RawTextQuery"
+        assert mock_index.query.await_args_list[2].args[0].__class__.__name__ == "VectorQuery"
+
+    @pytest.mark.asyncio
     async def test_search_knowledge_base_hybrid_uses_cached_rrf_fallback(self):
         """Once a server is known to lack HybridQuery support, skip the failing probe."""
         knowledge_helpers._HYBRID_UNSUPPORTED_INDEX_TYPES.clear()
@@ -832,6 +932,10 @@ class TestSearchKnowledgeBaseHelper:
                 [],
                 [],
                 [],
+                [],
+                [],
+                [],
+                [],
                 [
                     {
                         "id": "doc-fallback-phrase",
@@ -872,8 +976,8 @@ class TestSearchKnowledgeBaseHelper:
 
         assert result["results_count"] == 1
         assert result["results"][0]["id"] == "doc-fallback-phrase"
-        assert mock_index.query.call_count == 6
-        assert mock_index.query.await_args_list[5].args[0].__class__.__name__ == "_RawTextQuery"
+        assert mock_index.query.call_count == 10
+        assert mock_index.query.await_args_list[9].args[0].__class__.__name__ == "_RawTextQuery"
 
     @pytest.mark.asyncio
     async def test_search_knowledge_base_category_fallback_skips_exact_prequery_for_natural_language_hybrid(
@@ -1231,6 +1335,38 @@ class TestGetAllDocumentFragments:
         assert result["fragments_count"] == 1
         assert result["fragments"][0]["content"] == "Version 7.4 content"
 
+    @pytest.mark.asyncio
+    async def test_get_all_fragments_uses_filter_expression_object(self):
+        """Fragment lookup should pass a FilterExpression, not a raw string."""
+
+        class _StrictFilterQuery:
+            def __init__(self, *, filter_expression, return_fields, num_results, dialect=2):
+                if isinstance(filter_expression, str):
+                    raise TypeError("filter_expression must be a FilterExpression")
+                self._filter_expression = filter_expression
+                self._return_fields = return_fields
+                self.num_results = num_results
+                self.dialect = dialect
+
+        mock_index = AsyncMock()
+        mock_index.query = AsyncMock(return_value=[])
+
+        with (
+            patch(
+                "redis_sre_agent.core.knowledge_helpers.FilterQuery",
+                _StrictFilterQuery,
+            ),
+            patch(
+                "redis_sre_agent.core.knowledge_helpers.get_knowledge_index",
+                new_callable=AsyncMock,
+                return_value=mock_index,
+            ),
+        ):
+            result = await get_all_document_fragments(document_hash="test-hash-123")
+
+        assert result["document_hash"] == "test-hash-123"
+        assert result["fragments"] == []
+
 
 class TestGetRelatedDocumentFragments:
     """Test get_related_document_fragments function."""
@@ -1542,6 +1678,54 @@ class TestSkillHelpers:
 
 
 class TestSupportTicketHelpers:
+    @pytest.mark.asyncio
+    async def test_find_support_ticket_exact_matches_runs_one_query_per_exact_tag_field(self):
+        support_tickets_index = AsyncMock()
+        matching_doc = {
+            "id": "sre_support_tickets:ticket-hash:chunk:0",
+            "document_hash": "ticket-hash",
+            "chunk_index": 0,
+            "title": "Incident ticket",
+            "content": "Exact match content",
+            "source": "foo|bar/baz[prod]",
+            "doc_type": "support_ticket",
+            "name": "foo|bar/baz[prod]",
+            "version": "latest",
+        }
+        support_tickets_index.query = AsyncMock(
+            side_effect=[[matching_doc], [matching_doc], [matching_doc]]
+        )
+
+        with patch(
+            "redis_sre_agent.core.knowledge_helpers.get_support_tickets_index",
+            new_callable=AsyncMock,
+            return_value=support_tickets_index,
+        ):
+            result = await knowledge_helpers._find_support_ticket_exact_matches(
+                query="foo|bar/baz[prod]",
+                version="latest",
+            )
+
+        assert len(result) == 1
+        assert result[0]["document_hash"] == "ticket-hash"
+        assert support_tickets_index.query.await_count == len(knowledge_helpers._EXACT_MATCH_TAG_FIELDS)
+
+        expected_field_filters = (
+            r"@name:{foo\|bar\/baz\[prod\]}",
+            r"@document_hash:{foo\|bar\/baz\[prod\]}",
+            r"@source:{foo\|bar\/baz\[prod\]}",
+        )
+        observed_filters = [
+            str(call.args[0]._filter_expression)
+            for call in support_tickets_index.query.await_args_list
+        ]
+
+        for expected_filter, observed_filter in zip(expected_field_filters, observed_filters):
+            assert expected_filter in observed_filter
+            assert '@doc_type:{support_ticket}' in observed_filter
+            assert '@version:{latest}' in observed_filter
+            assert '"foo|bar/baz[prod]"' not in observed_filter
+
     @pytest.mark.asyncio
     async def test_search_support_tickets_helper_normalizes_ticket_id_from_chunk_key(self):
         with (

--- a/tests/unit/core/test_knowledge_helpers.py
+++ b/tests/unit/core/test_knowledge_helpers.py
@@ -1708,7 +1708,9 @@ class TestSupportTicketHelpers:
 
         assert len(result) == 1
         assert result[0]["document_hash"] == "ticket-hash"
-        assert support_tickets_index.query.await_count == len(knowledge_helpers._EXACT_MATCH_TAG_FIELDS)
+        assert support_tickets_index.query.await_count == len(
+            knowledge_helpers._EXACT_MATCH_TAG_FIELDS
+        )
 
         expected_field_filters = (
             r"@name:{foo\|bar\/baz\[prod\]}",
@@ -1722,8 +1724,8 @@ class TestSupportTicketHelpers:
 
         for expected_filter, observed_filter in zip(expected_field_filters, observed_filters):
             assert expected_filter in observed_filter
-            assert '@doc_type:{support_ticket}' in observed_filter
-            assert '@version:{latest}' in observed_filter
+            assert "@doc_type:{support_ticket}" in observed_filter
+            assert "@version:{latest}" in observed_filter
             assert '"foo|bar/baz[prod]"' not in observed_filter
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- fix exact TAG lookup to use canonical escaped TAG syntax and per-field exact-match queries with `dialect=2`
- tighten HybridQuery unsupported-error detection and add fallback coverage for `unknown command 'FT.HYBRID'`
- document the minimum Redis Search / Redis Query Engine requirement (`2.4+`) and clarify hybrid/RRF compatibility


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core knowledge retrieval query construction and hybrid fallback behavior, which can change search recall/ordering across Redis/Search versions. Changes are well-covered by new and updated unit tests but still depend on Redis module/version nuances in production.
> 
> **Overview**
> **Improves compatibility with older Redis/Search deployments for knowledge retrieval.** Exact-match TAG lookups now use canonical escaped TAG syntax (instead of quoting), run **one `FilterQuery` per exact-tag field**, and explicitly set `dialect=2` to avoid syntax/version edge cases.
> 
> **Hardens hybrid search fallback logic.** HybridQuery unsupported-error detection is tightened to trigger RRF fallback only on explicit syntax/capability failures (including `unknown/no such command 'FT.HYBRID'`), with added test coverage for these scenarios.
> 
> **Updates operational docs.** README and `docs/operations/gotchas.md` clarify Redis Search / Redis Query Engine **2.4+** as the effective minimum requirement, recommend Redis 8.x (with Redis 7.x supported when Search is new enough), and adjust dev setup to use `redis/redis-stack-server` for Redis Search.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ad85205988889db4a7abff0cdeda654a0debfd83. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->