### PR TITLE
Move written specs into specs/

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,7 +52,12 @@ make local-services-logs # Tail logs
 - CLI: `redis_sre_agent/cli/`
 - Configuration: `redis_sre_agent/core/config.py`
 - Docker config: `docker-compose.yml`
+- Written specs: `specs/`
 - Source documents: `source_documents/`
+
+## Specs
+- Put newly written design specs and implementation specs in `specs/`.
+- Prefer `specs/` over `docs/` for work-in-progress or review-oriented specification documents.
 
 ## Environment Variables
 See `.env.example` for full configuration. Key variables:

--- a/redis_sre_agent/core/cache_helpers.py
+++ b/redis_sre_agent/core/cache_helpers.py
@@ -1,0 +1,72 @@
+"""Shared helpers for cache and version MCP tools."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from redis_sre_agent import __version__
+from redis_sre_agent.core.redis import get_redis_client
+from redis_sre_agent.tools.cache import ToolCache
+
+
+def get_tool_cache(instance_id: Optional[str] = None) -> ToolCache:
+    """Build a tool cache scoped to one instance or all instances."""
+    return ToolCache(
+        redis_client=get_redis_client(),
+        instance_id=instance_id or "__all__",
+    )
+
+
+async def cache_stats_helper(instance_id: Optional[str] = None) -> Dict[str, Any]:
+    """Return cache statistics for one instance or all instances."""
+    cache = get_tool_cache(instance_id if instance_id else "__all__")
+    if instance_id:
+        return await cache.stats()
+    return await cache.stats_all()
+
+
+async def cache_clear_helper(
+    *,
+    instance_id: Optional[str] = None,
+    clear_all: bool = False,
+    confirm: bool = False,
+) -> Dict[str, Any]:
+    """Clear cached tool outputs with explicit confirmation."""
+    if not confirm:
+        return {
+            "error": "Confirmation required",
+            "status": "cancelled",
+            "instance_id": instance_id,
+        }
+
+    if not instance_id and not clear_all:
+        return {
+            "error": "Must specify instance_id or clear_all=True",
+            "status": "failed",
+        }
+
+    if clear_all:
+        cache = get_tool_cache("__all__")
+        deleted = await cache.clear_all()
+        return {
+            "status": "cleared",
+            "scope": "all",
+            "deleted": deleted,
+        }
+
+    cache = get_tool_cache(instance_id)
+    deleted = await cache.clear()
+    return {
+        "status": "cleared",
+        "scope": "instance",
+        "instance_id": instance_id,
+        "deleted": deleted,
+    }
+
+
+def version_helper() -> Dict[str, str]:
+    """Return package version metadata."""
+    return {
+        "name": "redis-sre-agent",
+        "version": __version__,
+    }

--- a/redis_sre_agent/core/cli_mcp_parity.py
+++ b/redis_sre_agent/core/cli_mcp_parity.py
@@ -1,0 +1,155 @@
+"""Helpers for auditing CLI to MCP parity."""
+
+from __future__ import annotations
+
+from typing import Any, Iterable
+
+import click
+
+from redis_sre_agent.cli.main import main
+from redis_sre_agent.mcp_server.server import mcp
+
+EXCLUDED_CLI_COMMAND_PATHS = frozenset(
+    {
+        "mcp list-tools",
+        "mcp serve",
+        "worker start",
+        "worker status",
+        "worker stop",
+    }
+)
+
+CLI_TO_MCP_TOOL_NAMES = {
+    "cache clear": "redis_sre_cache_clear",
+    "cache stats": "redis_sre_cache_stats",
+    "cluster backfill-instance-links": "redis_sre_backfill_instance_links",
+    "cluster create": "redis_sre_create_cluster",
+    "cluster delete": "redis_sre_delete_cluster",
+    "cluster get": "redis_sre_get_cluster",
+    "cluster list": "redis_sre_list_clusters",
+    "cluster update": "redis_sre_update_cluster",
+    "index list": "redis_sre_list_indices",
+    "index recreate": "redis_sre_recreate_indices",
+    "index schema-status": "redis_sre_get_index_schema_status",
+    "index sync-schemas": "redis_sre_sync_index_schemas",
+    "instance create": "redis_sre_create_instance",
+    "instance delete": "redis_sre_delete_instance",
+    "instance get": "redis_sre_get_instance",
+    "instance list": "redis_sre_list_instances",
+    "instance test": "redis_sre_test_instance",
+    "instance test-url": "redis_sre_test_redis_url",
+    "instance update": "redis_sre_update_instance",
+    "knowledge fragments": "redis_sre_get_knowledge_fragments",
+    "knowledge related": "redis_sre_get_related_knowledge_fragments",
+    "knowledge search": "redis_sre_knowledge_search",
+    "pipeline cleanup": "redis_sre_cleanup_pipeline_batches",
+    "pipeline full": "redis_sre_run_pipeline_full",
+    "pipeline ingest": "redis_sre_run_pipeline_ingest",
+    "pipeline prepare-sources": "redis_sre_prepare_source_documents",
+    "pipeline runbooks": "redis_sre_generate_pipeline_runbooks",
+    "pipeline scrape": "redis_sre_run_pipeline_scrape",
+    "pipeline show-batch": "redis_sre_get_pipeline_batch",
+    "pipeline status": "redis_sre_get_pipeline_status",
+    "query": "redis_sre_query",
+    "runbook evaluate": "redis_sre_evaluate_runbooks",
+    "runbook generate": "redis_sre_generate_runbook",
+    "schedule create": "redis_sre_create_schedule",
+    "schedule delete": "redis_sre_delete_schedule",
+    "schedule disable": "redis_sre_disable_schedule",
+    "schedule enable": "redis_sre_enable_schedule",
+    "schedule get": "redis_sre_get_schedule",
+    "schedule list": "redis_sre_list_schedules",
+    "schedule run-now": "redis_sre_run_schedule_now",
+    "schedule runs": "redis_sre_list_schedule_runs",
+    "schedule update": "redis_sre_update_schedule",
+    "support-package delete": "redis_sre_delete_support_package",
+    "support-package extract": "redis_sre_extract_support_package",
+    "support-package info": "redis_sre_get_support_package_info",
+    "support-package list": "redis_sre_list_support_packages",
+    "support-package upload": "redis_sre_upload_support_package",
+    "task delete": "redis_sre_delete_task",
+    "task get": "redis_sre_get_task",
+    "task list": "redis_sre_list_tasks",
+    "task purge": "redis_sre_purge_tasks",
+    "thread backfill": "redis_sre_backfill_threads",
+    "thread backfill-empty-subjects": "redis_sre_backfill_empty_thread_subjects",
+    "thread backfill-scheduled-subjects": "redis_sre_backfill_scheduled_thread_subjects",
+    "thread get": "redis_sre_get_thread",
+    "thread list": "redis_sre_list_threads",
+    "thread purge": "redis_sre_purge_threads",
+    "thread reindex": "redis_sre_reindex_threads",
+    "thread sources": "redis_sre_get_thread_sources",
+    "thread trace": "redis_sre_get_thread_trace",
+    "version": "redis_sre_version",
+}
+
+
+def _walk_click_commands(command: click.Command, prefix: tuple[str, ...]) -> set[str]:
+    if isinstance(command, click.MultiCommand):
+        ctx = click.Context(command)
+        command_paths: set[str] = set()
+        for name in command.list_commands(ctx):
+            child = command.get_command(ctx, name)
+            if child is None:
+                continue
+            command_paths.update(_walk_click_commands(child, prefix + (name,)))
+        return command_paths
+    return {" ".join(prefix)}
+
+
+def list_cli_command_paths() -> set[str]:
+    """Return every CLI leaf command path."""
+    ctx = click.Context(main)
+    command_paths: set[str] = set()
+    for name in main.list_commands(ctx):
+        child = main.get_command(ctx, name)
+        if child is None:
+            continue
+        command_paths.update(_walk_click_commands(child, (name,)))
+    return command_paths
+
+
+def list_in_scope_cli_command_paths() -> set[str]:
+    """Return CLI commands expected to have MCP parity."""
+    return list_cli_command_paths() - EXCLUDED_CLI_COMMAND_PATHS
+
+
+def list_mcp_tool_names() -> set[str]:
+    """Return registered MCP tool names."""
+    return {tool.name for tool in mcp._tool_manager._tools.values()}
+
+
+def audit_cli_mcp_parity(
+    *,
+    cli_command_paths: Iterable[str] | None = None,
+    mcp_tool_names: Iterable[str] | None = None,
+) -> dict[str, Any]:
+    """Audit in-scope CLI leaf commands against MCP tool coverage."""
+    cli_paths = set(list_cli_command_paths() if cli_command_paths is None else cli_command_paths)
+    tool_names = set(list_mcp_tool_names() if mcp_tool_names is None else mcp_tool_names)
+    in_scope_paths = sorted(cli_paths - EXCLUDED_CLI_COMMAND_PATHS)
+    excluded_paths = sorted(cli_paths & EXCLUDED_CLI_COMMAND_PATHS)
+    stale_exclusions = sorted(EXCLUDED_CLI_COMMAND_PATHS - cli_paths)
+    missing_cli_mappings = sorted(
+        path for path in in_scope_paths if path not in CLI_TO_MCP_TOOL_NAMES
+    )
+    missing_mcp_tools = {
+        path: CLI_TO_MCP_TOOL_NAMES[path]
+        for path in in_scope_paths
+        if path in CLI_TO_MCP_TOOL_NAMES and CLI_TO_MCP_TOOL_NAMES[path] not in tool_names
+    }
+
+    status = "ok"
+    if missing_cli_mappings or missing_mcp_tools or stale_exclusions:
+        status = "failed"
+
+    return {
+        "status": status,
+        "cli_command_count": len(cli_paths),
+        "in_scope_cli_command_count": len(in_scope_paths),
+        "mcp_tool_count": len(tool_names),
+        "excluded_cli_commands": excluded_paths,
+        "stale_exclusions": stale_exclusions,
+        "missing_cli_mappings": missing_cli_mappings,
+        "missing_mcp_tools": missing_mcp_tools,
+    }

--- a/redis_sre_agent/core/cluster_helpers.py
+++ b/redis_sre_agent/core/cluster_helpers.py
@@ -1,0 +1,226 @@
+"""Shared helpers for MCP cluster tools."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional
+
+from pydantic import SecretStr
+
+from redis_sre_agent.core import clusters as core_clusters
+from redis_sre_agent.core.cluster_admin_defaults import (
+    build_enterprise_admin_missing_fields_error,
+    missing_enterprise_admin_fields,
+    resolve_enterprise_admin_fields,
+)
+from redis_sre_agent.core.migrations.instances_to_clusters import (
+    run_instances_to_clusters_migration,
+)
+
+
+def _mask_cluster_payload(cluster: core_clusters.RedisCluster) -> Dict[str, Any]:
+    """Convert a cluster model to a masked JSON-safe payload."""
+    payload = cluster.model_dump(mode="json", exclude={"admin_password"})
+    if cluster.admin_password:
+        payload["admin_password"] = "***"
+    return payload
+
+
+async def list_clusters_helper(
+    *,
+    environment: Optional[str] = None,
+    status: Optional[str] = None,
+    cluster_type: Optional[str] = None,
+    user_id: Optional[str] = None,
+    search: Optional[str] = None,
+    limit: int = 100,
+    offset: int = 0,
+) -> Dict[str, Any]:
+    """Return filtered cluster results with masked credentials."""
+    result = await core_clusters.query_clusters(
+        environment=environment,
+        status=status,
+        cluster_type=cluster_type,
+        user_id=user_id,
+        search=search,
+        limit=limit,
+        offset=offset,
+    )
+    return {
+        "clusters": [_mask_cluster_payload(cluster) for cluster in result.clusters],
+        "total": result.total,
+        "limit": result.limit,
+        "offset": result.offset,
+    }
+
+
+async def get_cluster_helper(cluster_id: str) -> Dict[str, Any]:
+    """Return a single cluster payload or a not-found error."""
+    cluster = await core_clusters.get_cluster_by_id(cluster_id)
+    if not cluster:
+        return {"error": "Cluster not found", "id": cluster_id}
+    return _mask_cluster_payload(cluster)
+
+
+async def create_cluster_helper(
+    *,
+    name: str,
+    environment: str,
+    description: str,
+    cluster_type: str = "unknown",
+    notes: Optional[str] = None,
+    admin_url: Optional[str] = None,
+    admin_username: Optional[str] = None,
+    admin_password: Optional[str] = None,
+    status: Optional[str] = None,
+    version: Optional[str] = None,
+    last_checked: Optional[str] = None,
+    created_by: str = "user",
+    user_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Create a new cluster record."""
+    clusters = await core_clusters.get_clusters()
+    if any(cluster.name == name for cluster in clusters):
+        raise RuntimeError(f"Cluster with name '{name}' already exists")
+
+    normalized_cluster_type = (cluster_type or "unknown").lower()
+    resolved_admin = resolve_enterprise_admin_fields(
+        cluster_type=normalized_cluster_type,
+        admin_url=admin_url,
+        admin_username=admin_username,
+        admin_password=admin_password,
+    )
+    if normalized_cluster_type == "redis_enterprise":
+        missing_fields = missing_enterprise_admin_fields(
+            admin_url=resolved_admin.admin_url,
+            admin_username=resolved_admin.admin_username,
+            admin_password=resolved_admin.admin_password,
+        )
+        if missing_fields:
+            raise RuntimeError(build_enterprise_admin_missing_fields_error(missing_fields))
+
+    cluster_id = f"cluster-{environment.lower()}-{int(datetime.now(timezone.utc).timestamp())}"
+    new_cluster = core_clusters.RedisCluster(
+        id=cluster_id,
+        name=name,
+        cluster_type=normalized_cluster_type,
+        environment=environment.lower(),
+        description=description,
+        notes=notes,
+        admin_url=resolved_admin.admin_url,
+        admin_username=resolved_admin.admin_username,
+        admin_password=resolved_admin.admin_password,
+        status=status,
+        version=version,
+        last_checked=last_checked,
+        created_by=created_by.lower() if created_by else "user",
+        user_id=user_id,
+    )
+
+    clusters.append(new_cluster)
+    if not await core_clusters.save_clusters(clusters):
+        raise RuntimeError("Failed to save cluster")
+
+    return {"id": new_cluster.id, "status": "created"}
+
+
+async def update_cluster_helper(
+    cluster_id: str,
+    *,
+    name: Optional[str] = None,
+    cluster_type: Optional[str] = None,
+    environment: Optional[str] = None,
+    description: Optional[str] = None,
+    notes: Optional[str] = None,
+    admin_url: Optional[str] = None,
+    admin_username: Optional[str] = None,
+    admin_password: Optional[str] = None,
+    status: Optional[str] = None,
+    version: Optional[str] = None,
+    last_checked: Optional[str] = None,
+    created_by: Optional[str] = None,
+    user_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Update fields on an existing cluster."""
+    clusters = await core_clusters.get_clusters()
+    cluster_index = next(
+        (i for i, cluster in enumerate(clusters) if cluster.id == cluster_id), None
+    )
+    if cluster_index is None:
+        raise RuntimeError("Cluster not found")
+
+    update_data: Dict[str, Any] = {}
+    if name is not None:
+        update_data["name"] = name
+    if cluster_type is not None:
+        update_data["cluster_type"] = core_clusters.RedisClusterType(cluster_type.lower())
+    if environment is not None:
+        update_data["environment"] = environment.lower()
+    if description is not None:
+        update_data["description"] = description
+    if notes is not None:
+        update_data["notes"] = notes
+    if admin_url is not None:
+        update_data["admin_url"] = admin_url
+    if admin_username is not None:
+        update_data["admin_username"] = admin_username
+    if admin_password is not None:
+        update_data["admin_password"] = SecretStr(admin_password) if admin_password else None
+    if status is not None:
+        update_data["status"] = status
+    if version is not None:
+        update_data["version"] = version
+    if last_checked is not None:
+        update_data["last_checked"] = last_checked
+    if created_by is not None:
+        update_data["created_by"] = created_by.lower()
+    if user_id is not None:
+        update_data["user_id"] = user_id
+
+    update_data["updated_at"] = datetime.now(timezone.utc).isoformat()
+    current = clusters[cluster_index]
+    updated = current.model_copy(update=update_data)
+    validated = core_clusters.RedisCluster(**updated.model_dump(mode="json"))
+    clusters[cluster_index] = validated
+
+    if not await core_clusters.save_clusters(clusters):
+        raise RuntimeError("Failed to save updated cluster")
+
+    return {"id": validated.id, "status": "updated"}
+
+
+async def delete_cluster_helper(cluster_id: str, *, confirm: bool = False) -> Dict[str, Any]:
+    """Delete a cluster after explicit confirmation."""
+    if not confirm:
+        return {
+            "error": "Confirmation required",
+            "id": cluster_id,
+            "status": "cancelled",
+        }
+
+    clusters = await core_clusters.get_clusters()
+    remaining = [cluster for cluster in clusters if cluster.id != cluster_id]
+    if len(remaining) == len(clusters):
+        raise RuntimeError("Cluster not found")
+
+    if not await core_clusters.save_clusters(remaining):
+        raise RuntimeError("Failed to save after deletion")
+
+    try:
+        await core_clusters.delete_cluster_index_doc(cluster_id)
+    except Exception:
+        pass
+
+    return {"id": cluster_id, "status": "deleted"}
+
+
+async def backfill_instance_links_helper(
+    *, dry_run: bool = False, force: bool = False
+) -> Dict[str, Any]:
+    """Backfill missing cluster links for existing instance records."""
+    summary = await run_instances_to_clusters_migration(
+        dry_run=dry_run,
+        force=force,
+        source="mcp_cluster_backfill",
+    )
+    return summary.to_dict()

--- a/redis_sre_agent/core/docket_tasks.py
+++ b/redis_sre_agent/core/docket_tasks.py
@@ -454,6 +454,66 @@ async def process_knowledge_query(
 
 
 @sre_task
+async def process_pipeline_operation(
+    operation: str,
+    task_id: str,
+    thread_id: str,
+    batch_date: Optional[str] = None,
+    artifacts_path: str = "./artifacts",
+    scrapers: Optional[List[str]] = None,
+    latest_only: bool = False,
+    docs_path: str = "./redis-docs",
+    source_dir: str = "source_documents",
+    prepare_only: bool = False,
+    keep_days: int = 30,
+    url: Optional[str] = None,
+    test_url: Optional[str] = None,
+    list_urls: bool = False,
+    retry: Retry = Retry(attempts=2, delay=timedelta(seconds=2)),
+) -> Dict[str, Any]:
+    """Run a task-backed pipeline operation and persist its result."""
+    from redis_sre_agent.core.pipeline_execution_helpers import run_pipeline_operation_helper
+
+    logger.info("Processing pipeline operation %s for task %s", operation, task_id)
+
+    redis_client = get_redis_client()
+    task_manager = TaskManager(redis_client=redis_client)
+
+    await task_manager.update_task_status(task_id, TaskStatus.IN_PROGRESS)
+
+    try:
+        emitter = TaskEmitter(task_manager=task_manager, task_id=task_id)
+        result = await run_pipeline_operation_helper(
+            operation=operation,
+            batch_date=batch_date,
+            artifacts_path=artifacts_path,
+            scrapers=scrapers,
+            latest_only=latest_only,
+            docs_path=docs_path,
+            source_dir=source_dir,
+            prepare_only=prepare_only,
+            keep_days=keep_days,
+            url=url,
+            test_url=test_url,
+            list_urls=list_urls,
+            progress_emitter=emitter,
+        )
+        await task_manager.set_task_result(task_id, result)
+        await task_manager.update_task_status(task_id, TaskStatus.DONE)
+        return result
+    except Exception as e:
+        logger.error(
+            "Pipeline operation %s failed for task %s (attempt %s): %s",
+            operation,
+            task_id,
+            retry.attempt,
+            e,
+        )
+        await task_manager.set_task_error(task_id, str(e))
+        raise
+
+
+@sre_task
 async def scheduler_task(
     global_limit="scheduler",  # Need a sentinel value for concurrency limit argument
     perpetual: Perpetual = Perpetual(every=timedelta(seconds=30), automatic=True),

--- a/redis_sre_agent/core/docket_tasks.py
+++ b/redis_sre_agent/core/docket_tasks.py
@@ -947,11 +947,19 @@ async def process_agent_turn(
             routing_context["cluster_id"] = active_cluster_id
             routing_context.pop("instance_id", None)
 
-        agent_type = await route_to_appropriate_agent(
-            query=message,
-            context=routing_context,
-            user_preferences=None,  # Could be extended to include user preferences
-        )
+        requested_agent_type = (context or {}).get("requested_agent_type")
+        if requested_agent_type == "triage":
+            agent_type = AgentType.REDIS_TRIAGE
+        elif requested_agent_type == "chat":
+            agent_type = AgentType.REDIS_CHAT
+        elif requested_agent_type == "knowledge":
+            agent_type = AgentType.KNOWLEDGE_ONLY
+        else:
+            agent_type = await route_to_appropriate_agent(
+                query=message,
+                context=routing_context,
+                user_preferences=None,  # Could be extended to include user preferences
+            )
 
         logger.info(f"Routing query to {agent_type.value} agent")
 

--- a/redis_sre_agent/core/docket_tasks.py
+++ b/redis_sre_agent/core/docket_tasks.py
@@ -514,6 +514,64 @@ async def process_pipeline_operation(
 
 
 @sre_task
+async def process_runbook_operation(
+    operation: str,
+    task_id: str,
+    thread_id: str,
+    topic: Optional[str] = None,
+    scenario_description: Optional[str] = None,
+    severity: str = "warning",
+    category: str = "operational_runbook",
+    output_file: Optional[str] = None,
+    requirements: Optional[List[str]] = None,
+    max_iterations: int = 2,
+    auto_save: bool = True,
+    ingest: bool = False,
+    input_dir: str = "source_documents/runbooks",
+    retry: Retry = Retry(attempts=2, delay=timedelta(seconds=2)),
+) -> Dict[str, Any]:
+    """Run a task-backed runbook operation and persist its result."""
+    from redis_sre_agent.core.runbook_execution_helpers import run_runbook_operation_helper
+
+    logger.info("Processing runbook operation %s for task %s", operation, task_id)
+
+    redis_client = get_redis_client()
+    task_manager = TaskManager(redis_client=redis_client)
+
+    await task_manager.update_task_status(task_id, TaskStatus.IN_PROGRESS)
+
+    try:
+        emitter = TaskEmitter(task_manager=task_manager, task_id=task_id)
+        result = await run_runbook_operation_helper(
+            operation=operation,
+            topic=topic,
+            scenario_description=scenario_description,
+            severity=severity,
+            category=category,
+            output_file=output_file,
+            requirements=requirements,
+            max_iterations=max_iterations,
+            auto_save=auto_save,
+            ingest=ingest,
+            input_dir=input_dir,
+            progress_emitter=emitter,
+        )
+        await task_manager.set_task_result(task_id, result)
+        await task_manager.update_task_status(task_id, TaskStatus.DONE)
+        return result
+    except Exception as e:
+        logger.error(
+            "Runbook operation %s failed for task %s (attempt %s): %s",
+            operation,
+            task_id,
+            retry.attempt,
+            e,
+        )
+        await task_manager.set_task_error(task_id, str(e))
+        raise
+
+
+@sre_task
 async def scheduler_task(
     global_limit="scheduler",  # Need a sentinel value for concurrency limit argument
     perpetual: Perpetual = Perpetual(every=timedelta(seconds=30), automatic=True),

--- a/redis_sre_agent/core/index_helpers.py
+++ b/redis_sre_agent/core/index_helpers.py
@@ -71,10 +71,7 @@ async def list_indices_helper(
 
             try:
                 raw_info = await idx._redis_client.execute_command("FT.INFO", idx_name)
-                info = {
-                    _decode(raw_info[i]): raw_info[i + 1]
-                    for i in range(0, len(raw_info), 2)
-                }
+                info = {_decode(raw_info[i]): raw_info[i + 1] for i in range(0, len(raw_info), 2)}
                 entry["num_docs"] = int(_decode(info.get("num_docs", 0)))
             except Exception:
                 entry["num_docs"] = "?"

--- a/redis_sre_agent/core/index_helpers.py
+++ b/redis_sre_agent/core/index_helpers.py
@@ -1,0 +1,140 @@
+"""Shared helpers for MCP index tools."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from redis_sre_agent.core.redis import (
+    _iter_index_configs,
+    get_index_schema_status,
+    recreate_indices,
+    sync_index_schemas,
+)
+
+VALID_INDEX_NAMES = {
+    "knowledge",
+    "skills",
+    "support_tickets",
+    "schedules",
+    "threads",
+    "tasks",
+    "instances",
+    "clusters",
+}
+
+
+def _decode(value: Any) -> str:
+    if isinstance(value, bytes):
+        return value.decode()
+    return str(value or "")
+
+
+def _normalize_index_name(index_name: Optional[str]) -> Optional[str]:
+    normalized = (index_name or "").strip().lower()
+    if not normalized or normalized == "all":
+        return None
+    if normalized not in VALID_INDEX_NAMES:
+        valid = ", ".join(sorted(VALID_INDEX_NAMES | {"all"}))
+        raise ValueError(f"Invalid index_name '{index_name}'. Valid values: {valid}")
+    return normalized
+
+
+async def list_indices_helper(
+    *,
+    index_name: Optional[str] = None,
+    config=None,
+) -> Dict[str, Any]:
+    """List known index status and document counts."""
+    normalized_index_name = _normalize_index_name(index_name)
+    result: Dict[str, Any] = {
+        "success": True,
+        "requested_index": normalized_index_name or "all",
+        "indices": [],
+    }
+
+    for name, idx_name, get_fn, _schema in _iter_index_configs():
+        if normalized_index_name and name != normalized_index_name:
+            continue
+
+        try:
+            idx = await get_fn(config=config)
+            exists = await idx.exists()
+            entry: Dict[str, Any] = {
+                "name": name,
+                "index_name": idx_name,
+                "exists": exists,
+            }
+            if not exists:
+                entry["num_docs"] = 0
+                result["indices"].append(entry)
+                continue
+
+            try:
+                raw_info = await idx._redis_client.execute_command("FT.INFO", idx_name)
+                info = {
+                    _decode(raw_info[i]): raw_info[i + 1]
+                    for i in range(0, len(raw_info), 2)
+                }
+                entry["num_docs"] = int(_decode(info.get("num_docs", 0)))
+            except Exception:
+                entry["num_docs"] = "?"
+
+            result["indices"].append(entry)
+        except Exception as exc:
+            result["success"] = False
+            result["indices"].append(
+                {
+                    "name": name,
+                    "index_name": idx_name,
+                    "exists": False,
+                    "error": str(exc),
+                }
+            )
+
+    return result
+
+
+async def get_index_schema_status_helper(
+    *,
+    index_name: Optional[str] = None,
+    config=None,
+) -> Dict[str, Any]:
+    """Return schema drift status for one or all indices."""
+    normalized_index_name = _normalize_index_name(index_name)
+    return await get_index_schema_status(index_name=normalized_index_name, config=config)
+
+
+async def recreate_indices_helper(
+    *,
+    index_name: Optional[str] = None,
+    confirm: bool = False,
+    config=None,
+) -> Dict[str, Any]:
+    """Recreate one or all indices after confirmation."""
+    normalized_index_name = _normalize_index_name(index_name)
+    if not confirm:
+        return {
+            "success": False,
+            "status": "cancelled",
+            "error": "Confirmation required",
+            "index_name": normalized_index_name or "all",
+        }
+    return await recreate_indices(index_name=normalized_index_name, config=config)
+
+
+async def sync_index_schemas_helper(
+    *,
+    index_name: Optional[str] = None,
+    confirm: bool = False,
+    config=None,
+) -> Dict[str, Any]:
+    """Create or recreate drifted indices after confirmation."""
+    normalized_index_name = _normalize_index_name(index_name)
+    if not confirm:
+        return {
+            "success": False,
+            "status": "cancelled",
+            "error": "Confirmation required",
+            "index_name": normalized_index_name or "all",
+        }
+    return await sync_index_schemas(index_name=normalized_index_name, config=config)

--- a/redis_sre_agent/core/instance_inspection_helpers.py
+++ b/redis_sre_agent/core/instance_inspection_helpers.py
@@ -1,0 +1,57 @@
+"""Shared helpers for MCP instance inspection tools."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from pydantic import SecretStr
+
+from redis_sre_agent.core.instances import get_instance_by_id, mask_redis_url
+from redis_sre_agent.core.redis import test_redis_connection
+
+
+def _mask_instance_payload(instance: Any) -> Dict[str, Any]:
+    payload = instance.model_dump(mode="json", exclude={"connection_url", "admin_password"})
+    payload["connection_url"] = mask_redis_url(instance.connection_url)
+    if instance.admin_password:
+        payload["admin_password"] = "***"
+    return payload
+
+
+def _connection_url_value(connection_url: Any) -> str:
+    if isinstance(connection_url, SecretStr):
+        return connection_url.get_secret_value()
+    return str(connection_url)
+
+
+async def get_instance_helper(instance_id: str) -> Dict[str, Any]:
+    """Get a masked payload for a configured instance."""
+    instance = await get_instance_by_id(instance_id)
+    if not instance:
+        return {"error": "Instance not found", "id": instance_id}
+    return _mask_instance_payload(instance)
+
+
+async def check_redis_url_helper(connection_url: str) -> Dict[str, Any]:
+    """Test a Redis URL without creating an instance."""
+    success = await test_redis_connection(url=connection_url)
+    return {
+        "success": success,
+        "message": "Successfully connected" if success else "Failed to connect",
+        "url": mask_redis_url(connection_url),
+    }
+
+
+async def check_instance_helper(instance_id: str) -> Dict[str, Any]:
+    """Test connectivity to a configured instance."""
+    instance = await get_instance_by_id(instance_id)
+    if not instance:
+        return {"success": False, "error": "Instance not found", "id": instance_id}
+
+    success = await test_redis_connection(url=_connection_url_value(instance.connection_url))
+    return {
+        "success": success,
+        "message": "Successfully connected" if success else "Failed to connect",
+        "instance_id": instance_id,
+        "name": instance.name,
+    }

--- a/redis_sre_agent/core/instance_mutation_helpers.py
+++ b/redis_sre_agent/core/instance_mutation_helpers.py
@@ -1,0 +1,211 @@
+"""Shared helpers for MCP instance mutation tools."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+from redis_sre_agent.core.clusters import get_cluster_by_id
+from redis_sre_agent.core.instance_inspection_helpers import _mask_instance_payload
+from redis_sre_agent.core.instances import (
+    RedisInstance,
+    RedisInstanceType,
+    delete_instance_index_doc,
+    get_instances,
+    save_instances,
+)
+
+
+def _normalize_cluster_id(cluster_id: Optional[str]) -> Optional[str]:
+    if cluster_id is None:
+        return None
+    normalized = cluster_id.strip()
+    return normalized or None
+
+
+async def _validate_instance_cluster_link(
+    *,
+    cluster_id: Optional[str],
+    instance_type: Optional[str],
+) -> Optional[str]:
+    normalized_cluster_id = _normalize_cluster_id(cluster_id)
+    if normalized_cluster_id is None:
+        return None
+
+    cluster = await get_cluster_by_id(normalized_cluster_id)
+    if not cluster:
+        raise RuntimeError(f"Cluster with ID '{normalized_cluster_id}' not found")
+
+    normalized_instance_type = (instance_type or "unknown").strip().lower()
+    cluster_type = (
+        cluster.cluster_type.value
+        if hasattr(cluster.cluster_type, "value")
+        else str(cluster.cluster_type).strip().lower()
+    )
+    compatible_cluster_types = {
+        "redis_enterprise": {"redis_enterprise"},
+        "oss_cluster": {"oss_cluster"},
+        "redis_cloud": {"redis_cloud"},
+    }
+    allowed_cluster_types = compatible_cluster_types.get(normalized_instance_type)
+    if allowed_cluster_types and cluster_type not in allowed_cluster_types:
+        allowed_list = ", ".join(sorted(allowed_cluster_types))
+        raise RuntimeError(
+            f"instance_type '{normalized_instance_type}' is incompatible with cluster_type "
+            f"'{cluster_type}'. Allowed cluster_type(s): {allowed_list}"
+        )
+
+    return normalized_cluster_id
+
+
+def _apply_extension_updates(
+    current_extension_data: Optional[Dict[str, Any]],
+    *,
+    set_extensions: Optional[Dict[str, Any]],
+    unset_extensions: Optional[List[str]],
+) -> Optional[Dict[str, Any]]:
+    extension_data = dict(current_extension_data or {})
+    if set_extensions:
+        extension_data.update(set_extensions)
+    if unset_extensions:
+        for key in unset_extensions:
+            extension_data.pop(key, None)
+    return extension_data or None
+
+
+async def update_instance_helper(
+    instance_id: str,
+    *,
+    name: Optional[str] = None,
+    connection_url: Optional[str] = None,
+    environment: Optional[str] = None,
+    usage: Optional[str] = None,
+    description: Optional[str] = None,
+    repo_url: Optional[str] = None,
+    notes: Optional[str] = None,
+    monitoring_identifier: Optional[str] = None,
+    logging_identifier: Optional[str] = None,
+    instance_type: Optional[str] = None,
+    admin_url: Optional[str] = None,
+    admin_username: Optional[str] = None,
+    admin_password: Optional[str] = None,
+    cluster_id: Optional[str] = None,
+    redis_cloud_subscription_id: Optional[int] = None,
+    redis_cloud_database_id: Optional[int] = None,
+    redis_cloud_subscription_type: Optional[str] = None,
+    redis_cloud_database_name: Optional[str] = None,
+    status: Optional[str] = None,
+    version: Optional[str] = None,
+    memory: Optional[str] = None,
+    connections: Optional[int] = None,
+    user_id: Optional[str] = None,
+    set_extensions: Optional[Dict[str, Any]] = None,
+    unset_extensions: Optional[List[str]] = None,
+) -> Dict[str, Any]:
+    """Update fields on an existing Redis instance and return a masked payload."""
+    instances = await get_instances()
+    instance_index = next((i for i, item in enumerate(instances) if item.id == instance_id), None)
+    if instance_index is None:
+        return {"error": "Instance not found", "id": instance_id}
+
+    current = instances[instance_index]
+    update_data: Dict[str, Any] = {}
+
+    if name is not None:
+        update_data["name"] = name
+    if connection_url is not None:
+        update_data["connection_url"] = connection_url
+    if environment is not None:
+        update_data["environment"] = environment.lower()
+    if usage is not None:
+        update_data["usage"] = usage.lower()
+    if description is not None:
+        update_data["description"] = description
+    if repo_url is not None:
+        update_data["repo_url"] = repo_url
+    if notes is not None:
+        update_data["notes"] = notes
+    if monitoring_identifier is not None:
+        update_data["monitoring_identifier"] = monitoring_identifier
+    if logging_identifier is not None:
+        update_data["logging_identifier"] = logging_identifier
+    if instance_type is not None:
+        update_data["instance_type"] = RedisInstanceType(instance_type.lower())
+    if admin_url is not None:
+        update_data["admin_url"] = admin_url
+    if admin_username is not None:
+        update_data["admin_username"] = admin_username
+    if admin_password is not None:
+        update_data["admin_password"] = admin_password
+    if cluster_id is not None:
+        update_data["cluster_id"] = _normalize_cluster_id(cluster_id)
+    if redis_cloud_subscription_id is not None:
+        update_data["redis_cloud_subscription_id"] = redis_cloud_subscription_id
+    if redis_cloud_database_id is not None:
+        update_data["redis_cloud_database_id"] = redis_cloud_database_id
+    if redis_cloud_subscription_type is not None:
+        update_data["redis_cloud_subscription_type"] = redis_cloud_subscription_type.lower()
+    if redis_cloud_database_name is not None:
+        update_data["redis_cloud_database_name"] = redis_cloud_database_name
+    if status is not None:
+        update_data["status"] = status
+    if version is not None:
+        update_data["version"] = version
+    if memory is not None:
+        update_data["memory"] = memory
+    if connections is not None:
+        update_data["connections"] = connections
+    if user_id is not None:
+        update_data["user_id"] = user_id
+
+    effective_instance_type = update_data.get("instance_type", current.instance_type)
+    effective_cluster_id = update_data.get("cluster_id", current.cluster_id)
+    if "cluster_id" in update_data:
+        update_data["cluster_id"] = await _validate_instance_cluster_link(
+            cluster_id=effective_cluster_id,
+            instance_type=effective_instance_type,
+        )
+
+    if set_extensions or unset_extensions:
+        update_data["extension_data"] = _apply_extension_updates(
+            current.extension_data,
+            set_extensions=set_extensions,
+            unset_extensions=unset_extensions,
+        )
+
+    update_data["updated_at"] = datetime.now(timezone.utc).isoformat()
+    updated = current.model_copy(update=update_data)
+    validated = RedisInstance(**updated.model_dump(mode="json"))
+    instances[instance_index] = validated
+
+    if not await save_instances(instances):
+        raise RuntimeError("Failed to save updated instance")
+
+    payload = _mask_instance_payload(validated)
+    payload["status"] = "updated"
+    return payload
+
+
+async def delete_instance_helper(instance_id: str, *, confirm: bool = False) -> Dict[str, Any]:
+    """Delete a Redis instance after explicit confirmation."""
+    if not confirm:
+        return {
+            "error": "Confirmation required",
+            "id": instance_id,
+            "status": "cancelled",
+        }
+
+    instances = await get_instances()
+    remaining_instances = [instance for instance in instances if instance.id != instance_id]
+    if len(remaining_instances) == len(instances):
+        return {"error": "Instance not found", "id": instance_id}
+
+    if not await save_instances(remaining_instances):
+        raise RuntimeError("Failed to save after deletion")
+
+    try:
+        await delete_instance_index_doc(instance_id)
+    except Exception:
+        pass
+
+    return {"id": instance_id, "status": "deleted"}

--- a/redis_sre_agent/core/pipeline_execution_helpers.py
+++ b/redis_sre_agent/core/pipeline_execution_helpers.py
@@ -1,0 +1,338 @@
+"""Shared helpers for task-backed pipeline execution workflows."""
+
+from __future__ import annotations
+
+import inspect
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from docket import Docket
+
+from redis_sre_agent.core.redis import get_redis_client
+from redis_sre_agent.core.tasks import create_task
+from redis_sre_agent.pipelines.ingestion.processor import IngestionPipeline
+from redis_sre_agent.pipelines.orchestrator import PipelineOrchestrator
+from redis_sre_agent.pipelines.scraper.base import ArtifactStorage
+
+
+async def _emit_progress(
+    progress_emitter: Any,
+    message: str,
+    update_type: str,
+    metadata: Optional[Dict[str, Any]] = None,
+) -> None:
+    """Emit a task update when a progress emitter is available."""
+    if progress_emitter is not None:
+        await progress_emitter.emit(message, update_type, metadata or {})
+
+
+def _build_scrape_config(*, latest_only: bool, docs_path: str) -> Dict[str, Dict[str, Any]]:
+    """Build scraper configuration shared by scrape/full operations."""
+    return {
+        "redis_docs": {"latest_only": latest_only},
+        "redis_docs_local": {"latest_only": latest_only, "docs_repo_path": docs_path},
+    }
+
+
+def _resolve_batch_date(storage: ArtifactStorage, batch_date: Optional[str]) -> str:
+    """Validate and apply an optional batch-date override."""
+    if not batch_date:
+        return storage.current_date
+
+    try:
+        datetime.strptime(batch_date, "%Y-%m-%d")
+    except ValueError as exc:
+        raise ValueError(f"Invalid batch date format: {batch_date}. Use YYYY-MM-DD") from exc
+
+    storage.current_date = batch_date
+    storage.current_batch_path = storage.base_path / batch_date
+    storage._dirs_created = False
+    return batch_date
+
+
+def _list_source_markdown_files(source_path: Path) -> List[Path]:
+    """Return source markdown files excluding README files."""
+    markdown_files = [
+        path for path in source_path.rglob("*.md") if path.name.lower() != "readme.md"
+    ]
+    return sorted(markdown_files)
+
+
+def _build_pipeline_task_message(operation: str, kwargs: Dict[str, Any]) -> str:
+    """Generate a concise subject line for a pipeline task."""
+    if operation == "cleanup":
+        return f"Cleanup pipeline batches older than {kwargs.get('keep_days', 30)} days"
+    if operation == "ingest":
+        batch_date = kwargs.get("batch_date")
+        return (
+            f"Run pipeline ingest for batch {batch_date}" if batch_date else "Run pipeline ingest"
+        )
+    if operation == "prepare_sources":
+        return f"Prepare source documents from {kwargs.get('source_dir', 'source_documents')}"
+    if operation == "runbooks":
+        if kwargs.get("url"):
+            return f"Generate pipeline runbooks for {kwargs['url']}"
+        if kwargs.get("test_url"):
+            return f"Test pipeline runbook extraction for {kwargs['test_url']}"
+        if kwargs.get("list_urls"):
+            return "List configured pipeline runbook URLs"
+        return "Generate pipeline runbooks"
+    return f"Run pipeline {operation}"
+
+
+async def get_redis_url() -> str:
+    """Resolve the Redis URL for Docket without a module import cycle."""
+    from redis_sre_agent.core.docket_tasks import get_redis_url as resolve_redis_url
+
+    return await resolve_redis_url()
+
+
+def _get_pipeline_task_callable() -> Any:
+    """Resolve the Docket task callable without a module import cycle."""
+    from redis_sre_agent.core.docket_tasks import process_pipeline_operation
+
+    return process_pipeline_operation
+
+
+async def run_pipeline_operation_helper(
+    operation: str,
+    *,
+    batch_date: Optional[str] = None,
+    artifacts_path: str = "./artifacts",
+    scrapers: Optional[List[str]] = None,
+    latest_only: bool = False,
+    docs_path: str = "./redis-docs",
+    source_dir: str = "source_documents",
+    prepare_only: bool = False,
+    keep_days: int = 30,
+    url: Optional[str] = None,
+    test_url: Optional[str] = None,
+    list_urls: bool = False,
+    progress_emitter: Any = None,
+) -> Dict[str, Any]:
+    """Execute a pipeline operation and return a structured result."""
+    await _emit_progress(
+        progress_emitter,
+        f"Starting pipeline {operation}",
+        "pipeline_start",
+        {"operation": operation},
+    )
+
+    if operation == "scrape":
+        orchestrator = PipelineOrchestrator(
+            artifacts_path,
+            _build_scrape_config(latest_only=latest_only, docs_path=docs_path),
+            scrapers=scrapers,
+        )
+        result = await orchestrator.run_scraping_pipeline(scrapers)
+        await _emit_progress(
+            progress_emitter,
+            f"Completed pipeline {operation}",
+            "pipeline_complete",
+            {"operation": operation},
+        )
+        return {"operation": operation, **result}
+
+    if operation == "ingest":
+        orchestrator = PipelineOrchestrator(
+            artifacts_path,
+            {"ingestion": {"latest_only": latest_only}},
+        )
+        result = await orchestrator.run_ingestion_pipeline(batch_date)
+        await _emit_progress(
+            progress_emitter,
+            f"Completed pipeline {operation}",
+            "pipeline_complete",
+            {"operation": operation},
+        )
+        return {"operation": operation, **result}
+
+    if operation == "full":
+        config = _build_scrape_config(latest_only=latest_only, docs_path=docs_path)
+        config["ingestion"] = {"latest_only": latest_only}
+        orchestrator = PipelineOrchestrator(artifacts_path, config, scrapers=scrapers)
+        result = await orchestrator.run_full_pipeline(scrapers)
+        await _emit_progress(
+            progress_emitter,
+            f"Completed pipeline {operation}",
+            "pipeline_complete",
+            {"operation": operation},
+        )
+        return {"operation": operation, **result}
+
+    if operation == "cleanup":
+        orchestrator = PipelineOrchestrator(artifacts_path)
+        result = await orchestrator.cleanup_old_batches(keep_days)
+        await _emit_progress(
+            progress_emitter,
+            f"Completed pipeline {operation}",
+            "pipeline_complete",
+            {"operation": operation},
+        )
+        return {"operation": operation, **result}
+
+    if operation == "runbooks":
+        active_modes = sum(bool(value) for value in [url, test_url, list_urls])
+        if active_modes > 1:
+            raise ValueError("Only one of url, test_url, or list_urls may be provided")
+
+        orchestrator = PipelineOrchestrator(artifacts_path, scrapers=["runbook_generator"])
+        generator = orchestrator.scrapers["runbook_generator"]
+
+        if list_urls:
+            await _emit_progress(
+                progress_emitter,
+                f"Completed pipeline {operation}",
+                "pipeline_complete",
+                {"operation": operation},
+            )
+            return {
+                "operation": operation,
+                "mode": "list_urls",
+                "configured_urls": generator.get_configured_urls(),
+            }
+
+        if test_url:
+            await _emit_progress(
+                progress_emitter,
+                f"Completed pipeline {operation}",
+                "pipeline_complete",
+                {"operation": operation},
+            )
+            return {
+                "operation": operation,
+                "mode": "test_url",
+                "url": test_url,
+                "result": await generator.test_url_extraction(test_url),
+            }
+
+        if url:
+            added = await generator.add_runbook_url(url)
+            single_url_config = dict(generator.config)
+            single_url_config["runbook_urls"] = [url]
+            single_url_orchestrator = PipelineOrchestrator(
+                artifacts_path,
+                {"runbook_generator": single_url_config},
+                scrapers=["runbook_generator"],
+            )
+            single_generator = single_url_orchestrator.scrapers["runbook_generator"]
+            result = await single_generator.run_scraping_job()
+            await _emit_progress(
+                progress_emitter,
+                f"Completed pipeline {operation}",
+                "pipeline_complete",
+                {"operation": operation},
+            )
+            return {
+                "operation": operation,
+                "mode": "single_url",
+                "url": url,
+                "url_added": added,
+                **result,
+            }
+
+        result = await generator.run_scraping_job()
+        await _emit_progress(
+            progress_emitter,
+            f"Completed pipeline {operation}",
+            "pipeline_complete",
+            {"operation": operation},
+        )
+        return {"operation": operation, "mode": "configured_urls", **result}
+
+    if operation == "prepare_sources":
+        source_path = Path(source_dir)
+        if not source_path.exists():
+            raise ValueError(f"Source directory does not exist: {source_path}")
+
+        markdown_files = _list_source_markdown_files(source_path)
+        if not markdown_files:
+            raise ValueError(f"No markdown files found in {source_path}")
+
+        storage = ArtifactStorage(artifacts_path)
+        batch_date_to_use = _resolve_batch_date(storage, batch_date)
+        pipeline = IngestionPipeline(storage)
+
+        prepared_count = await pipeline.prepare_source_artifacts(source_path, batch_date_to_use)
+        result: Dict[str, Any] = {
+            "operation": operation,
+            "batch_date": batch_date_to_use,
+            "prepared_count": prepared_count,
+            "prepare_only": prepare_only,
+            "source_documents": [str(path.relative_to(source_path)) for path in markdown_files],
+        }
+
+        if prepare_only:
+            result["ingestion"] = {"performed": False}
+            await _emit_progress(
+                progress_emitter,
+                f"Completed pipeline {operation}",
+                "pipeline_complete",
+                {"operation": operation},
+            )
+            return result
+
+        ingestion_results = await pipeline.ingest_prepared_batch(batch_date_to_use)
+        successful = [item for item in ingestion_results if item.get("status") == "success"]
+        failed = [item for item in ingestion_results if item.get("status") == "error"]
+        result["ingestion"] = {
+            "performed": True,
+            "successful_documents": len(successful),
+            "failed_documents": len(failed),
+            "total_chunks_indexed": sum(item.get("chunks_indexed", 0) for item in successful),
+            "results": ingestion_results,
+        }
+        await _emit_progress(
+            progress_emitter,
+            f"Completed pipeline {operation}",
+            "pipeline_complete",
+            {"operation": operation},
+        )
+        return result
+
+    raise ValueError(f"Unknown pipeline operation: {operation}")
+
+
+async def queue_pipeline_operation_task(
+    operation: str,
+    *,
+    user_id: Optional[str] = None,
+    **kwargs: Any,
+) -> Dict[str, Any]:
+    """Create and queue a task-backed pipeline operation."""
+    redis_client = get_redis_client()
+    context: Dict[str, Any] = {
+        "task_type": "pipeline",
+        "pipeline_operation": operation,
+    }
+    if user_id:
+        context["user_id"] = user_id
+
+    result = await create_task(
+        message=_build_pipeline_task_message(operation, kwargs),
+        context=context,
+        redis_client=redis_client,
+    )
+
+    task_kwargs = {key: value for key, value in kwargs.items() if value is not None}
+    async with Docket(url=await get_redis_url(), name="sre_docket") as docket:
+        task_func = docket.add(_get_pipeline_task_callable(), key=result["task_id"])
+        if inspect.isawaitable(task_func):
+            task_func = await task_func
+        await task_func(
+            operation=operation,
+            task_id=result["task_id"],
+            thread_id=result["thread_id"],
+            **task_kwargs,
+        )
+
+    return {
+        "thread_id": result["thread_id"],
+        "task_id": result["task_id"],
+        "status": result["status"].value
+        if hasattr(result["status"], "value")
+        else str(result["status"]),
+        "message": f"Pipeline {operation} task queued for processing",
+        "operation": operation,
+    }

--- a/redis_sre_agent/core/pipeline_helpers.py
+++ b/redis_sre_agent/core/pipeline_helpers.py
@@ -1,0 +1,60 @@
+"""Shared helpers for pipeline inspection workflows."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+from redis_sre_agent.pipelines.orchestrator import PipelineOrchestrator
+from redis_sre_agent.pipelines.scraper.base import ArtifactStorage
+
+
+async def get_pipeline_status_helper(artifacts_path: str = "./artifacts") -> Dict[str, Any]:
+    """Return pipeline status in a machine-friendly shape."""
+    orchestrator = PipelineOrchestrator(artifacts_path)
+    return await orchestrator.get_pipeline_status()
+
+
+async def get_pipeline_batch_helper(
+    batch_date: str, artifacts_path: str = "./artifacts"
+) -> Dict[str, Any]:
+    """Return detailed information for a specific batch."""
+    storage = ArtifactStorage(artifacts_path)
+    manifest = storage.get_batch_manifest(batch_date)
+    if not manifest:
+        return {
+            "batch_date": batch_date,
+            "artifacts_path": str(storage.base_path),
+            "error": f"No manifest found for batch {batch_date}",
+        }
+
+    batch_path = Path(artifacts_path) / batch_date
+    ingestion_manifest = batch_path / "ingestion_manifest.json"
+
+    ingestion: Dict[str, Any] = {
+        "available": False,
+        "status": "not_ingested",
+    }
+    if ingestion_manifest.exists():
+        with ingestion_manifest.open(encoding="utf-8") as f:
+            ingestion_data = json.load(f)
+        ingestion = {
+            "available": True,
+            "status": "success" if ingestion_data.get("success") else "failed",
+            "documents_processed": ingestion_data.get("documents_processed", 0),
+            "chunks_created": ingestion_data.get("chunks_created", 0),
+            "chunks_indexed": ingestion_data.get("chunks_indexed", 0),
+            "categories_processed": ingestion_data.get("categories_processed", {}),
+        }
+
+    return {
+        "batch_date": batch_date,
+        "artifacts_path": str(storage.base_path),
+        "created_at": manifest.get("created_at"),
+        "total_documents": manifest.get("total_documents", 0),
+        "categories": manifest.get("categories", {}),
+        "document_types": manifest.get("document_types", {}),
+        "sources": manifest.get("sources", []),
+        "ingestion": ingestion,
+    }

--- a/redis_sre_agent/core/query_helpers.py
+++ b/redis_sre_agent/core/query_helpers.py
@@ -1,0 +1,132 @@
+"""Shared helpers for the unified query MCP tool."""
+
+from __future__ import annotations
+
+import inspect
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from docket import Docket
+
+from redis_sre_agent.core.clusters import get_cluster_by_id
+from redis_sre_agent.core.instances import get_instance_by_id
+from redis_sre_agent.core.redis import get_redis_client
+from redis_sre_agent.core.support_package_helpers import get_support_package_manager
+from redis_sre_agent.core.tasks import create_task
+from redis_sre_agent.core.threads import ThreadManager
+
+VALID_QUERY_AGENTS = {"auto", "triage", "chat", "knowledge"}
+
+
+def _normalize_agent_selection(agent: Optional[str]) -> str:
+    normalized = (agent or "auto").strip().lower()
+    if normalized not in VALID_QUERY_AGENTS:
+        valid = ", ".join(sorted(VALID_QUERY_AGENTS))
+        raise ValueError(f"Invalid agent '{agent}'. Valid values: {valid}")
+    return normalized
+
+
+async def get_redis_url() -> str:
+    """Resolve the Redis URL for Docket without a module import cycle."""
+    from redis_sre_agent.core.docket_tasks import get_redis_url as resolve_redis_url
+
+    return await resolve_redis_url()
+
+
+def _get_query_task_callable() -> Any:
+    """Resolve the unified query task callable without a module import cycle."""
+    from redis_sre_agent.core.docket_tasks import process_agent_turn
+
+    return process_agent_turn
+
+
+async def _validate_thread(thread_id: str, *, redis_client: Any) -> None:
+    thread_manager = ThreadManager(redis_client=redis_client)
+    thread = await thread_manager.get_thread(thread_id)
+    if not thread:
+        raise ValueError(f"Thread {thread_id} not found")
+
+
+async def _resolve_support_package_context(support_package_id: str) -> Dict[str, str]:
+    manager = get_support_package_manager()
+    metadata = await manager.get_metadata(support_package_id)
+    if not metadata:
+        raise ValueError(f"Support package not found: {support_package_id}")
+
+    support_package_path = await manager.extract(support_package_id)
+    return {
+        "support_package_id": support_package_id,
+        "support_package_path": str(Path(support_package_path)),
+    }
+
+
+async def queue_query_task_helper(
+    *,
+    query: str,
+    instance_id: Optional[str] = None,
+    cluster_id: Optional[str] = None,
+    support_package_id: Optional[str] = None,
+    thread_id: Optional[str] = None,
+    agent: Optional[str] = None,
+    user_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Create and queue a unified query task with routing/thread semantics."""
+    agent_selection = _normalize_agent_selection(agent)
+    if instance_id and cluster_id:
+        raise ValueError("Please provide only one of instance_id or cluster_id")
+
+    redis_client = get_redis_client()
+    if thread_id:
+        await _validate_thread(thread_id, redis_client=redis_client)
+
+    if instance_id:
+        instance = await get_instance_by_id(instance_id)
+        if not instance:
+            raise ValueError(f"Instance not found: {instance_id}")
+
+    if cluster_id:
+        cluster = await get_cluster_by_id(cluster_id)
+        if not cluster:
+            raise ValueError(f"Cluster not found: {cluster_id}")
+
+    thread_context: Dict[str, Any] = {}
+    if instance_id:
+        thread_context["instance_id"] = instance_id
+    if cluster_id:
+        thread_context["cluster_id"] = cluster_id
+    if user_id:
+        thread_context["user_id"] = user_id
+    if support_package_id:
+        thread_context.update(await _resolve_support_package_context(support_package_id))
+
+    turn_context = dict(thread_context)
+    if agent_selection != "auto":
+        turn_context["requested_agent_type"] = agent_selection
+
+    result = await create_task(
+        message=query,
+        thread_id=thread_id,
+        context=thread_context or None,
+        redis_client=redis_client,
+    )
+
+    async with Docket(url=await get_redis_url(), name="sre_docket") as docket:
+        task_func = docket.add(_get_query_task_callable(), key=result["task_id"])
+        if inspect.isawaitable(task_func):
+            task_func = await task_func
+        await task_func(
+            thread_id=result["thread_id"],
+            message=query,
+            context=turn_context or None,
+            task_id=result["task_id"],
+        )
+
+    return {
+        "thread_id": result["thread_id"],
+        "task_id": result["task_id"],
+        "status": result["status"].value
+        if hasattr(result["status"], "value")
+        else str(result["status"]),
+        "message": "Query task queued for processing",
+        "agent": agent_selection,
+    }

--- a/redis_sre_agent/core/runbook_execution_helpers.py
+++ b/redis_sre_agent/core/runbook_execution_helpers.py
@@ -1,0 +1,297 @@
+"""Shared helpers for task-backed runbook workflows."""
+
+from __future__ import annotations
+
+import inspect
+import json
+import re
+from dataclasses import asdict, is_dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from docket import Docket
+
+from redis_sre_agent.agent.runbook_generator import GeneratedRunbook, RunbookGenerator
+from redis_sre_agent.core.knowledge_helpers import ingest_sre_document_helper
+from redis_sre_agent.core.redis import get_redis_client
+from redis_sre_agent.core.tasks import create_task
+
+
+async def _emit_progress(
+    progress_emitter: Any,
+    message: str,
+    update_type: str,
+    metadata: Optional[Dict[str, Any]] = None,
+) -> None:
+    """Emit a task update when a progress emitter is available."""
+    if progress_emitter is not None:
+        await progress_emitter.emit(message, update_type, metadata or {})
+
+
+def _slugify_topic(topic: str) -> str:
+    """Create a filesystem-safe stem for generated runbooks."""
+    normalized = re.sub(r"[^a-z0-9]+", "-", topic.lower()).strip("-")
+    return normalized or "generated-runbook"
+
+
+def _resolve_runbook_output_path(
+    topic: str, output_file: Optional[str], auto_save: bool
+) -> Optional[Path]:
+    """Determine where a generated runbook should be written, if anywhere."""
+    if output_file:
+        return Path(output_file)
+    if auto_save:
+        return Path("source_documents/runbooks") / f"{_slugify_topic(topic)}.md"
+    return None
+
+
+def _serialize_value(value: Any) -> Any:
+    """Serialize dataclass values into plain dictionaries."""
+    if value is None:
+        return None
+    if is_dataclass(value):
+        return asdict(value)
+    return value
+
+
+def _extract_runbook_title(content: str, fallback_title: str) -> str:
+    """Use the first Markdown heading as the title when available."""
+    title_line = next((line for line in content.splitlines() if line.startswith("# ")), None)
+    if title_line:
+        return title_line[2:].strip()
+    return fallback_title
+
+
+def _build_runbook_task_message(operation: str, kwargs: Dict[str, Any]) -> str:
+    """Generate a concise subject line for a runbook task."""
+    if operation == "generate":
+        topic = kwargs.get("topic")
+        return f"Generate runbook for {topic}" if topic else "Generate runbook"
+    if operation == "evaluate":
+        return f"Evaluate runbooks in {kwargs.get('input_dir', 'source_documents/runbooks')}"
+    return f"Runbook operation {operation}"
+
+
+async def get_redis_url() -> str:
+    """Resolve the Redis URL for Docket without a module import cycle."""
+    from redis_sre_agent.core.docket_tasks import get_redis_url as resolve_redis_url
+
+    return await resolve_redis_url()
+
+
+def _get_runbook_task_callable() -> Any:
+    """Resolve the Docket task callable without a module import cycle."""
+    from redis_sre_agent.core.docket_tasks import process_runbook_operation
+
+    return process_runbook_operation
+
+
+async def _generate_runbook(
+    *,
+    topic: str,
+    scenario_description: str,
+    severity: str,
+    category: str,
+    output_file: Optional[str],
+    requirements: Optional[List[str]],
+    max_iterations: int,
+    auto_save: bool,
+    ingest: bool,
+) -> Dict[str, Any]:
+    """Generate, optionally save, and optionally ingest a runbook."""
+    generator = RunbookGenerator()
+    result = await generator.generate_runbook(
+        topic=topic,
+        scenario_description=scenario_description,
+        severity=severity,
+        category=category,
+        specific_requirements=requirements or None,
+        max_iterations=max_iterations,
+    )
+
+    if not result.get("success"):
+        return {"operation": "generate", **result}
+
+    runbook = result["runbook"]
+    saved_path = _resolve_runbook_output_path(topic, output_file, auto_save)
+    if saved_path is not None:
+        saved_path.parent.mkdir(parents=True, exist_ok=True)
+        saved_path.write_text(runbook.content, encoding="utf-8")
+
+    if ingest:
+        await ingest_sre_document_helper(
+            title=runbook.title,
+            content=runbook.content,
+            source=str(saved_path) if saved_path is not None else "generated_runbook",
+            category=runbook.category,
+            severity=runbook.severity,
+            doc_type="runbook",
+        )
+
+    return {
+        "operation": "generate",
+        "success": True,
+        "iterations": result.get("iterations", 0),
+        "saved_path": str(saved_path) if saved_path is not None else None,
+        "runbook": _serialize_value(runbook),
+        "evaluation": _serialize_value(result.get("evaluation")),
+        "research": _serialize_value(result.get("research")),
+    }
+
+
+async def _evaluate_runbooks(*, input_dir: str, output_file: Optional[str]) -> Dict[str, Any]:
+    """Evaluate runbook markdown files in a directory."""
+    input_path = Path(input_dir)
+    markdown_files = sorted(input_path.glob("*.md"))
+    if not markdown_files:
+        raise ValueError(f"No markdown files found in {input_path}")
+
+    generator = RunbookGenerator()
+    results: List[Dict[str, Any]] = []
+    errors: List[Dict[str, str]] = []
+
+    for markdown_file in markdown_files:
+        content = markdown_file.read_text(encoding="utf-8")
+        title = _extract_runbook_title(content, markdown_file.stem)
+        runbook = GeneratedRunbook(
+            title=title,
+            content=content,
+            category="existing_runbook",
+            severity="unknown",
+            sources=["existing_file"],
+            generation_timestamp="",
+        )
+
+        try:
+            evaluation = await generator._evaluate_runbook(runbook)
+            results.append(
+                {
+                    "filename": markdown_file.name,
+                    "title": title,
+                    **asdict(evaluation),
+                }
+            )
+        except Exception as exc:
+            errors.append({"filename": markdown_file.name, "error": str(exc)})
+
+    total_runbooks = len(results)
+    average_score = (
+        sum(item["overall_score"] for item in results) / total_runbooks if total_runbooks else 0.0
+    )
+    payload: Dict[str, Any] = {
+        "operation": "evaluate",
+        "input_dir": str(input_path),
+        "total_files": len(markdown_files),
+        "total_runbooks": total_runbooks,
+        "average_score": average_score,
+        "excellent": sum(1 for item in results if item["overall_score"] >= 4.0),
+        "good": sum(1 for item in results if 3.0 <= item["overall_score"] < 4.0),
+        "needs_improvement": sum(1 for item in results if item["overall_score"] < 3.0),
+        "results": results,
+        "errors": errors,
+        "output_file": output_file,
+        "evaluation_timestamp": datetime.now(timezone.utc).isoformat(),
+    }
+
+    if output_file:
+        output_path = Path(output_file)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+    return payload
+
+
+async def run_runbook_operation_helper(
+    operation: str,
+    *,
+    topic: Optional[str] = None,
+    scenario_description: Optional[str] = None,
+    severity: str = "warning",
+    category: str = "operational_runbook",
+    output_file: Optional[str] = None,
+    requirements: Optional[List[str]] = None,
+    max_iterations: int = 2,
+    auto_save: bool = True,
+    ingest: bool = False,
+    input_dir: str = "source_documents/runbooks",
+    progress_emitter: Any = None,
+) -> Dict[str, Any]:
+    """Execute a runbook operation and return a structured result."""
+    await _emit_progress(
+        progress_emitter,
+        f"Starting runbook {operation}",
+        "runbook_start",
+        {"operation": operation},
+    )
+
+    if operation == "generate":
+        if topic is None or scenario_description is None:
+            raise ValueError("topic and scenario_description are required for generate")
+        result = await _generate_runbook(
+            topic=topic,
+            scenario_description=scenario_description,
+            severity=severity,
+            category=category,
+            output_file=output_file,
+            requirements=requirements,
+            max_iterations=max_iterations,
+            auto_save=auto_save,
+            ingest=ingest,
+        )
+    elif operation == "evaluate":
+        result = await _evaluate_runbooks(input_dir=input_dir, output_file=output_file)
+    else:
+        raise ValueError(f"Unknown runbook operation: {operation}")
+
+    await _emit_progress(
+        progress_emitter,
+        f"Completed runbook {operation}",
+        "runbook_complete",
+        {"operation": operation},
+    )
+    return result
+
+
+async def queue_runbook_operation_task(
+    operation: str,
+    *,
+    user_id: Optional[str] = None,
+    **kwargs: Any,
+) -> Dict[str, Any]:
+    """Create and queue a task-backed runbook operation."""
+    redis_client = get_redis_client()
+    context: Dict[str, Any] = {
+        "task_type": "runbook",
+        "runbook_operation": operation,
+    }
+    if user_id:
+        context["user_id"] = user_id
+
+    result = await create_task(
+        message=_build_runbook_task_message(operation, kwargs),
+        context=context,
+        redis_client=redis_client,
+    )
+
+    task_kwargs = {key: value for key, value in kwargs.items() if value is not None}
+    async with Docket(url=await get_redis_url(), name="sre_docket") as docket:
+        task_func = docket.add(_get_runbook_task_callable(), key=result["task_id"])
+        if inspect.isawaitable(task_func):
+            task_func = await task_func
+        await task_func(
+            operation=operation,
+            task_id=result["task_id"],
+            thread_id=result["thread_id"],
+            **task_kwargs,
+        )
+
+    return {
+        "thread_id": result["thread_id"],
+        "task_id": result["task_id"],
+        "status": result["status"].value
+        if hasattr(result["status"], "value")
+        else str(result["status"]),
+        "message": f"Runbook {operation} task queued for processing",
+        "operation": operation,
+    }

--- a/redis_sre_agent/core/schedule_helpers.py
+++ b/redis_sre_agent/core/schedule_helpers.py
@@ -1,0 +1,296 @@
+"""Helpers for exposing schedule workflows over MCP."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional
+
+from docket import Docket
+
+from redis_sre_agent.core import schedules as core_schedules
+from redis_sre_agent.core.docket_tasks import get_redis_url, process_agent_turn
+from redis_sre_agent.core.keys import RedisKeys
+from redis_sre_agent.core.redis import get_redis_client
+from redis_sre_agent.core.tasks import TaskManager, TaskStatus
+from redis_sre_agent.core.threads import ThreadManager
+
+
+def _normalize_task_status(status: Any) -> str:
+    if isinstance(status, TaskStatus):
+        return status.value
+    if status:
+        return str(status)
+    return TaskStatus.QUEUED.value
+
+
+def _build_schedule_subject(schedule: Dict[str, Any]) -> str:
+    subject = (schedule.get("name") or "").strip()
+    if subject:
+        return subject
+
+    instructions = (schedule.get("instructions") or "").strip()
+    if instructions:
+        return instructions.splitlines()[0][:80]
+
+    return "Scheduled Run"
+
+
+def _build_manual_run_context(
+    schedule_id: str, schedule: Dict[str, Any], current_time: datetime
+) -> Dict[str, Any]:
+    context = {
+        "schedule_id": schedule_id,
+        "schedule_name": schedule.get("name"),
+        "automated": True,
+        "manual_trigger": True,
+        "original_query": schedule.get("instructions"),
+        "scheduled_at": current_time.isoformat(),
+    }
+    if schedule.get("redis_instance_id"):
+        context["instance_id"] = schedule["redis_instance_id"]
+    return context
+
+
+async def list_schedules_helper(limit: int = 50) -> Dict[str, Any]:
+    schedules = await core_schedules.list_schedules()
+    return {"schedules": schedules[:limit], "total": len(schedules), "limit": limit}
+
+
+async def get_schedule_helper(schedule_id: str) -> Dict[str, Any]:
+    schedule = await core_schedules.get_schedule(schedule_id)
+    if not schedule:
+        return {"error": "Schedule not found", "id": schedule_id}
+    return schedule
+
+
+async def create_schedule_helper(
+    *,
+    name: str,
+    interval_type: str,
+    interval_value: int,
+    instructions: str,
+    redis_instance_id: Optional[str] = None,
+    description: Optional[str] = None,
+    enabled: bool = True,
+) -> Dict[str, Any]:
+    schedule = core_schedules.Schedule(
+        name=name,
+        description=description,
+        interval_type=interval_type.lower(),
+        interval_value=interval_value,
+        redis_instance_id=redis_instance_id,
+        instructions=instructions,
+        enabled=enabled,
+    )
+    schedule.next_run_at = schedule.calculate_next_run().isoformat()
+    schedule.updated_at = datetime.now(timezone.utc).isoformat()
+
+    if not await core_schedules.store_schedule(schedule.model_dump()):
+        raise RuntimeError("Failed to store schedule")
+
+    return {"id": schedule.id, "status": "created"}
+
+
+async def update_schedule_helper(
+    schedule_id: str,
+    *,
+    name: Optional[str] = None,
+    description: Optional[str] = None,
+    instructions: Optional[str] = None,
+    redis_instance_id: Optional[str] = None,
+    interval_type: Optional[str] = None,
+    interval_value: Optional[int] = None,
+    enabled: Optional[bool] = None,
+    recalc_next_run: bool = True,
+) -> Dict[str, Any]:
+    current = await core_schedules.get_schedule(schedule_id)
+    if not current:
+        raise RuntimeError("Schedule not found")
+
+    data = dict(current)
+    if name is not None:
+        data["name"] = name
+    if description is not None:
+        data["description"] = description
+    if instructions is not None:
+        data["instructions"] = instructions
+    if redis_instance_id is not None:
+        data["redis_instance_id"] = redis_instance_id
+    if interval_type is not None:
+        data["interval_type"] = interval_type.lower()
+    if interval_value is not None:
+        data["interval_value"] = interval_value
+    if enabled is not None:
+        data["enabled"] = bool(enabled)
+
+    data["id"] = current.get("id")
+    data["created_at"] = current.get("created_at")
+    schedule = core_schedules.Schedule(**data)
+
+    changed_interval = interval_type is not None or interval_value is not None
+    was_disabled = not current.get("enabled", True)
+    if recalc_next_run and (changed_interval or (enabled is True and was_disabled)):
+        schedule.next_run_at = schedule.calculate_next_run().isoformat()
+
+    schedule.updated_at = datetime.now(timezone.utc).isoformat()
+
+    if not await core_schedules.store_schedule(schedule.model_dump()):
+        raise RuntimeError("Failed to store updated schedule")
+
+    return {"id": schedule.id, "status": "updated"}
+
+
+async def enable_schedule_helper(schedule_id: str) -> Dict[str, Any]:
+    current = await core_schedules.get_schedule(schedule_id)
+    if not current:
+        raise RuntimeError("Schedule not found")
+
+    current["enabled"] = True
+    schedule = core_schedules.Schedule(**current)
+    if not schedule.next_run_at:
+        schedule.next_run_at = schedule.calculate_next_run().isoformat()
+    schedule.updated_at = datetime.now(timezone.utc).isoformat()
+
+    if not await core_schedules.store_schedule(schedule.model_dump()):
+        raise RuntimeError("Failed to store enabled schedule")
+
+    return {"id": schedule.id, "status": "enabled"}
+
+
+async def disable_schedule_helper(schedule_id: str) -> Dict[str, Any]:
+    current = await core_schedules.get_schedule(schedule_id)
+    if not current:
+        raise RuntimeError("Schedule not found")
+
+    current["enabled"] = False
+    schedule = core_schedules.Schedule(**current)
+    schedule.updated_at = datetime.now(timezone.utc).isoformat()
+
+    if not await core_schedules.store_schedule(schedule.model_dump()):
+        raise RuntimeError("Failed to store disabled schedule")
+
+    return {"id": schedule.id, "status": "disabled"}
+
+
+async def delete_schedule_helper(schedule_id: str, *, confirm: bool = False) -> Dict[str, Any]:
+    if not confirm:
+        return {"error": "Confirmation required", "id": schedule_id, "status": "cancelled"}
+
+    schedule = await core_schedules.get_schedule(schedule_id)
+    if not schedule:
+        raise RuntimeError("Schedule not found")
+
+    if not await core_schedules.delete_schedule(schedule_id):
+        raise RuntimeError("Delete failed or schedule not found")
+
+    return {"id": schedule_id, "status": "deleted"}
+
+
+async def run_schedule_now_helper(schedule_id: str) -> Dict[str, Any]:
+    schedule = await core_schedules.get_schedule(schedule_id)
+    if not schedule:
+        return {"error": "Schedule not found", "id": schedule_id}
+
+    current_time = datetime.now(timezone.utc)
+    run_context = _build_manual_run_context(schedule_id, schedule, current_time)
+
+    redis_client = get_redis_client()
+    thread_manager = ThreadManager(redis_client=redis_client)
+    thread_id = await thread_manager.create_thread(
+        user_id="scheduler",
+        session_id=f"manual_schedule_{schedule_id}_{current_time.strftime('%Y%m%d_%H%M%S')}",
+        initial_context=run_context,
+        tags=["automated", "scheduled", "manual_trigger"],
+    )
+    try:
+        await thread_manager.set_thread_subject(thread_id, _build_schedule_subject(schedule))
+    except Exception:
+        pass
+
+    docket_task_id = None
+    async with Docket(url=await get_redis_url(), name="sre_docket") as docket:
+        task_key = f"manual_schedule_{schedule_id}_{current_time.strftime('%Y%m%d_%H%M%S')}"
+        try:
+            task_func = docket.add(process_agent_turn, key=task_key)
+            docket_task_id = await task_func(
+                thread_id=thread_id,
+                message=schedule.get("instructions") or "",
+                context=run_context,
+            )
+        except Exception as e:
+            if "already exists" in str(e).lower() or "duplicate" in str(e).lower():
+                docket_task_id = "already_running"
+            else:
+                raise
+
+    return {
+        "schedule_id": schedule_id,
+        "status": "pending",
+        "scheduled_at": current_time.isoformat(),
+        "thread_id": thread_id,
+        "docket_task_id": str(docket_task_id) if docket_task_id is not None else None,
+    }
+
+
+async def list_schedule_runs_helper(schedule_id: str, limit: int = 50) -> Dict[str, Any]:
+    schedule = await core_schedules.get_schedule(schedule_id)
+    if not schedule:
+        return {"error": "Schedule not found", "id": schedule_id}
+
+    redis_client = get_redis_client()
+    thread_manager = ThreadManager(redis_client=redis_client)
+    task_manager = TaskManager(redis_client=redis_client)
+
+    summaries = await thread_manager.list_threads(user_id="scheduler", limit=200)
+    runs = []
+
+    for summary in summaries:
+        thread_id = summary["thread_id"]
+        state = await thread_manager.get_thread(thread_id)
+        if not state or state.context.get("schedule_id") != schedule_id:
+            continue
+
+        task_id = None
+        task_status = TaskStatus.QUEUED.value
+        started_at = summary.get("created_at")
+        completed_at = None
+        error = None
+
+        try:
+            task_ids = await redis_client.zrevrange(RedisKeys.thread_tasks_index(thread_id), 0, 0)
+            if task_ids:
+                task_id = task_ids[0]
+                if isinstance(task_id, bytes):
+                    task_id = task_id.decode()
+        except Exception:
+            task_id = None
+
+        if task_id:
+            try:
+                task = await task_manager.get_task_state(task_id)
+            except Exception:
+                task = None
+            if task:
+                task_status = _normalize_task_status(task.status)
+                started_at = task.metadata.created_at or started_at
+                if task_status == TaskStatus.DONE.value:
+                    completed_at = task.metadata.updated_at
+                error = task.error_message
+
+        runs.append(
+            {
+                "thread_id": thread_id,
+                "task_id": task_id,
+                "schedule_id": schedule_id,
+                "status": task_status,
+                "scheduled_at": state.context.get("scheduled_at") or summary.get("created_at"),
+                "started_at": started_at,
+                "completed_at": completed_at,
+                "created_at": summary.get("created_at"),
+                "subject": summary.get("subject") or "Scheduled Run",
+                "error": error,
+            }
+        )
+
+    runs.sort(key=lambda run: run.get("scheduled_at") or "", reverse=True)
+    return {"schedule_id": schedule_id, "runs": runs[:limit], "total": len(runs), "limit": limit}

--- a/redis_sre_agent/core/support_package_helpers.py
+++ b/redis_sre_agent/core/support_package_helpers.py
@@ -1,0 +1,27 @@
+"""Shared helpers for support-package management."""
+
+from __future__ import annotations
+
+from redis_sre_agent.core.config import settings
+from redis_sre_agent.tools.support_package.manager import SupportPackageManager
+from redis_sre_agent.tools.support_package.storage import LocalStorage, S3Storage
+
+
+def get_support_package_manager() -> SupportPackageManager:
+    """Return a configured support-package manager."""
+    storage_type = getattr(settings, "support_package_storage_type", "local")
+
+    if storage_type == "s3":
+        storage = S3Storage(
+            bucket=getattr(settings, "support_package_s3_bucket", ""),
+            prefix=getattr(settings, "support_package_s3_prefix", "support-packages/"),
+            region=getattr(settings, "support_package_s3_region", None),
+            endpoint_url=getattr(settings, "support_package_s3_endpoint", None),
+        )
+    else:
+        storage = LocalStorage(base_path=settings.support_package_artifacts_dir / "storage")
+
+    return SupportPackageManager(
+        storage=storage,
+        extract_dir=settings.support_package_artifacts_dir / "extracted",
+    )

--- a/redis_sre_agent/core/task_inspection_helpers.py
+++ b/redis_sre_agent/core/task_inspection_helpers.py
@@ -1,0 +1,72 @@
+"""Shared helpers for direct task inspection MCP tools."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from redis_sre_agent.core.tasks import TaskStatus, get_task_by_id, list_tasks
+
+
+def _normalize_status(status: Any) -> Optional[str]:
+    """Convert task statuses into MCP-friendly strings."""
+    if status is None:
+        return None
+    if isinstance(status, TaskStatus):
+        return status.value
+    return str(status)
+
+
+def _normalize_task(task: Dict[str, Any]) -> Dict[str, Any]:
+    """Normalize task payloads returned by core task APIs."""
+    normalized = dict(task)
+    normalized["status"] = _normalize_status(task.get("status"))
+    normalized["tool_calls"] = task.get("tool_calls") or []
+    return normalized
+
+
+def _coerce_status_filter(status: Optional[str]) -> Optional[TaskStatus]:
+    """Parse an optional task status filter."""
+    if status is None:
+        return None
+    try:
+        return TaskStatus(status)
+    except ValueError as exc:
+        raise ValueError(f"Invalid task status filter: {status}") from exc
+
+
+def _clamp_limit(limit: int) -> int:
+    """Clamp list limits to a small, predictable range."""
+    return max(1, min(limit, 100))
+
+
+async def get_task_helper(task_id: str) -> Dict[str, Any]:
+    """Return a normalized task payload."""
+    task = await get_task_by_id(task_id=task_id)
+    return _normalize_task(task)
+
+
+async def list_tasks_helper(
+    *,
+    user_id: Optional[str] = None,
+    status: Optional[str] = None,
+    show_all: bool = False,
+    limit: int = 50,
+) -> Dict[str, Any]:
+    """List tasks using the shared core task API."""
+    normalized_limit = _clamp_limit(limit)
+    status_filter = _coerce_status_filter(status)
+    tasks = await list_tasks(
+        user_id=user_id,
+        status_filter=status_filter,
+        show_all=show_all,
+        limit=normalized_limit,
+    )
+    normalized_tasks = [_normalize_task(task) for task in tasks]
+    return {
+        "tasks": normalized_tasks,
+        "count": len(normalized_tasks),
+        "user_id": user_id,
+        "status": status_filter.value if status_filter else None,
+        "show_all": show_all,
+        "limit": normalized_limit,
+    }

--- a/redis_sre_agent/core/task_purge_helpers.py
+++ b/redis_sre_agent/core/task_purge_helpers.py
@@ -1,0 +1,115 @@
+"""Shared helpers for bulk task purge MCP tools."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, Optional
+
+from redis_sre_agent.core.redis import SRE_TASKS_INDEX, get_redis_client
+from redis_sre_agent.core.tasks import delete_task as delete_task_core
+
+
+def _parse_duration(value: str) -> timedelta:
+    """Parse a duration like 7d, 24h, 15m, or 30s."""
+    normalized = (value or "").strip().lower()
+    try:
+        if normalized.endswith("d"):
+            return timedelta(days=float(normalized[:-1]))
+        if normalized.endswith("h"):
+            return timedelta(hours=float(normalized[:-1]))
+        if normalized.endswith("m"):
+            return timedelta(minutes=float(normalized[:-1]))
+        if normalized.endswith("s"):
+            return timedelta(seconds=float(normalized[:-1]))
+        return timedelta(seconds=float(normalized))
+    except Exception as exc:
+        raise ValueError(f"Invalid duration '{value}': {exc}") from exc
+
+
+def _decode(value: Any) -> str:
+    if isinstance(value, bytes):
+        return value.decode()
+    return str(value or "")
+
+
+async def purge_tasks_helper(
+    *,
+    status: Optional[str] = None,
+    older_than: Optional[str] = None,
+    purge_all: bool = False,
+    dry_run: bool = False,
+    confirm: bool = False,
+    redis_client=None,
+) -> Dict[str, Any]:
+    """Delete tasks in bulk with safeguards and optional dry-run mode."""
+    if not purge_all and not older_than and not status:
+        return {
+            "error": "Refusing to purge without a scope. Provide older_than/status or purge_all.",
+            "status": "failed",
+        }
+
+    if not dry_run and not confirm:
+        return {
+            "error": "Confirmation required",
+            "status": "cancelled",
+            "dry_run": False,
+        }
+
+    client = redis_client or get_redis_client()
+    cutoff_ts = None
+    if older_than:
+        cutoff_ts = (datetime.now(timezone.utc) - _parse_duration(older_than)).timestamp()
+
+    cursor = 0
+    scanned = 0
+    deleted = 0
+    matched: list[str] = []
+
+    while True:
+        cursor, keys = await client.scan(cursor=cursor, match=f"{SRE_TASKS_INDEX}:*", count=1000)
+        if not keys and cursor == 0:
+            break
+
+        for key in keys or []:
+            redis_key = _decode(key)
+            task_id = redis_key[len(f"{SRE_TASKS_INDEX}:") :]
+
+            try:
+                st_raw, upd_raw, _ = await client.hmget(
+                    redis_key, "status", "updated_at", "created_at"
+                )
+                task_status = _decode(st_raw).lower()
+                updated_at = float(_decode(upd_raw) or 0)
+            except Exception:
+                task_status = ""
+                updated_at = 0.0
+
+            eligible = True
+            if status:
+                eligible = eligible and (task_status == status.lower())
+            if cutoff_ts is not None:
+                eligible = eligible and (updated_at > 0 and updated_at < cutoff_ts)
+
+            if not purge_all and not eligible:
+                scanned += 1
+                continue
+
+            matched.append(task_id)
+            if not dry_run:
+                try:
+                    await delete_task_core(task_id=task_id, redis_client=client)
+                    deleted += 1
+                except Exception:
+                    pass
+            scanned += 1
+
+        if cursor == 0:
+            break
+
+    return {
+        "status": "dry_run" if dry_run else "purged",
+        "scanned": scanned,
+        "deleted": deleted,
+        "matched": matched,
+        "dry_run": dry_run,
+    }

--- a/redis_sre_agent/core/thread_inspection_helpers.py
+++ b/redis_sre_agent/core/thread_inspection_helpers.py
@@ -1,0 +1,155 @@
+"""Shared helpers for MCP thread inspection tools."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, List, Optional
+
+from redis_sre_agent.core.keys import RedisKeys
+from redis_sre_agent.core.redis import get_redis_client
+from redis_sre_agent.core.tasks import TaskManager
+from redis_sre_agent.core.threads import ThreadManager
+
+
+def _decode_task_id(task_id: Any) -> str:
+    if isinstance(task_id, bytes):
+        return task_id.decode()
+    return str(task_id)
+
+
+def _extract_source_fragments(updates: Any, task_id: str) -> List[Dict[str, Any]]:
+    fragments: List[Dict[str, Any]] = []
+    for update in updates or []:
+        try:
+            if (getattr(update, "update_type", "") or "") != "knowledge_sources":
+                continue
+            metadata = getattr(update, "metadata", None) or {}
+            for fragment in metadata.get("fragments") or []:
+                fragments.append(
+                    {
+                        "timestamp": getattr(update, "timestamp", None),
+                        "task_id": task_id,
+                        "id": fragment.get("id"),
+                        "document_hash": fragment.get("document_hash"),
+                        "chunk_index": fragment.get("chunk_index"),
+                        "title": fragment.get("title"),
+                        "source": fragment.get("source"),
+                    }
+                )
+        except Exception:
+            continue
+    return fragments
+
+
+def _build_tool_call(envelope: Dict[str, Any], include_tool_data: bool) -> Dict[str, Any]:
+    data = envelope.get("data") or {}
+    summary = envelope.get("summary")
+    if summary:
+        result_preview = summary
+    else:
+        result_preview = json.dumps(data, default=str)
+
+    tool_call = {
+        "name": envelope.get("name") or envelope.get("tool_key", "unknown"),
+        "tool_key": envelope.get("tool_key"),
+        "args": envelope.get("args") or {},
+        "status": envelope.get("status", "unknown"),
+        "summary": summary,
+        "result_preview": result_preview,
+    }
+    if include_tool_data:
+        tool_call["data"] = data
+    return tool_call
+
+
+def _derive_citations(tool_envelopes: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    citations: List[Dict[str, Any]] = []
+    for envelope in tool_envelopes:
+        tool_key = str(envelope.get("tool_key", ""))
+        tool_name = str(envelope.get("name", ""))
+        if "knowledge" not in tool_key.lower() or "search" not in tool_name.lower():
+            continue
+
+        data = envelope.get("data") or {}
+        for result in data.get("results") or []:
+            citations.append(
+                {
+                    "title": result.get("title"),
+                    "source": result.get("source"),
+                    "score": result.get("score"),
+                    "document_id": result.get("id"),
+                }
+            )
+    return citations
+
+
+async def get_thread_sources_helper(
+    thread_id: str, task_id: Optional[str] = None
+) -> Dict[str, Any]:
+    """Collect knowledge-source fragments for a thread or a single task turn."""
+    client = get_redis_client()
+    thread_manager = ThreadManager(redis_client=client)
+    task_manager = TaskManager(redis_client=client)
+
+    thread = await thread_manager.get_thread(thread_id)
+    if not thread:
+        return {
+            "error": f"Thread {thread_id} not found",
+            "thread_id": thread_id,
+            "task_id": task_id,
+            "fragments": [],
+            "count": 0,
+        }
+
+    fragments: List[Dict[str, Any]] = []
+    task_ids = await client.zrange(RedisKeys.thread_tasks_index(thread_id), 0, -1)
+    for raw_task_id in task_ids:
+        normalized_task_id = _decode_task_id(raw_task_id)
+        if task_id and normalized_task_id != task_id:
+            continue
+
+        task_state = await task_manager.get_task_state(normalized_task_id)
+        if not task_state:
+            continue
+
+        fragments.extend(_extract_source_fragments(task_state.updates, normalized_task_id))
+
+    return {
+        "thread_id": thread_id,
+        "task_id": task_id,
+        "fragments": fragments,
+        "count": len(fragments),
+    }
+
+
+async def get_thread_trace_helper(
+    message_id: str, include_tool_data: bool = False
+) -> Dict[str, Any]:
+    """Retrieve and summarize a message decision trace."""
+    client = get_redis_client()
+    thread_manager = ThreadManager(redis_client=client)
+    trace = await thread_manager.get_message_trace(message_id)
+
+    if not trace:
+        return {
+            "error": f"No decision trace found for message {message_id}",
+            "message_id": message_id,
+            "tool_calls": [],
+            "tool_call_count": 0,
+            "citations": [],
+            "citation_count": 0,
+        }
+
+    tool_envelopes = trace.get("tool_envelopes") or []
+    tool_calls = [_build_tool_call(envelope, include_tool_data) for envelope in tool_envelopes]
+    citations = _derive_citations(tool_envelopes)
+
+    return {
+        "message_id": trace.get("message_id", message_id),
+        "otel_trace_id": trace.get("otel_trace_id"),
+        "created_at": trace.get("created_at"),
+        "tool_calls": tool_calls,
+        "tool_call_count": len(tool_calls),
+        "citations": citations,
+        "citation_count": len(citations),
+    }

--- a/redis_sre_agent/core/thread_maintenance_helpers.py
+++ b/redis_sre_agent/core/thread_maintenance_helpers.py
@@ -1,0 +1,379 @@
+"""Helpers for thread maintenance MCP tools."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Any, Optional
+
+from redis_sre_agent.core.keys import RedisKeys
+from redis_sre_agent.core.redis import (
+    SRE_TASKS_INDEX,
+    SRE_THREADS_INDEX,
+    get_redis_client,
+    get_threads_index,
+)
+from redis_sre_agent.core.tasks import delete_task as delete_task_core
+from redis_sre_agent.core.threads import ThreadManager
+
+
+def _decode(value: Any) -> str:
+    if isinstance(value, bytes):
+        return value.decode()
+    return str(value or "")
+
+
+def _parse_duration(value: str) -> timedelta:
+    normalized = (value or "").strip().lower()
+    try:
+        if normalized.endswith("d"):
+            return timedelta(days=float(normalized[:-1]))
+        if normalized.endswith("h"):
+            return timedelta(hours=float(normalized[:-1]))
+        if normalized.endswith("m"):
+            return timedelta(minutes=float(normalized[:-1]))
+        if normalized.endswith("s"):
+            return timedelta(seconds=float(normalized[:-1]))
+        return timedelta(seconds=float(normalized))
+    except Exception as exc:
+        raise ValueError(f"Invalid duration '{value}': {exc}") from exc
+
+
+def _derive_subject(state: Any) -> Optional[str]:
+    context = getattr(state, "context", {}) or {}
+    original_query = context.get("original_query")
+    if isinstance(original_query, str) and original_query.strip():
+        return original_query.strip()
+
+    for message in getattr(state, "messages", []) or []:
+        if getattr(message, "role", None) == "user":
+            content = getattr(message, "content", "")
+            if isinstance(content, str) and content.strip():
+                return content.strip()
+
+    legacy_messages = context.get("messages") if isinstance(context, dict) else None
+    if isinstance(legacy_messages, list):
+        for message in legacy_messages:
+            if isinstance(message, dict) and message.get("role") == "user":
+                content = message.get("content")
+                if isinstance(content, str) and content.strip():
+                    return content.strip()
+
+    return None
+
+
+async def _backfill_threads_from_zset(
+    thread_manager: ThreadManager, client, limit: int, start: int
+) -> int:
+    processed = 0
+    offset = start
+    page = 500
+
+    while True:
+        ids = await client.zrevrange(RedisKeys.threads_index(), offset, offset + page - 1)
+        if not ids:
+            break
+
+        for raw in ids:
+            if limit and processed >= limit:
+                return processed
+            thread_id = _decode(raw)
+            await thread_manager._upsert_thread_search_doc(thread_id)
+            processed += 1
+
+        offset += page
+
+    return processed
+
+
+async def reindex_threads_helper(
+    *,
+    drop: bool = False,
+    limit: int = 0,
+    start: int = 0,
+    redis_client=None,
+) -> dict[str, Any]:
+    client = redis_client or get_redis_client()
+    thread_manager = ThreadManager(redis_client=client)
+    index = await get_threads_index()
+
+    try:
+        exists = await index.exists()
+    except Exception:
+        exists = False
+
+    dropped = False
+    if exists and drop:
+        try:
+            await index.drop()  # type: ignore[attr-defined]
+            dropped = True
+        except Exception:
+            try:
+                await client.execute_command("FT.DROPINDEX", SRE_THREADS_INDEX)
+                dropped = True
+            except Exception:
+                pass
+
+    if not await index.exists():
+        await index.create()
+
+    processed = await _backfill_threads_from_zset(thread_manager, client, limit=limit, start=start)
+    return {
+        "status": "completed",
+        "processed": processed,
+        "dropped": dropped,
+        "index": SRE_THREADS_INDEX,
+    }
+
+
+async def backfill_threads_helper(
+    *,
+    limit: int = 0,
+    start: int = 0,
+    redis_client=None,
+) -> dict[str, Any]:
+    client = redis_client or get_redis_client()
+    thread_manager = ThreadManager(redis_client=client)
+    processed = await _backfill_threads_from_zset(thread_manager, client, limit=limit, start=start)
+    return {"status": "completed", "processed": processed, "index": SRE_THREADS_INDEX}
+
+
+async def backfill_scheduled_thread_subjects_helper(
+    *,
+    limit: int = 0,
+    start: int = 0,
+    dry_run: bool = False,
+    redis_client=None,
+) -> dict[str, Any]:
+    client = redis_client or get_redis_client()
+    thread_manager = ThreadManager(redis_client=client)
+    scanned = 0
+    subject_updates = 0
+    tag_updates = 0
+    offset = start
+    page = 500
+
+    while True:
+        ids = await client.zrevrange(RedisKeys.threads_index(), offset, offset + page - 1)
+        if not ids:
+            break
+
+        for raw in ids:
+            if limit and scanned >= limit:
+                return {
+                    "status": "dry_run" if dry_run else "completed",
+                    "scanned": scanned,
+                    "subjects_updated": subject_updates,
+                    "tags_updated": tag_updates,
+                    "dry_run": dry_run,
+                }
+
+            thread_id = _decode(raw)
+            state = await thread_manager.get_thread(thread_id)
+            if not state:
+                scanned += 1
+                continue
+
+            metadata = state.metadata
+            context = state.context or {}
+            schedule_name = context.get("schedule_name") or None
+            is_scheduled = (
+                (metadata.user_id or "") == "scheduler"
+                or ("scheduled" in (metadata.tags or []))
+                or (bool(context.get("automated")) and bool(schedule_name))
+            )
+
+            subject = (metadata.subject or "").strip()
+            if (
+                is_scheduled
+                and schedule_name
+                and (not subject or subject.lower() in {"untitled", "unknown"})
+            ):
+                if not dry_run:
+                    await thread_manager.set_thread_subject(thread_id, schedule_name)
+                subject_updates += 1
+
+            if is_scheduled and "scheduled" not in (metadata.tags or []):
+                if not dry_run:
+                    metadata.tags = list(sorted(set((metadata.tags or []) + ["scheduled"])))
+                    await thread_manager._save_thread_state(state)
+                tag_updates += 1
+
+            scanned += 1
+
+        offset += page
+
+    return {
+        "status": "dry_run" if dry_run else "completed",
+        "scanned": scanned,
+        "subjects_updated": subject_updates,
+        "tags_updated": tag_updates,
+        "dry_run": dry_run,
+    }
+
+
+async def backfill_empty_thread_subjects_helper(
+    *,
+    limit: int = 0,
+    start: int = 0,
+    dry_run: bool = False,
+    redis_client=None,
+) -> dict[str, Any]:
+    client = redis_client or get_redis_client()
+    thread_manager = ThreadManager(redis_client=client)
+    scanned = 0
+    updated = 0
+    cursor = start
+
+    while True:
+        cursor, keys = await client.scan(cursor=cursor, match=f"{SRE_THREADS_INDEX}:*", count=1000)
+        if not keys and cursor == 0:
+            break
+
+        for key in keys or []:
+            if limit and scanned >= limit:
+                return {
+                    "status": "dry_run" if dry_run else "completed",
+                    "scanned": scanned,
+                    "subjects_updated": updated,
+                    "dry_run": dry_run,
+                }
+
+            redis_key = _decode(key)
+            thread_id = redis_key[len(f"{SRE_THREADS_INDEX}:") :]
+            state = await thread_manager.get_thread(thread_id)
+            if not state:
+                scanned += 1
+                continue
+
+            subject = (state.metadata.subject or "").strip()
+            if subject and subject.lower() not in {"untitled", "unknown"}:
+                scanned += 1
+                continue
+
+            candidate = _derive_subject(state)
+            if not candidate:
+                scanned += 1
+                continue
+
+            line = candidate.splitlines()[0].strip()
+            if len(line) > 80:
+                line = line[:77].rstrip() + "..."
+
+            if not dry_run:
+                await thread_manager.set_thread_subject(thread_id, line)
+            updated += 1
+            scanned += 1
+
+        if cursor == 0:
+            break
+
+    return {
+        "status": "dry_run" if dry_run else "completed",
+        "scanned": scanned,
+        "subjects_updated": updated,
+        "dry_run": dry_run,
+    }
+
+
+async def purge_threads_helper(
+    *,
+    older_than: Optional[str] = None,
+    purge_all: bool = False,
+    include_tasks: bool = True,
+    dry_run: bool = False,
+    confirm: bool = False,
+    redis_client=None,
+) -> dict[str, Any]:
+    if not purge_all and not older_than:
+        return {
+            "error": "Refusing to purge without a scope. Provide older_than or purge_all.",
+            "status": "failed",
+        }
+
+    if not dry_run and not confirm:
+        return {"error": "Confirmation required", "status": "cancelled", "dry_run": False}
+
+    client = redis_client or get_redis_client()
+    thread_manager = ThreadManager(redis_client=client)
+    cutoff_ts = None
+    if older_than:
+        cutoff_ts = (datetime.now(timezone.utc) - _parse_duration(older_than)).timestamp()
+
+    cursor = 0
+    scanned = 0
+    deleted = 0
+    deleted_tasks = 0
+    matched: list[str] = []
+
+    while True:
+        cursor, keys = await client.scan(cursor=cursor, match=f"{SRE_THREADS_INDEX}:*", count=1000)
+        if not keys and cursor == 0:
+            break
+
+        for key in keys or []:
+            redis_key = _decode(key)
+            thread_id = redis_key[len(f"{SRE_THREADS_INDEX}:") :]
+
+            eligible = True
+            if cutoff_ts is not None:
+                try:
+                    created_at = await client.hget(redis_key, "created_at")
+                    created_ts = float(_decode(created_at) or 0)
+                    eligible = created_ts > 0 and created_ts <= cutoff_ts
+                except Exception:
+                    eligible = False
+
+            if not purge_all and not eligible:
+                scanned += 1
+                continue
+
+            matched.append(thread_id)
+            if not dry_run:
+                if include_tasks:
+                    task_ids = await client.zrevrange(
+                        RedisKeys.thread_tasks_index(thread_id), 0, -1
+                    )
+                    for raw in task_ids or []:
+                        try:
+                            await delete_task_core(task_id=_decode(raw), redis_client=client)
+                            deleted_tasks += 1
+                        except Exception:
+                            pass
+
+                    task_cursor = 0
+                    while True:
+                        task_cursor, task_keys = await client.scan(
+                            cursor=task_cursor, match=f"{SRE_TASKS_INDEX}:*", count=1000
+                        )
+                        for task_key in task_keys or []:
+                            task_doc_key = _decode(task_key)
+                            try:
+                                owning_thread = await client.hget(task_doc_key, "thread_id")
+                                if _decode(owning_thread) == thread_id:
+                                    await client.delete(task_doc_key)
+                            except Exception:
+                                pass
+                        if task_cursor == 0:
+                            break
+
+                if await thread_manager.delete_thread(thread_id):
+                    try:
+                        await client.delete(f"{SRE_THREADS_INDEX}:{thread_id}")
+                    except Exception:
+                        pass
+                    deleted += 1
+
+            scanned += 1
+
+        if cursor == 0:
+            break
+
+    return {
+        "status": "dry_run" if dry_run else "purged",
+        "scanned": scanned,
+        "deleted": deleted,
+        "deleted_tasks": deleted_tasks,
+        "matched": matched,
+        "dry_run": dry_run,
+        "include_tasks": include_tasks,
+    }

--- a/redis_sre_agent/mcp_server/__init__.py
+++ b/redis_sre_agent/mcp_server/__init__.py
@@ -35,6 +35,10 @@ Utility tools (return immediately):
 - redis_sre_cache_stats: Show tool cache statistics
 - redis_sre_cache_clear: Clear cached tool outputs
 - redis_sre_version: Show Redis SRE Agent version metadata
+- redis_sre_list_indices: List RediSearch indices and their document counts
+- redis_sre_get_index_schema_status: Show schema drift status for one or all indices
+- redis_sre_recreate_indices: Recreate RediSearch indices with confirmation
+- redis_sre_sync_index_schemas: Recreate only missing or drifted indices with confirmation
 - redis_sre_list_instances: List configured Redis instances
 - redis_sre_get_instance: Get a configured Redis instance by id
 - redis_sre_update_instance: Update a configured Redis instance

--- a/redis_sre_agent/mcp_server/__init__.py
+++ b/redis_sre_agent/mcp_server/__init__.py
@@ -33,6 +33,9 @@ Utility tools (return immediately):
 - redis_sre_search_support_tickets: Search support-ticket docs only
 - redis_sre_get_support_ticket: Get full support-ticket content by ticket id
 - redis_sre_list_instances: List configured Redis instances
+- redis_sre_get_instance: Get a configured Redis instance by id
+- redis_sre_test_instance: Test a configured Redis instance connection
+- redis_sre_test_redis_url: Test a Redis URL without creating an instance
 - redis_sre_create_instance: Create a new Redis instance configuration
 - redis_sre_get_task: Get a full task payload by task ID
 - redis_sre_list_tasks: List tasks with status filtering

--- a/redis_sre_agent/mcp_server/__init__.py
+++ b/redis_sre_agent/mcp_server/__init__.py
@@ -16,6 +16,8 @@ Task-based tools (require polling redis_sre_get_task_status):
 - redis_sre_prepare_source_documents: Prepare and optionally ingest source documents
 - redis_sre_generate_pipeline_runbooks: Run pipeline runbook operations in the background
 - redis_sre_cleanup_pipeline_batches: Remove old pipeline batches in the background
+- redis_sre_generate_runbook: Generate a Redis SRE runbook in the background
+- redis_sre_evaluate_runbooks: Evaluate runbook markdown files in the background
 
 Utility tools (return immediately):
 - redis_sre_knowledge_search: Direct search of knowledge base docs

--- a/redis_sre_agent/mcp_server/__init__.py
+++ b/redis_sre_agent/mcp_server/__init__.py
@@ -34,6 +34,8 @@ Utility tools (return immediately):
 - redis_sre_get_support_ticket: Get full support-ticket content by ticket id
 - redis_sre_list_instances: List configured Redis instances
 - redis_sre_create_instance: Create a new Redis instance configuration
+- redis_sre_get_task: Get a full task payload by task ID
+- redis_sre_list_tasks: List tasks with status filtering
 - redis_sre_get_task_status: Check task progress, notifications, and results
 - redis_sre_get_thread: Get full conversation history and results
 """

--- a/redis_sre_agent/mcp_server/__init__.py
+++ b/redis_sre_agent/mcp_server/__init__.py
@@ -51,6 +51,11 @@ Utility tools (return immediately):
 - redis_sre_delete_schedule: Delete a schedule with confirmation
 - redis_sre_run_schedule_now: Trigger a schedule immediately
 - redis_sre_list_schedule_runs: List recent runs for a schedule
+- redis_sre_reindex_threads: Recreate the threads index and backfill documents
+- redis_sre_backfill_threads: Backfill the threads index from existing thread data
+- redis_sre_backfill_scheduled_thread_subjects: Set schedule-derived subjects and tags
+- redis_sre_backfill_empty_thread_subjects: Derive subjects for empty/placeholder threads
+- redis_sre_purge_threads: Purge threads in bulk with safeguards
 - redis_sre_list_indices: List RediSearch indices and their document counts
 - redis_sre_get_index_schema_status: Show schema drift status for one or all indices
 - redis_sre_recreate_indices: Recreate RediSearch indices with confirmation

--- a/redis_sre_agent/mcp_server/__init__.py
+++ b/redis_sre_agent/mcp_server/__init__.py
@@ -13,6 +13,8 @@ Task-based tools (require polling redis_sre_get_task_status):
 
 Utility tools (return immediately):
 - redis_sre_knowledge_search: Direct search of knowledge base docs
+- redis_sre_get_knowledge_fragments: Get all chunks for a document hash
+- redis_sre_get_related_knowledge_fragments: Get nearby chunks around a fragment
 - redis_sre_get_pipeline_status: Show pipeline artifacts and recent ingestion state
 - redis_sre_get_pipeline_batch: Show manifest and ingestion details for a batch
 - redis_sre_list_support_packages: List uploaded support packages

--- a/redis_sre_agent/mcp_server/__init__.py
+++ b/redis_sre_agent/mcp_server/__init__.py
@@ -44,6 +44,7 @@ Utility tools (return immediately):
 - redis_sre_create_instance: Create a new Redis instance configuration
 - redis_sre_get_task: Get a full task payload by task ID
 - redis_sre_list_tasks: List tasks with status filtering
+- redis_sre_purge_tasks: Purge tasks in bulk with safeguards
 - redis_sre_get_task_status: Check task progress, notifications, and results
 - redis_sre_get_thread: Get full conversation history and results
 - redis_sre_get_thread_sources: Get recorded knowledge fragments for a thread

--- a/redis_sre_agent/mcp_server/__init__.py
+++ b/redis_sre_agent/mcp_server/__init__.py
@@ -32,6 +32,9 @@ Utility tools (return immediately):
 - redis_sre_delete_support_package: Delete a support package
 - redis_sre_search_support_tickets: Search support-ticket docs only
 - redis_sre_get_support_ticket: Get full support-ticket content by ticket id
+- redis_sre_cache_stats: Show tool cache statistics
+- redis_sre_cache_clear: Clear cached tool outputs
+- redis_sre_version: Show Redis SRE Agent version metadata
 - redis_sre_list_instances: List configured Redis instances
 - redis_sre_get_instance: Get a configured Redis instance by id
 - redis_sre_update_instance: Update a configured Redis instance

--- a/redis_sre_agent/mcp_server/__init__.py
+++ b/redis_sre_agent/mcp_server/__init__.py
@@ -10,6 +10,12 @@ Task-based tools (require polling redis_sre_get_task_status):
 - redis_sre_general_chat: Quick Q&A with full toolset including external MCP tools
 - redis_sre_database_chat: Redis-focused chat with selective MCP tool exclusion
 - redis_sre_knowledge_query: Ask the Knowledge Agent a question
+- redis_sre_run_pipeline_scrape: Run the scraping pipeline in the background
+- redis_sre_run_pipeline_ingest: Ingest a batch in the background
+- redis_sre_run_pipeline_full: Run scraping and ingestion together in the background
+- redis_sre_prepare_source_documents: Prepare and optionally ingest source documents
+- redis_sre_generate_pipeline_runbooks: Run pipeline runbook operations in the background
+- redis_sre_cleanup_pipeline_batches: Remove old pipeline batches in the background
 
 Utility tools (return immediately):
 - redis_sre_knowledge_search: Direct search of knowledge base docs

--- a/redis_sre_agent/mcp_server/__init__.py
+++ b/redis_sre_agent/mcp_server/__init__.py
@@ -13,6 +13,13 @@ Task-based tools (require polling redis_sre_get_task_status):
 
 Utility tools (return immediately):
 - redis_sre_knowledge_search: Direct search of knowledge base docs
+- redis_sre_get_pipeline_status: Show pipeline artifacts and recent ingestion state
+- redis_sre_get_pipeline_batch: Show manifest and ingestion details for a batch
+- redis_sre_list_support_packages: List uploaded support packages
+- redis_sre_get_support_package_info: Get metadata for a support package
+- redis_sre_upload_support_package: Upload a support package
+- redis_sre_extract_support_package: Extract a support package
+- redis_sre_delete_support_package: Delete a support package
 - redis_sre_search_support_tickets: Search support-ticket docs only
 - redis_sre_get_support_ticket: Get full support-ticket content by ticket id
 - redis_sre_list_instances: List configured Redis instances

--- a/redis_sre_agent/mcp_server/__init__.py
+++ b/redis_sre_agent/mcp_server/__init__.py
@@ -42,6 +42,15 @@ Utility tools (return immediately):
 - redis_sre_update_cluster: Update a configured Redis cluster
 - redis_sre_delete_cluster: Delete a configured Redis cluster
 - redis_sre_backfill_instance_links: Backfill cluster links for existing instances
+- redis_sre_list_schedules: List configured schedules
+- redis_sre_get_schedule: Get a configured schedule by id
+- redis_sre_create_schedule: Create a new schedule
+- redis_sre_update_schedule: Update an existing schedule
+- redis_sre_enable_schedule: Enable a schedule
+- redis_sre_disable_schedule: Disable a schedule
+- redis_sre_delete_schedule: Delete a schedule with confirmation
+- redis_sre_run_schedule_now: Trigger a schedule immediately
+- redis_sre_list_schedule_runs: List recent runs for a schedule
 - redis_sre_list_indices: List RediSearch indices and their document counts
 - redis_sre_get_index_schema_status: Show schema drift status for one or all indices
 - redis_sre_recreate_indices: Recreate RediSearch indices with confirmation

--- a/redis_sre_agent/mcp_server/__init__.py
+++ b/redis_sre_agent/mcp_server/__init__.py
@@ -34,6 +34,8 @@ Utility tools (return immediately):
 - redis_sre_get_support_ticket: Get full support-ticket content by ticket id
 - redis_sre_list_instances: List configured Redis instances
 - redis_sre_get_instance: Get a configured Redis instance by id
+- redis_sre_update_instance: Update a configured Redis instance
+- redis_sre_delete_instance: Delete a configured Redis instance
 - redis_sre_test_instance: Test a configured Redis instance connection
 - redis_sre_test_redis_url: Test a Redis URL without creating an instance
 - redis_sre_create_instance: Create a new Redis instance configuration

--- a/redis_sre_agent/mcp_server/__init__.py
+++ b/redis_sre_agent/mcp_server/__init__.py
@@ -34,6 +34,7 @@ Utility tools (return immediately):
 - redis_sre_get_support_ticket: Get full support-ticket content by ticket id
 - redis_sre_cache_stats: Show tool cache statistics
 - redis_sre_cache_clear: Clear cached tool outputs
+- redis_sre_audit_cli_mcp_parity: Audit in-scope CLI commands against MCP coverage
 - redis_sre_version: Show Redis SRE Agent version metadata
 - redis_sre_query: Queue a routed query with optional thread, target, and support-package context
 - redis_sre_list_clusters: List configured Redis clusters

--- a/redis_sre_agent/mcp_server/__init__.py
+++ b/redis_sre_agent/mcp_server/__init__.py
@@ -36,6 +36,12 @@ Utility tools (return immediately):
 - redis_sre_cache_clear: Clear cached tool outputs
 - redis_sre_version: Show Redis SRE Agent version metadata
 - redis_sre_query: Queue a routed query with optional thread, target, and support-package context
+- redis_sre_list_clusters: List configured Redis clusters
+- redis_sre_get_cluster: Get a configured Redis cluster by id
+- redis_sre_create_cluster: Create a new Redis cluster configuration
+- redis_sre_update_cluster: Update a configured Redis cluster
+- redis_sre_delete_cluster: Delete a configured Redis cluster
+- redis_sre_backfill_instance_links: Backfill cluster links for existing instances
 - redis_sre_list_indices: List RediSearch indices and their document counts
 - redis_sre_get_index_schema_status: Show schema drift status for one or all indices
 - redis_sre_recreate_indices: Recreate RediSearch indices with confirmation

--- a/redis_sre_agent/mcp_server/__init__.py
+++ b/redis_sre_agent/mcp_server/__init__.py
@@ -35,6 +35,7 @@ Utility tools (return immediately):
 - redis_sre_cache_stats: Show tool cache statistics
 - redis_sre_cache_clear: Clear cached tool outputs
 - redis_sre_version: Show Redis SRE Agent version metadata
+- redis_sre_query: Queue a routed query with optional thread, target, and support-package context
 - redis_sre_list_indices: List RediSearch indices and their document counts
 - redis_sre_get_index_schema_status: Show schema drift status for one or all indices
 - redis_sre_recreate_indices: Recreate RediSearch indices with confirmation

--- a/redis_sre_agent/mcp_server/__init__.py
+++ b/redis_sre_agent/mcp_server/__init__.py
@@ -38,6 +38,8 @@ Utility tools (return immediately):
 - redis_sre_list_tasks: List tasks with status filtering
 - redis_sre_get_task_status: Check task progress, notifications, and results
 - redis_sre_get_thread: Get full conversation history and results
+- redis_sre_get_thread_sources: Get recorded knowledge fragments for a thread
+- redis_sre_get_thread_trace: Get tool-call trace and citations for a message
 """
 
 from redis_sre_agent.mcp_server.server import mcp

--- a/redis_sre_agent/mcp_server/server.py
+++ b/redis_sre_agent/mcp_server/server.py
@@ -44,6 +44,8 @@ the background. You MUST watch each task for:
 | `redis_sre_prepare_source_documents()` | Prepare and optionally ingest local source docs | Varies |
 | `redis_sre_generate_pipeline_runbooks()` | Run pipeline runbook operations | Varies |
 | `redis_sre_cleanup_pipeline_batches()` | Remove old pipeline batches | Varies |
+| `redis_sre_generate_runbook()` | Generate a Redis SRE runbook | Varies |
+| `redis_sre_evaluate_runbooks()` | Evaluate runbook markdown files | Varies |
 
 **Note**: Deep triage performs comprehensive analysis including metrics collection, log analysis,
 knowledge base searches, and multi-topic recommendation synthesis. Complex queries or
@@ -118,7 +120,7 @@ while True:
 - Use `redis_sre_get_task_citations()` only when you need tool provenance or citation data
 - Use `redis_sre_knowledge_search()` for quick doc lookups (no polling needed)
 - Use fragment tools when you need the full document or nearby chunk context for a search hit
-- Use task-backed pipeline tools for scrape/ingest/prepare/runbook/cleanup workflows
+- Use task-backed pipeline and runbook tools for scrape/ingest/prepare/runbook/cleanup workflows
 - Use `redis_sre_get_pipeline_status()` and `redis_sre_get_pipeline_batch()` for ingestion inspection
 - Use support-package tools to upload, inspect, and extract Redis Enterprise diagnostics
 - Use `redis_sre_search_support_tickets()` and `redis_sre_get_support_ticket()` for ticket-only retrieval
@@ -649,6 +651,74 @@ async def redis_sre_cleanup_pipeline_batches(
             "error": str(e),
             "status": "failed",
             "message": f"Failed to start pipeline cleanup: {e}",
+        }
+
+
+@mcp.tool()
+async def redis_sre_generate_runbook(
+    topic: str,
+    scenario_description: str,
+    severity: str = "warning",
+    category: str = "operational_runbook",
+    output_file: Optional[str] = None,
+    requirements: Optional[List[str]] = None,
+    max_iterations: int = 2,
+    auto_save: bool = True,
+    ingest: bool = False,
+    user_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Create a task to generate a Redis SRE runbook."""
+    from redis_sre_agent.core.runbook_execution_helpers import queue_runbook_operation_task
+
+    logger.info("MCP runbook generate request")
+
+    try:
+        return await queue_runbook_operation_task(
+            operation="generate",
+            user_id=user_id,
+            topic=topic,
+            scenario_description=scenario_description,
+            severity=severity,
+            category=category,
+            output_file=output_file,
+            requirements=requirements,
+            max_iterations=max_iterations,
+            auto_save=auto_save,
+            ingest=ingest,
+        )
+    except Exception as e:
+        logger.error("Runbook generate failed: %s", e)
+        return {
+            "error": str(e),
+            "status": "failed",
+            "message": f"Failed to start runbook generation: {e}",
+        }
+
+
+@mcp.tool()
+async def redis_sre_evaluate_runbooks(
+    input_dir: str = "source_documents/runbooks",
+    output_file: Optional[str] = None,
+    user_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Create a task to evaluate runbook markdown files."""
+    from redis_sre_agent.core.runbook_execution_helpers import queue_runbook_operation_task
+
+    logger.info("MCP runbook evaluate request")
+
+    try:
+        return await queue_runbook_operation_task(
+            operation="evaluate",
+            user_id=user_id,
+            input_dir=input_dir,
+            output_file=output_file,
+        )
+    except Exception as e:
+        logger.error("Runbook evaluation failed: %s", e)
+        return {
+            "error": str(e),
+            "status": "failed",
+            "message": f"Failed to start runbook evaluation: {e}",
         }
 
 

--- a/redis_sre_agent/mcp_server/server.py
+++ b/redis_sre_agent/mcp_server/server.py
@@ -74,6 +74,8 @@ After calling any of these, you MUST:
 | `redis_sre_get_support_ticket()` | Get full support-ticket content by ticket id |
 | `redis_sre_list_instances()` | List available Redis instances |
 | `redis_sre_list_threads()` | List conversation threads (find previous chats) |
+| `redis_sre_get_thread_sources()` | Get recorded knowledge fragments for a thread |
+| `redis_sre_get_thread_trace()` | Get tool-call trace for a message |
 | `redis_sre_get_task_status()` | Check task progress |
 | `redis_sre_get_task_citations()` | Get task citation/tool-call data |
 | `redis_sre_get_task()` | Get a full task payload by task id |
@@ -121,6 +123,7 @@ while True:
 - **Always poll redis_sre_get_task_status()** - results are on the task, not returned directly
 - Use `redis_sre_get_task_citations()` only when you need tool provenance or citation data
 - Use `redis_sre_get_task()` and `redis_sre_list_tasks()` for direct task inspection without polling semantics
+- Use `redis_sre_get_thread_sources()` and `redis_sre_get_thread_trace()` for thread provenance inspection
 - Use `redis_sre_knowledge_search()` for quick doc lookups (no polling needed)
 - Use fragment tools when you need the full document or nearby chunk context for a search hit
 - Use task-backed pipeline and runbook tools for scrape/ingest/prepare/runbook/cleanup workflows
@@ -1547,6 +1550,58 @@ async def redis_sre_list_threads(
             "total": 0,
             "limit": limit,
             "offset": offset,
+        }
+
+
+@mcp.tool()
+async def redis_sre_get_thread_sources(
+    thread_id: str,
+    task_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Get knowledge fragments recorded for a thread, optionally for one task turn."""
+    from redis_sre_agent.core.thread_inspection_helpers import get_thread_sources_helper
+
+    logger.info(f"MCP get_thread_sources: thread_id={thread_id}, task_id={task_id}")
+
+    try:
+        return await get_thread_sources_helper(thread_id=thread_id, task_id=task_id)
+    except Exception as e:
+        logger.error(f"Get thread sources failed: {e}")
+        return {
+            "error": str(e),
+            "thread_id": thread_id,
+            "task_id": task_id,
+            "fragments": [],
+            "count": 0,
+        }
+
+
+@mcp.tool()
+async def redis_sre_get_thread_trace(
+    message_id: str,
+    include_tool_data: bool = False,
+) -> Dict[str, Any]:
+    """Get the decision trace and derived citations for a single message."""
+    from redis_sre_agent.core.thread_inspection_helpers import get_thread_trace_helper
+
+    logger.info(
+        f"MCP get_thread_trace: message_id={message_id}, include_tool_data={include_tool_data}"
+    )
+
+    try:
+        return await get_thread_trace_helper(
+            message_id=message_id,
+            include_tool_data=include_tool_data,
+        )
+    except Exception as e:
+        logger.error(f"Get thread trace failed: {e}")
+        return {
+            "error": str(e),
+            "message_id": message_id,
+            "tool_calls": [],
+            "tool_call_count": 0,
+            "citations": [],
+            "citation_count": 0,
         }
 
 

--- a/redis_sre_agent/mcp_server/server.py
+++ b/redis_sre_agent/mcp_server/server.py
@@ -73,6 +73,9 @@ After calling any of these, you MUST:
 | `redis_sre_search_support_tickets()` | Search support-ticket docs only |
 | `redis_sre_get_support_ticket()` | Get full support-ticket content by ticket id |
 | `redis_sre_list_instances()` | List available Redis instances |
+| `redis_sre_get_instance()` | Get a configured Redis instance by id |
+| `redis_sre_test_instance()` | Test a configured Redis instance connection |
+| `redis_sre_test_redis_url()` | Test a Redis URL without creating an instance |
 | `redis_sre_list_threads()` | List conversation threads (find previous chats) |
 | `redis_sre_get_thread_sources()` | Get recorded knowledge fragments for a thread |
 | `redis_sre_get_thread_trace()` | Get tool-call trace for a message |
@@ -130,7 +133,8 @@ while True:
 - Use `redis_sre_get_pipeline_status()` and `redis_sre_get_pipeline_batch()` for ingestion inspection
 - Use support-package tools to upload, inspect, and extract Redis Enterprise diagnostics
 - Use `redis_sre_search_support_tickets()` and `redis_sre_get_support_ticket()` for ticket-only retrieval
-- Use `redis_sre_list_instances()` to find instance IDs before calling other tools
+- Use `redis_sre_list_instances()` and `redis_sre_get_instance()` to inspect configured instances
+- Use `redis_sre_test_instance()` and `redis_sre_test_redis_url()` for connectivity checks
 - Check the `updates` array to show users what the agent is doing""",
 )
 
@@ -1917,6 +1921,59 @@ async def redis_sre_list_instances(
             "error": str(e),
             "instances": [],
             "total": 0,
+        }
+
+
+@mcp.tool()
+async def redis_sre_get_instance(instance_id: str) -> Dict[str, Any]:
+    """Get a configured Redis instance by ID."""
+    from redis_sre_agent.core.instance_inspection_helpers import get_instance_helper
+
+    logger.info("MCP get_instance: %s", instance_id)
+
+    try:
+        return await get_instance_helper(instance_id)
+    except Exception as e:
+        logger.error("Get instance failed: %s", e)
+        return {
+            "error": str(e),
+            "id": instance_id,
+        }
+
+
+@mcp.tool()
+async def redis_sre_test_redis_url(connection_url: str) -> Dict[str, Any]:
+    """Test a Redis connection URL without creating an instance."""
+    from redis_sre_agent.core.instance_inspection_helpers import check_redis_url_helper
+
+    logger.info("MCP test_redis_url request")
+
+    try:
+        return await check_redis_url_helper(connection_url)
+    except Exception as e:
+        logger.error("Test redis url failed: %s", e)
+        return {
+            "success": False,
+            "error": str(e),
+            "url": connection_url,
+        }
+
+
+@mcp.tool()
+async def redis_sre_test_instance(instance_id: str) -> Dict[str, Any]:
+    """Test connection to a configured Redis instance by ID."""
+    from redis_sre_agent.core.instance_inspection_helpers import check_instance_helper
+
+    logger.info("MCP test_instance: %s", instance_id)
+
+    try:
+        return await check_instance_helper(instance_id)
+    except Exception as e:
+        logger.error("Test instance failed: %s", e)
+        return {
+            "success": False,
+            "error": str(e),
+            "id": instance_id,
         }
 
 

--- a/redis_sre_agent/mcp_server/server.py
+++ b/redis_sre_agent/mcp_server/server.py
@@ -523,6 +523,143 @@ async def redis_sre_query(
 
 
 @mcp.tool()
+async def redis_sre_list_clusters(
+    environment: Optional[str] = None,
+    status: Optional[str] = None,
+    cluster_type: Optional[str] = None,
+    user_id: Optional[str] = None,
+    search: Optional[str] = None,
+    limit: int = 100,
+    offset: int = 0,
+) -> Dict[str, Any]:
+    """List configured Redis clusters with optional filtering."""
+    from redis_sre_agent.core.cluster_helpers import list_clusters_helper
+
+    return await list_clusters_helper(
+        environment=environment,
+        status=status,
+        cluster_type=cluster_type,
+        user_id=user_id,
+        search=search,
+        limit=limit,
+        offset=offset,
+    )
+
+
+@mcp.tool()
+async def redis_sre_get_cluster(cluster_id: str) -> Dict[str, Any]:
+    """Get a configured Redis cluster by ID."""
+    from redis_sre_agent.core.cluster_helpers import get_cluster_helper
+
+    return await get_cluster_helper(cluster_id)
+
+
+@mcp.tool()
+async def redis_sre_create_cluster(
+    name: str,
+    environment: str,
+    description: str,
+    cluster_type: str = "unknown",
+    notes: Optional[str] = None,
+    admin_url: Optional[str] = None,
+    admin_username: Optional[str] = None,
+    admin_password: Optional[str] = None,
+    status: Optional[str] = None,
+    version: Optional[str] = None,
+    last_checked: Optional[str] = None,
+    created_by: str = "user",
+    user_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Create a new Redis cluster configuration."""
+    from redis_sre_agent.core.cluster_helpers import create_cluster_helper
+
+    try:
+        return await create_cluster_helper(
+            name=name,
+            environment=environment,
+            description=description,
+            cluster_type=cluster_type,
+            notes=notes,
+            admin_url=admin_url,
+            admin_username=admin_username,
+            admin_password=admin_password,
+            status=status,
+            version=version,
+            last_checked=last_checked,
+            created_by=created_by,
+            user_id=user_id,
+        )
+    except Exception as e:
+        return {"error": str(e), "status": "failed"}
+
+
+@mcp.tool()
+async def redis_sre_update_cluster(
+    cluster_id: str,
+    name: Optional[str] = None,
+    cluster_type: Optional[str] = None,
+    environment: Optional[str] = None,
+    description: Optional[str] = None,
+    notes: Optional[str] = None,
+    admin_url: Optional[str] = None,
+    admin_username: Optional[str] = None,
+    admin_password: Optional[str] = None,
+    status: Optional[str] = None,
+    version: Optional[str] = None,
+    last_checked: Optional[str] = None,
+    created_by: Optional[str] = None,
+    user_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Update an existing Redis cluster configuration."""
+    from redis_sre_agent.core.cluster_helpers import update_cluster_helper
+
+    try:
+        return await update_cluster_helper(
+            cluster_id,
+            name=name,
+            cluster_type=cluster_type,
+            environment=environment,
+            description=description,
+            notes=notes,
+            admin_url=admin_url,
+            admin_username=admin_username,
+            admin_password=admin_password,
+            status=status,
+            version=version,
+            last_checked=last_checked,
+            created_by=created_by,
+            user_id=user_id,
+        )
+    except Exception as e:
+        return {"error": str(e), "id": cluster_id, "status": "failed"}
+
+
+@mcp.tool()
+async def redis_sre_delete_cluster(cluster_id: str, confirm: bool = False) -> Dict[str, Any]:
+    """Delete a configured Redis cluster."""
+    from redis_sre_agent.core.cluster_helpers import delete_cluster_helper
+
+    try:
+        return await delete_cluster_helper(cluster_id, confirm=confirm)
+    except Exception as e:
+        return {"error": str(e), "id": cluster_id, "status": "failed"}
+
+
+@mcp.tool()
+async def redis_sre_backfill_instance_links(
+    dry_run: bool = False,
+    force: bool = False,
+) -> Dict[str, Any]:
+    """Backfill cluster links for existing instance records."""
+    from redis_sre_agent.core.cluster_helpers import backfill_instance_links_helper
+
+    try:
+        return await backfill_instance_links_helper(dry_run=dry_run, force=force)
+    except Exception as e:
+        return {"error": str(e), "status": "failed"}
+
+
+@mcp.tool()
 async def redis_sre_run_pipeline_scrape(
     artifacts_path: str = "./artifacts",
     scrapers: Optional[List[str]] = None,

--- a/redis_sre_agent/mcp_server/server.py
+++ b/redis_sre_agent/mcp_server/server.py
@@ -53,6 +53,13 @@ After calling any of these, you MUST:
 | Tool | Purpose |
 |------|---------|
 | `redis_sre_knowledge_search()` | Direct search of docs (raw results) |
+| `redis_sre_get_pipeline_status()` | Show pipeline artifacts and recent ingestion state |
+| `redis_sre_get_pipeline_batch()` | Show manifest and ingestion details for a batch |
+| `redis_sre_list_support_packages()` | List uploaded support packages |
+| `redis_sre_get_support_package_info()` | Get metadata for a support package |
+| `redis_sre_upload_support_package()` | Upload a support package |
+| `redis_sre_extract_support_package()` | Extract a support package |
+| `redis_sre_delete_support_package()` | Delete a support package |
 | `redis_sre_search_support_tickets()` | Search support-ticket docs only |
 | `redis_sre_get_support_ticket()` | Get full support-ticket content by ticket id |
 | `redis_sre_list_instances()` | List available Redis instances |
@@ -102,6 +109,8 @@ while True:
 - **Always poll redis_sre_get_task_status()** - results are on the task, not returned directly
 - Use `redis_sre_get_task_citations()` only when you need tool provenance or citation data
 - Use `redis_sre_knowledge_search()` for quick doc lookups (no polling needed)
+- Use `redis_sre_get_pipeline_status()` and `redis_sre_get_pipeline_batch()` for ingestion inspection
+- Use support-package tools to upload, inspect, and extract Redis Enterprise diagnostics
 - Use `redis_sre_search_support_tickets()` and `redis_sre_get_support_ticket()` for ticket-only retrieval
 - Use `redis_sre_list_instances()` to find instance IDs before calling other tools
 - Check the `updates` array to show users what the agent is doing""",
@@ -443,6 +452,269 @@ async def redis_sre_database_chat(
             "error": str(e),
             "status": "failed",
             "message": f"Failed to start database chat: {e}",
+        }
+
+
+@mcp.tool()
+async def redis_sre_list_support_packages(limit: int = 100) -> Dict[str, Any]:
+    """List uploaded support packages.
+
+    Args:
+        limit: Maximum number of packages to return.
+
+    Returns:
+        packages: Serialized package metadata
+        total: Number of returned packages
+    """
+    from redis_sre_agent.core.support_package_helpers import get_support_package_manager
+
+    logger.info("MCP list_support_packages: limit=%s", limit)
+
+    try:
+        limit = max(1, limit)
+        manager = get_support_package_manager()
+        packages = await manager.list_packages()
+        return {
+            "packages": [pkg.model_dump(mode="json") for pkg in packages[:limit]],
+            "total": min(len(packages), limit),
+            "limit": limit,
+        }
+    except Exception as e:
+        logger.error("List support packages failed: %s", e)
+        return {
+            "error": str(e),
+            "packages": [],
+            "total": 0,
+            "limit": limit,
+        }
+
+
+@mcp.tool()
+async def redis_sre_get_support_package_info(package_id: str) -> Dict[str, Any]:
+    """Get information about a support package.
+
+    Args:
+        package_id: Support package id.
+
+    Returns:
+        Serialized metadata plus extraction state.
+    """
+    from redis_sre_agent.core.support_package_helpers import get_support_package_manager
+
+    logger.info("MCP get_support_package_info: package_id=%s", package_id)
+
+    try:
+        manager = get_support_package_manager()
+        metadata = await manager.get_metadata(package_id)
+        if not metadata:
+            return {
+                "package_id": package_id,
+                "status": "not_found",
+                "error": "Package not found",
+            }
+
+        payload = metadata.model_dump(mode="json")
+        payload["is_extracted"] = await manager.is_extracted(package_id)
+        return payload
+    except Exception as e:
+        logger.error("Get support package info failed: %s", e)
+        return {
+            "package_id": package_id,
+            "status": "failed",
+            "error": str(e),
+        }
+
+
+@mcp.tool()
+async def redis_sre_upload_support_package(
+    file_path: str, package_id: Optional[str] = None
+) -> Dict[str, Any]:
+    """Upload a support package.
+
+    Args:
+        file_path: Local path to a `.tar.gz` support package.
+        package_id: Optional custom package id.
+
+    Returns:
+        package_id: Stored package id
+        filename: Original filename
+        status: Upload status
+    """
+    from pathlib import Path
+
+    from redis_sre_agent.core.support_package_helpers import get_support_package_manager
+
+    logger.info("MCP upload_support_package: file_path=%s, package_id=%s", file_path, package_id)
+
+    try:
+        source_path = Path(file_path)
+        if not source_path.exists():
+            return {
+                "file_path": file_path,
+                "status": "failed",
+                "error": f"File not found: {file_path}",
+            }
+
+        manager = get_support_package_manager()
+        result_id = await manager.upload(source_path, package_id=package_id)
+        return {
+            "package_id": result_id,
+            "filename": source_path.name,
+            "status": "uploaded",
+        }
+    except Exception as e:
+        logger.error("Upload support package failed: %s", e)
+        return {
+            "file_path": file_path,
+            "status": "failed",
+            "error": str(e),
+        }
+
+
+@mcp.tool()
+async def redis_sre_extract_support_package(package_id: str) -> Dict[str, Any]:
+    """Extract a support package.
+
+    Args:
+        package_id: Support package id.
+
+    Returns:
+        package_id: Support package id
+        path: Extracted directory
+        status: Extraction status
+    """
+    from redis_sre_agent.core.support_package_helpers import get_support_package_manager
+
+    logger.info("MCP extract_support_package: package_id=%s", package_id)
+
+    try:
+        manager = get_support_package_manager()
+        extract_path = await manager.extract(package_id)
+        return {
+            "package_id": package_id,
+            "path": str(extract_path),
+            "status": "extracted",
+        }
+    except Exception as e:
+        logger.error("Extract support package failed: %s", e)
+        return {
+            "package_id": package_id,
+            "status": "failed",
+            "error": str(e),
+        }
+
+
+@mcp.tool()
+async def redis_sre_delete_support_package(
+    package_id: str, confirm: bool = False
+) -> Dict[str, Any]:
+    """Delete a support package.
+
+    Args:
+        package_id: Support package id.
+        confirm: Explicit confirmation for deletion.
+
+    Returns:
+        package_id: Support package id
+        status: Delete status
+    """
+    from redis_sre_agent.core.support_package_helpers import get_support_package_manager
+
+    logger.info("MCP delete_support_package: package_id=%s confirm=%s", package_id, confirm)
+
+    if not confirm:
+        return {
+            "package_id": package_id,
+            "status": "failed",
+            "error": "Deletion requires confirm=true",
+        }
+
+    try:
+        manager = get_support_package_manager()
+        await manager.delete(package_id)
+        return {
+            "package_id": package_id,
+            "status": "deleted",
+        }
+    except Exception as e:
+        logger.error("Delete support package failed: %s", e)
+        return {
+            "package_id": package_id,
+            "status": "failed",
+            "error": str(e),
+        }
+
+
+@mcp.tool()
+async def redis_sre_get_pipeline_status(artifacts_path: str = "./artifacts") -> Dict[str, Any]:
+    """Get pipeline status and available batches.
+
+    Use this to inspect the current ingestion artifact state without shell access.
+
+    Args:
+        artifacts_path: Artifact root path. Defaults to './artifacts'.
+
+    Returns:
+        artifacts_path: Root artifact path
+        current_batch_date: Today's batch folder name
+        available_batches: Known batch directories
+        scrapers: Configured scraper metadata
+        ingestion: Recent ingestion summary
+    """
+    from redis_sre_agent.core.pipeline_helpers import get_pipeline_status_helper
+
+    logger.info("MCP get_pipeline_status: artifacts_path=%s", artifacts_path)
+
+    try:
+        result = await get_pipeline_status_helper(artifacts_path=artifacts_path)
+        result["artifacts_path"] = str(result.get("artifacts_path", artifacts_path))
+        return result
+    except Exception as e:
+        logger.error("Get pipeline status failed: %s", e)
+        return {
+            "error": str(e),
+            "artifacts_path": artifacts_path,
+            "available_batches": [],
+            "scrapers": {},
+            "ingestion": {},
+        }
+
+
+@mcp.tool()
+async def redis_sre_get_pipeline_batch(
+    batch_date: str, artifacts_path: str = "./artifacts"
+) -> Dict[str, Any]:
+    """Get detailed information for a specific pipeline batch.
+
+    This exposes the batch manifest and any ingestion summary for the target batch.
+
+    Args:
+        batch_date: Batch date in YYYY-MM-DD format
+        artifacts_path: Artifact root path. Defaults to './artifacts'.
+
+    Returns:
+        batch_date: Requested batch date
+        total_documents: Number of documents in the batch manifest
+        categories: Category counts for the batch
+        document_types: Document-type counts for the batch
+        ingestion: Ingestion status/details if present
+    """
+    from redis_sre_agent.core.pipeline_helpers import get_pipeline_batch_helper
+
+    logger.info(
+        "MCP get_pipeline_batch: batch_date=%s, artifacts_path=%s",
+        batch_date,
+        artifacts_path,
+    )
+
+    try:
+        return await get_pipeline_batch_helper(batch_date=batch_date, artifacts_path=artifacts_path)
+    except Exception as e:
+        logger.error("Get pipeline batch failed: %s", e)
+        return {
+            "error": str(e),
+            "batch_date": batch_date,
+            "artifacts_path": artifacts_path,
         }
 
 

--- a/redis_sre_agent/mcp_server/server.py
+++ b/redis_sre_agent/mcp_server/server.py
@@ -74,6 +74,7 @@ After calling any of these, you MUST:
 | `redis_sre_get_support_ticket()` | Get full support-ticket content by ticket id |
 | `redis_sre_cache_stats()` | Show tool cache statistics |
 | `redis_sre_cache_clear()` | Clear cached tool outputs |
+| `redis_sre_audit_cli_mcp_parity()` | Audit in-scope CLI commands against MCP coverage |
 | `redis_sre_version()` | Show Redis SRE Agent version metadata |
 | `redis_sre_list_instances()` | List available Redis instances |
 | `redis_sre_get_instance()` | Get a configured Redis instance by id |
@@ -1696,6 +1697,20 @@ async def redis_sre_cache_clear(
             "status": "failed",
             "instance_id": instance_id,
         }
+
+
+@mcp.tool()
+def redis_sre_audit_cli_mcp_parity() -> Dict[str, Any]:
+    """Audit in-scope CLI leaf commands against MCP tool coverage."""
+    from redis_sre_agent.core.cli_mcp_parity import audit_cli_mcp_parity
+
+    logger.info("MCP CLI/MCP parity audit request")
+
+    try:
+        return audit_cli_mcp_parity()
+    except Exception as e:
+        logger.error("CLI/MCP parity audit failed: %s", e)
+        return {"error": str(e), "status": "failed"}
 
 
 @mcp.tool()

--- a/redis_sre_agent/mcp_server/server.py
+++ b/redis_sre_agent/mcp_server/server.py
@@ -89,6 +89,7 @@ After calling any of these, you MUST:
 | `redis_sre_get_task_citations()` | Get task citation/tool-call data |
 | `redis_sre_get_task()` | Get a full task payload by task id |
 | `redis_sre_list_tasks()` | List tasks with status filtering |
+| `redis_sre_purge_tasks()` | Purge tasks in bulk with safeguards |
 | `redis_sre_get_thread()` | Get conversation history |
 
 ## Standard Workflow
@@ -132,6 +133,7 @@ while True:
 - **Always poll redis_sre_get_task_status()** - results are on the task, not returned directly
 - Use `redis_sre_get_task_citations()` only when you need tool provenance or citation data
 - Use `redis_sre_get_task()` and `redis_sre_list_tasks()` for direct task inspection without polling semantics
+- Use `redis_sre_purge_tasks()` for bulk task cleanup with explicit confirmation
 - Use `redis_sre_get_thread_sources()` and `redis_sre_get_thread_trace()` for thread provenance inspection
 - Use `redis_sre_knowledge_search()` for quick doc lookups (no polling needed)
 - Use fragment tools when you need the full document or nearby chunk context for a search hit
@@ -1730,6 +1732,42 @@ async def redis_sre_list_tasks(
             "error": str(e),
             "status": "failed",
             "message": f"Failed to list tasks: {e}",
+        }
+
+
+@mcp.tool()
+async def redis_sre_purge_tasks(
+    status: Optional[str] = None,
+    older_than: Optional[str] = None,
+    purge_all: bool = False,
+    dry_run: bool = False,
+    confirm: bool = False,
+) -> Dict[str, Any]:
+    """Purge tasks in bulk with safeguards and optional dry-run mode."""
+    from redis_sre_agent.core.task_purge_helpers import purge_tasks_helper
+
+    logger.info(
+        "MCP purge_tasks: status=%s older_than=%s purge_all=%s dry_run=%s confirm=%s",
+        status,
+        older_than,
+        purge_all,
+        dry_run,
+        confirm,
+    )
+
+    try:
+        return await purge_tasks_helper(
+            status=status,
+            older_than=older_than,
+            purge_all=purge_all,
+            dry_run=dry_run,
+            confirm=confirm,
+        )
+    except Exception as e:
+        logger.error("Purge tasks failed: %s", e)
+        return {
+            "error": str(e),
+            "status": "failed",
         }
 
 

--- a/redis_sre_agent/mcp_server/server.py
+++ b/redis_sre_agent/mcp_server/server.py
@@ -801,6 +801,100 @@ async def redis_sre_list_schedule_runs(
 
 
 @mcp.tool()
+async def redis_sre_reindex_threads(
+    drop: bool = False,
+    limit: int = 0,
+    start: int = 0,
+) -> Dict[str, Any]:
+    """Recreate the threads index and backfill search documents."""
+    from redis_sre_agent.core.thread_maintenance_helpers import reindex_threads_helper
+
+    try:
+        return await reindex_threads_helper(drop=drop, limit=limit, start=start)
+    except Exception as e:
+        return {"error": str(e), "status": "failed"}
+
+
+@mcp.tool()
+async def redis_sre_backfill_threads(
+    limit: int = 0,
+    start: int = 0,
+) -> Dict[str, Any]:
+    """Backfill the threads index from existing thread data."""
+    from redis_sre_agent.core.thread_maintenance_helpers import backfill_threads_helper
+
+    try:
+        return await backfill_threads_helper(limit=limit, start=start)
+    except Exception as e:
+        return {"error": str(e), "status": "failed"}
+
+
+@mcp.tool()
+async def redis_sre_backfill_scheduled_thread_subjects(
+    limit: int = 0,
+    start: int = 0,
+    dry_run: bool = False,
+) -> Dict[str, Any]:
+    """Backfill scheduled thread subjects and tags."""
+    from redis_sre_agent.core.thread_maintenance_helpers import (
+        backfill_scheduled_thread_subjects_helper,
+    )
+
+    try:
+        return await backfill_scheduled_thread_subjects_helper(
+            limit=limit,
+            start=start,
+            dry_run=dry_run,
+        )
+    except Exception as e:
+        return {"error": str(e), "status": "failed"}
+
+
+@mcp.tool()
+async def redis_sre_backfill_empty_thread_subjects(
+    limit: int = 0,
+    start: int = 0,
+    dry_run: bool = False,
+) -> Dict[str, Any]:
+    """Backfill empty or placeholder thread subjects."""
+    from redis_sre_agent.core.thread_maintenance_helpers import (
+        backfill_empty_thread_subjects_helper,
+    )
+
+    try:
+        return await backfill_empty_thread_subjects_helper(
+            limit=limit,
+            start=start,
+            dry_run=dry_run,
+        )
+    except Exception as e:
+        return {"error": str(e), "status": "failed"}
+
+
+@mcp.tool()
+async def redis_sre_purge_threads(
+    older_than: Optional[str] = None,
+    purge_all: bool = False,
+    include_tasks: bool = True,
+    dry_run: bool = False,
+    confirm: bool = False,
+) -> Dict[str, Any]:
+    """Purge threads in bulk with safeguards."""
+    from redis_sre_agent.core.thread_maintenance_helpers import purge_threads_helper
+
+    try:
+        return await purge_threads_helper(
+            older_than=older_than,
+            purge_all=purge_all,
+            include_tasks=include_tasks,
+            dry_run=dry_run,
+            confirm=confirm,
+        )
+    except Exception as e:
+        return {"error": str(e), "status": "failed"}
+
+
+@mcp.tool()
 async def redis_sre_run_pipeline_scrape(
     artifacts_path: str = "./artifacts",
     scrapers: Optional[List[str]] = None,

--- a/redis_sre_agent/mcp_server/server.py
+++ b/redis_sre_agent/mcp_server/server.py
@@ -76,6 +76,8 @@ After calling any of these, you MUST:
 | `redis_sre_list_threads()` | List conversation threads (find previous chats) |
 | `redis_sre_get_task_status()` | Check task progress |
 | `redis_sre_get_task_citations()` | Get task citation/tool-call data |
+| `redis_sre_get_task()` | Get a full task payload by task id |
+| `redis_sre_list_tasks()` | List tasks with status filtering |
 | `redis_sre_get_thread()` | Get conversation history |
 
 ## Standard Workflow
@@ -118,6 +120,7 @@ while True:
 
 - **Always poll redis_sre_get_task_status()** - results are on the task, not returned directly
 - Use `redis_sre_get_task_citations()` only when you need tool provenance or citation data
+- Use `redis_sre_get_task()` and `redis_sre_list_tasks()` for direct task inspection without polling semantics
 - Use `redis_sre_knowledge_search()` for quick doc lookups (no polling needed)
 - Use fragment tools when you need the full document or nearby chunk context for a search hit
 - Use task-backed pipeline and runbook tools for scrape/ingest/prepare/runbook/cleanup workflows
@@ -1544,6 +1547,63 @@ async def redis_sre_list_threads(
             "total": 0,
             "limit": limit,
             "offset": offset,
+        }
+
+
+@mcp.tool()
+async def redis_sre_get_task(task_id: str) -> Dict[str, Any]:
+    """Get a full task payload by task ID."""
+    from redis_sre_agent.core.task_inspection_helpers import get_task_helper
+
+    logger.info("MCP get_task: %s", task_id)
+
+    try:
+        return await get_task_helper(task_id)
+    except ValueError as e:
+        return {
+            "error": str(e),
+            "task_id": task_id,
+            "status": "not_found",
+        }
+    except Exception as e:
+        logger.error("Get task failed: %s", e)
+        return {
+            "error": str(e),
+            "task_id": task_id,
+        }
+
+
+@mcp.tool()
+async def redis_sre_list_tasks(
+    user_id: Optional[str] = None,
+    status: Optional[str] = None,
+    show_all: bool = False,
+    limit: int = 50,
+) -> Dict[str, Any]:
+    """List recent tasks with optional status filtering."""
+    from redis_sre_agent.core.task_inspection_helpers import list_tasks_helper
+
+    logger.info("MCP list_tasks request")
+
+    try:
+        return await list_tasks_helper(
+            user_id=user_id,
+            status=status,
+            show_all=show_all,
+            limit=limit,
+        )
+    except ValueError as e:
+        return {
+            "error": str(e),
+            "status": "failed",
+            "message": str(e),
+        }
+    except Exception as e:
+        logger.error("List tasks failed: %s", e)
+        return {
+            "error": str(e),
+            "status": "failed",
+            "message": f"Failed to list tasks: {e}",
         }
 
 

--- a/redis_sre_agent/mcp_server/server.py
+++ b/redis_sre_agent/mcp_server/server.py
@@ -1302,6 +1302,88 @@ def redis_sre_version() -> Dict[str, str]:
 
 
 @mcp.tool()
+async def redis_sre_list_indices(index_name: Optional[str] = None) -> Dict[str, Any]:
+    """List known RediSearch indices and their current status."""
+    from redis_sre_agent.core.index_helpers import list_indices_helper
+
+    logger.info("MCP list_indices: index_name=%s", index_name)
+
+    try:
+        return await list_indices_helper(index_name=index_name)
+    except Exception as e:
+        logger.error("List indices failed: %s", e)
+        return {
+            "success": False,
+            "status": "failed",
+            "error": str(e),
+            "index_name": index_name or "all",
+        }
+
+
+@mcp.tool()
+async def redis_sre_get_index_schema_status(index_name: Optional[str] = None) -> Dict[str, Any]:
+    """Show whether index schemas match the current code definitions."""
+    from redis_sre_agent.core.index_helpers import get_index_schema_status_helper
+
+    logger.info("MCP get_index_schema_status: index_name=%s", index_name)
+
+    try:
+        return await get_index_schema_status_helper(index_name=index_name)
+    except Exception as e:
+        logger.error("Get index schema status failed: %s", e)
+        return {
+            "success": False,
+            "status": "failed",
+            "error": str(e),
+            "index_name": index_name or "all",
+        }
+
+
+@mcp.tool()
+async def redis_sre_recreate_indices(
+    index_name: Optional[str] = None,
+    confirm: bool = False,
+) -> Dict[str, Any]:
+    """Drop and recreate RediSearch indices after explicit confirmation."""
+    from redis_sre_agent.core.index_helpers import recreate_indices_helper
+
+    logger.info("MCP recreate_indices: index_name=%s confirm=%s", index_name, confirm)
+
+    try:
+        return await recreate_indices_helper(index_name=index_name, confirm=confirm)
+    except Exception as e:
+        logger.error("Recreate indices failed: %s", e)
+        return {
+            "success": False,
+            "status": "failed",
+            "error": str(e),
+            "index_name": index_name or "all",
+        }
+
+
+@mcp.tool()
+async def redis_sre_sync_index_schemas(
+    index_name: Optional[str] = None,
+    confirm: bool = False,
+) -> Dict[str, Any]:
+    """Create or recreate only drifted indices after explicit confirmation."""
+    from redis_sre_agent.core.index_helpers import sync_index_schemas_helper
+
+    logger.info("MCP sync_index_schemas: index_name=%s confirm=%s", index_name, confirm)
+
+    try:
+        return await sync_index_schemas_helper(index_name=index_name, confirm=confirm)
+    except Exception as e:
+        logger.error("Sync index schemas failed: %s", e)
+        return {
+            "success": False,
+            "status": "failed",
+            "error": str(e),
+            "index_name": index_name or "all",
+        }
+
+
+@mcp.tool()
 async def redis_sre_get_support_ticket(ticket_id: str) -> Dict[str, Any]:
     """Retrieve complete support-ticket content by ticket id.
 

--- a/redis_sre_agent/mcp_server/server.py
+++ b/redis_sre_agent/mcp_server/server.py
@@ -74,6 +74,9 @@ After calling any of these, you MUST:
 | `redis_sre_get_support_ticket()` | Get full support-ticket content by ticket id |
 | `redis_sre_list_instances()` | List available Redis instances |
 | `redis_sre_get_instance()` | Get a configured Redis instance by id |
+| `redis_sre_create_instance()` | Create a Redis instance configuration |
+| `redis_sre_update_instance()` | Update a configured Redis instance |
+| `redis_sre_delete_instance()` | Delete a configured Redis instance |
 | `redis_sre_test_instance()` | Test a configured Redis instance connection |
 | `redis_sre_test_redis_url()` | Test a Redis URL without creating an instance |
 | `redis_sre_list_threads()` | List conversation threads (find previous chats) |
@@ -134,6 +137,7 @@ while True:
 - Use support-package tools to upload, inspect, and extract Redis Enterprise diagnostics
 - Use `redis_sre_search_support_tickets()` and `redis_sre_get_support_ticket()` for ticket-only retrieval
 - Use `redis_sre_list_instances()` and `redis_sre_get_instance()` to inspect configured instances
+- Use `redis_sre_create_instance()`, `redis_sre_update_instance()`, and `redis_sre_delete_instance()` to manage instance configs
 - Use `redis_sre_test_instance()` and `redis_sre_test_redis_url()` for connectivity checks
 - Check the `updates` array to show users what the agent is doing""",
 )
@@ -2066,6 +2070,96 @@ async def redis_sre_create_instance(
     except Exception as e:
         logger.error(f"Create instance failed: {e}")
         return {"error": str(e), "status": "failed"}
+
+
+@mcp.tool()
+async def redis_sre_update_instance(
+    instance_id: str,
+    name: Optional[str] = None,
+    connection_url: Optional[str] = None,
+    environment: Optional[str] = None,
+    usage: Optional[str] = None,
+    description: Optional[str] = None,
+    repo_url: Optional[str] = None,
+    notes: Optional[str] = None,
+    monitoring_identifier: Optional[str] = None,
+    logging_identifier: Optional[str] = None,
+    instance_type: Optional[str] = None,
+    admin_url: Optional[str] = None,
+    admin_username: Optional[str] = None,
+    admin_password: Optional[str] = None,
+    cluster_id: Optional[str] = None,
+    redis_cloud_subscription_id: Optional[int] = None,
+    redis_cloud_database_id: Optional[int] = None,
+    redis_cloud_subscription_type: Optional[str] = None,
+    redis_cloud_database_name: Optional[str] = None,
+    status: Optional[str] = None,
+    version: Optional[str] = None,
+    memory: Optional[str] = None,
+    connections: Optional[int] = None,
+    user_id: Optional[str] = None,
+    set_extensions: Optional[Dict[str, Any]] = None,
+    unset_extensions: Optional[List[str]] = None,
+) -> Dict[str, Any]:
+    """Update an existing Redis instance configuration."""
+    from redis_sre_agent.core.instance_mutation_helpers import update_instance_helper
+
+    logger.info("MCP update_instance: %s", instance_id)
+
+    try:
+        return await update_instance_helper(
+            instance_id,
+            name=name,
+            connection_url=connection_url,
+            environment=environment,
+            usage=usage,
+            description=description,
+            repo_url=repo_url,
+            notes=notes,
+            monitoring_identifier=monitoring_identifier,
+            logging_identifier=logging_identifier,
+            instance_type=instance_type,
+            admin_url=admin_url,
+            admin_username=admin_username,
+            admin_password=admin_password,
+            cluster_id=cluster_id,
+            redis_cloud_subscription_id=redis_cloud_subscription_id,
+            redis_cloud_database_id=redis_cloud_database_id,
+            redis_cloud_subscription_type=redis_cloud_subscription_type,
+            redis_cloud_database_name=redis_cloud_database_name,
+            status=status,
+            version=version,
+            memory=memory,
+            connections=connections,
+            user_id=user_id,
+            set_extensions=set_extensions,
+            unset_extensions=unset_extensions,
+        )
+    except Exception as e:
+        logger.error("Update instance failed: %s", e)
+        return {
+            "error": str(e),
+            "id": instance_id,
+            "status": "failed",
+        }
+
+
+@mcp.tool()
+async def redis_sre_delete_instance(instance_id: str, confirm: bool = False) -> Dict[str, Any]:
+    """Delete a Redis instance configuration."""
+    from redis_sre_agent.core.instance_mutation_helpers import delete_instance_helper
+
+    logger.info("MCP delete_instance: %s", instance_id)
+
+    try:
+        return await delete_instance_helper(instance_id, confirm=confirm)
+    except Exception as e:
+        logger.error("Delete instance failed: %s", e)
+        return {
+            "error": str(e),
+            "id": instance_id,
+            "status": "failed",
+        }
 
 
 # ============================================================================

--- a/redis_sre_agent/mcp_server/server.py
+++ b/redis_sre_agent/mcp_server/server.py
@@ -489,6 +489,40 @@ async def redis_sre_database_chat(
 
 
 @mcp.tool()
+async def redis_sre_query(
+    query: str,
+    instance_id: Optional[str] = None,
+    cluster_id: Optional[str] = None,
+    support_package_id: Optional[str] = None,
+    thread_id: Optional[str] = None,
+    agent: str = "auto",
+    user_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Create a routed query task with thread continuation and support-package targeting."""
+    from redis_sre_agent.core.query_helpers import queue_query_task_helper
+
+    logger.info("MCP query request: %s...", query[:100])
+
+    try:
+        return await queue_query_task_helper(
+            query=query,
+            instance_id=instance_id,
+            cluster_id=cluster_id,
+            support_package_id=support_package_id,
+            thread_id=thread_id,
+            agent=agent,
+            user_id=user_id,
+        )
+    except Exception as e:
+        logger.error(f"Query failed: {e}")
+        return {
+            "error": str(e),
+            "status": "failed",
+            "message": f"Failed to start query: {e}",
+        }
+
+
+@mcp.tool()
 async def redis_sre_run_pipeline_scrape(
     artifacts_path: str = "./artifacts",
     scrapers: Optional[List[str]] = None,

--- a/redis_sre_agent/mcp_server/server.py
+++ b/redis_sre_agent/mcp_server/server.py
@@ -72,6 +72,9 @@ After calling any of these, you MUST:
 | `redis_sre_delete_support_package()` | Delete a support package |
 | `redis_sre_search_support_tickets()` | Search support-ticket docs only |
 | `redis_sre_get_support_ticket()` | Get full support-ticket content by ticket id |
+| `redis_sre_cache_stats()` | Show tool cache statistics |
+| `redis_sre_cache_clear()` | Clear cached tool outputs |
+| `redis_sre_version()` | Show Redis SRE Agent version metadata |
 | `redis_sre_list_instances()` | List available Redis instances |
 | `redis_sre_get_instance()` | Get a configured Redis instance by id |
 | `redis_sre_create_instance()` | Create a Redis instance configuration |
@@ -136,6 +139,8 @@ while True:
 - Use `redis_sre_get_pipeline_status()` and `redis_sre_get_pipeline_batch()` for ingestion inspection
 - Use support-package tools to upload, inspect, and extract Redis Enterprise diagnostics
 - Use `redis_sre_search_support_tickets()` and `redis_sre_get_support_ticket()` for ticket-only retrieval
+- Use `redis_sre_cache_stats()` to inspect cache state and `redis_sre_cache_clear()` to clear cached tool outputs
+- Use `redis_sre_version()` for basic package/version inspection
 - Use `redis_sre_list_instances()` and `redis_sre_get_instance()` to inspect configured instances
 - Use `redis_sre_create_instance()`, `redis_sre_update_instance()`, and `redis_sre_delete_instance()` to manage instance configs
 - Use `redis_sre_test_instance()` and `redis_sre_test_redis_url()` for connectivity checks
@@ -1234,6 +1239,64 @@ async def redis_sre_search_support_tickets(
             "ticket_count": 0,
             "total_results": 0,
         }
+
+
+@mcp.tool()
+async def redis_sre_cache_stats(instance_id: Optional[str] = None) -> Dict[str, Any]:
+    """Show tool cache statistics for one instance or all instances."""
+    from redis_sre_agent.core.cache_helpers import cache_stats_helper
+
+    logger.info("MCP cache_stats: instance_id=%s", instance_id)
+
+    try:
+        return await cache_stats_helper(instance_id=instance_id)
+    except Exception as e:
+        logger.error("Cache stats failed: %s", e)
+        return {
+            "error": str(e),
+            "status": "failed",
+            "instance_id": instance_id,
+        }
+
+
+@mcp.tool()
+async def redis_sre_cache_clear(
+    instance_id: Optional[str] = None,
+    clear_all: bool = False,
+    confirm: bool = False,
+) -> Dict[str, Any]:
+    """Clear cached tool outputs for one instance or all instances."""
+    from redis_sre_agent.core.cache_helpers import cache_clear_helper
+
+    logger.info(
+        "MCP cache_clear: instance_id=%s clear_all=%s confirm=%s",
+        instance_id,
+        clear_all,
+        confirm,
+    )
+
+    try:
+        return await cache_clear_helper(
+            instance_id=instance_id,
+            clear_all=clear_all,
+            confirm=confirm,
+        )
+    except Exception as e:
+        logger.error("Cache clear failed: %s", e)
+        return {
+            "error": str(e),
+            "status": "failed",
+            "instance_id": instance_id,
+        }
+
+
+@mcp.tool()
+def redis_sre_version() -> Dict[str, str]:
+    """Show Redis SRE Agent version metadata."""
+    from redis_sre_agent.core.cache_helpers import version_helper
+
+    logger.info("MCP version request")
+    return version_helper()
 
 
 @mcp.tool()

--- a/redis_sre_agent/mcp_server/server.py
+++ b/redis_sre_agent/mcp_server/server.py
@@ -53,6 +53,8 @@ After calling any of these, you MUST:
 | Tool | Purpose |
 |------|---------|
 | `redis_sre_knowledge_search()` | Direct search of docs (raw results) |
+| `redis_sre_get_knowledge_fragments()` | Get all chunks for a document hash |
+| `redis_sre_get_related_knowledge_fragments()` | Get nearby chunks around a document fragment |
 | `redis_sre_get_pipeline_status()` | Show pipeline artifacts and recent ingestion state |
 | `redis_sre_get_pipeline_batch()` | Show manifest and ingestion details for a batch |
 | `redis_sre_list_support_packages()` | List uploaded support packages |
@@ -109,6 +111,7 @@ while True:
 - **Always poll redis_sre_get_task_status()** - results are on the task, not returned directly
 - Use `redis_sre_get_task_citations()` only when you need tool provenance or citation data
 - Use `redis_sre_knowledge_search()` for quick doc lookups (no polling needed)
+- Use fragment tools when you need the full document or nearby chunk context for a search hit
 - Use `redis_sre_get_pipeline_status()` and `redis_sre_get_pipeline_batch()` for ingestion inspection
 - Use support-package tools to upload, inspect, and extract Redis Enterprise diagnostics
 - Use `redis_sre_search_support_tickets()` and `redis_sre_get_support_ticket()` for ticket-only retrieval
@@ -452,6 +455,87 @@ async def redis_sre_database_chat(
             "error": str(e),
             "status": "failed",
             "message": f"Failed to start database chat: {e}",
+        }
+
+
+@mcp.tool()
+async def redis_sre_get_knowledge_fragments(
+    document_hash: str,
+    include_metadata: bool = True,
+    index_type: str = "knowledge",
+    version: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Get all document fragments for a document hash.
+
+    Args:
+        document_hash: Document hash to fetch.
+        include_metadata: Include document metadata in the response.
+        index_type: Index type to query.
+        version: Optional version filter.
+
+    Returns:
+        Fragment payload for the requested document hash.
+    """
+    from redis_sre_agent.core.knowledge_helpers import get_all_document_fragments
+
+    logger.info(
+        "MCP get_knowledge_fragments: document_hash=%s index_type=%s version=%s",
+        document_hash,
+        index_type,
+        version,
+    )
+
+    try:
+        return await get_all_document_fragments(
+            document_hash,
+            include_metadata=include_metadata,
+            index_type=index_type,
+            version=version,
+        )
+    except Exception as e:
+        logger.error("Get knowledge fragments failed: %s", e)
+        return {
+            "document_hash": document_hash,
+            "error": str(e),
+            "fragments": [],
+        }
+
+
+@mcp.tool()
+async def redis_sre_get_related_knowledge_fragments(
+    document_hash: str, chunk_index: int, window: int = 2
+) -> Dict[str, Any]:
+    """Get related fragments around a target chunk.
+
+    Args:
+        document_hash: Document hash to fetch.
+        chunk_index: Target chunk index.
+        window: Number of chunks before/after to include.
+
+    Returns:
+        Related fragment payload for the requested chunk.
+    """
+    from redis_sre_agent.core.knowledge_helpers import get_related_document_fragments
+
+    logger.info(
+        "MCP get_related_knowledge_fragments: document_hash=%s chunk_index=%s window=%s",
+        document_hash,
+        chunk_index,
+        window,
+    )
+
+    try:
+        return await get_related_document_fragments(
+            document_hash,
+            current_chunk_index=chunk_index,
+            context_window=window,
+        )
+    except Exception as e:
+        logger.error("Get related knowledge fragments failed: %s", e)
+        return {
+            "document_hash": document_hash,
+            "error": str(e),
+            "related_fragments": [],
         }
 
 

--- a/redis_sre_agent/mcp_server/server.py
+++ b/redis_sre_agent/mcp_server/server.py
@@ -38,6 +38,12 @@ the background. You MUST watch each task for:
 | `redis_sre_general_chat()` | Quick Q&A with full toolset (including external MCP tools) | 10-30 seconds |
 | `redis_sre_database_chat()` | Redis-focused chat (no external MCP tools) | 10-30 seconds |
 | `redis_sre_knowledge_query()` | Answer questions using knowledge base | 10-30 seconds |
+| `redis_sre_run_pipeline_scrape()` | Run the scraping pipeline | Varies |
+| `redis_sre_run_pipeline_ingest()` | Ingest a prepared batch | Varies |
+| `redis_sre_run_pipeline_full()` | Run scraping and ingestion together | Varies |
+| `redis_sre_prepare_source_documents()` | Prepare and optionally ingest local source docs | Varies |
+| `redis_sre_generate_pipeline_runbooks()` | Run pipeline runbook operations | Varies |
+| `redis_sre_cleanup_pipeline_batches()` | Remove old pipeline batches | Varies |
 
 **Note**: Deep triage performs comprehensive analysis including metrics collection, log analysis,
 knowledge base searches, and multi-topic recommendation synthesis. Complex queries or
@@ -112,6 +118,7 @@ while True:
 - Use `redis_sre_get_task_citations()` only when you need tool provenance or citation data
 - Use `redis_sre_knowledge_search()` for quick doc lookups (no polling needed)
 - Use fragment tools when you need the full document or nearby chunk context for a search hit
+- Use task-backed pipeline tools for scrape/ingest/prepare/runbook/cleanup workflows
 - Use `redis_sre_get_pipeline_status()` and `redis_sre_get_pipeline_batch()` for ingestion inspection
 - Use support-package tools to upload, inspect, and extract Redis Enterprise diagnostics
 - Use `redis_sre_search_support_tickets()` and `redis_sre_get_support_ticket()` for ticket-only retrieval
@@ -455,6 +462,193 @@ async def redis_sre_database_chat(
             "error": str(e),
             "status": "failed",
             "message": f"Failed to start database chat: {e}",
+        }
+
+
+@mcp.tool()
+async def redis_sre_run_pipeline_scrape(
+    artifacts_path: str = "./artifacts",
+    scrapers: Optional[List[str]] = None,
+    latest_only: bool = False,
+    docs_path: str = "./redis-docs",
+    user_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Create a task to run the scraping pipeline."""
+    from redis_sre_agent.core.pipeline_execution_helpers import queue_pipeline_operation_task
+
+    logger.info("MCP pipeline scrape request")
+
+    try:
+        return await queue_pipeline_operation_task(
+            operation="scrape",
+            user_id=user_id,
+            artifacts_path=artifacts_path,
+            scrapers=scrapers,
+            latest_only=latest_only,
+            docs_path=docs_path,
+        )
+    except Exception as e:
+        logger.error("Pipeline scrape failed: %s", e)
+        return {
+            "error": str(e),
+            "status": "failed",
+            "message": f"Failed to start pipeline scrape: {e}",
+        }
+
+
+@mcp.tool()
+async def redis_sre_run_pipeline_ingest(
+    batch_date: Optional[str] = None,
+    artifacts_path: str = "./artifacts",
+    latest_only: bool = False,
+    user_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Create a task to run pipeline ingestion for a batch."""
+    from redis_sre_agent.core.pipeline_execution_helpers import queue_pipeline_operation_task
+
+    logger.info("MCP pipeline ingest request")
+
+    try:
+        return await queue_pipeline_operation_task(
+            operation="ingest",
+            user_id=user_id,
+            batch_date=batch_date,
+            artifacts_path=artifacts_path,
+            latest_only=latest_only,
+        )
+    except Exception as e:
+        logger.error("Pipeline ingest failed: %s", e)
+        return {
+            "error": str(e),
+            "status": "failed",
+            "message": f"Failed to start pipeline ingest: {e}",
+        }
+
+
+@mcp.tool()
+async def redis_sre_run_pipeline_full(
+    artifacts_path: str = "./artifacts",
+    scrapers: Optional[List[str]] = None,
+    latest_only: bool = False,
+    docs_path: str = "./redis-docs",
+    user_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Create a task to run the full scraping plus ingestion pipeline."""
+    from redis_sre_agent.core.pipeline_execution_helpers import queue_pipeline_operation_task
+
+    logger.info("MCP pipeline full request")
+
+    try:
+        return await queue_pipeline_operation_task(
+            operation="full",
+            user_id=user_id,
+            artifacts_path=artifacts_path,
+            scrapers=scrapers,
+            latest_only=latest_only,
+            docs_path=docs_path,
+        )
+    except Exception as e:
+        logger.error("Pipeline full failed: %s", e)
+        return {
+            "error": str(e),
+            "status": "failed",
+            "message": f"Failed to start full pipeline: {e}",
+        }
+
+
+@mcp.tool()
+async def redis_sre_prepare_source_documents(
+    source_dir: str = "source_documents",
+    batch_date: Optional[str] = None,
+    prepare_only: bool = False,
+    artifacts_path: str = "./artifacts",
+    user_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Create a task to prepare source documents as pipeline artifacts."""
+    from redis_sre_agent.core.pipeline_execution_helpers import queue_pipeline_operation_task
+
+    logger.info("MCP prepare source documents request")
+
+    try:
+        return await queue_pipeline_operation_task(
+            operation="prepare_sources",
+            user_id=user_id,
+            source_dir=source_dir,
+            batch_date=batch_date,
+            prepare_only=prepare_only,
+            artifacts_path=artifacts_path,
+        )
+    except Exception as e:
+        logger.error("Prepare source documents failed: %s", e)
+        return {
+            "error": str(e),
+            "status": "failed",
+            "message": f"Failed to start source preparation: {e}",
+        }
+
+
+@mcp.tool()
+async def redis_sre_generate_pipeline_runbooks(
+    url: Optional[str] = None,
+    test_url: Optional[str] = None,
+    list_urls: bool = False,
+    artifacts_path: str = "./artifacts",
+    user_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Create a task to run pipeline runbook generation operations."""
+    from redis_sre_agent.core.pipeline_execution_helpers import queue_pipeline_operation_task
+
+    logger.info("MCP pipeline runbooks request")
+
+    try:
+        return await queue_pipeline_operation_task(
+            operation="runbooks",
+            user_id=user_id,
+            url=url,
+            test_url=test_url,
+            list_urls=list_urls,
+            artifacts_path=artifacts_path,
+        )
+    except Exception as e:
+        logger.error("Pipeline runbooks failed: %s", e)
+        return {
+            "error": str(e),
+            "status": "failed",
+            "message": f"Failed to start pipeline runbooks: {e}",
+        }
+
+
+@mcp.tool()
+async def redis_sre_cleanup_pipeline_batches(
+    keep_days: int = 30,
+    artifacts_path: str = "./artifacts",
+    confirm: bool = False,
+    user_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Create a task to clean up old pipeline batches."""
+    from redis_sre_agent.core.pipeline_execution_helpers import queue_pipeline_operation_task
+
+    logger.info("MCP pipeline cleanup request")
+
+    if not confirm:
+        return {
+            "status": "failed",
+            "message": "Cleanup is destructive. Re-run with confirm=True to continue.",
+        }
+
+    try:
+        return await queue_pipeline_operation_task(
+            operation="cleanup",
+            user_id=user_id,
+            keep_days=keep_days,
+            artifacts_path=artifacts_path,
+        )
+    except Exception as e:
+        logger.error("Pipeline cleanup failed: %s", e)
+        return {
+            "error": str(e),
+            "status": "failed",
+            "message": f"Failed to start pipeline cleanup: {e}",
         }
 
 

--- a/redis_sre_agent/mcp_server/server.py
+++ b/redis_sre_agent/mcp_server/server.py
@@ -660,6 +660,147 @@ async def redis_sre_backfill_instance_links(
 
 
 @mcp.tool()
+async def redis_sre_list_schedules(limit: int = 50) -> Dict[str, Any]:
+    """List configured schedules."""
+    from redis_sre_agent.core.schedule_helpers import list_schedules_helper
+
+    try:
+        return await list_schedules_helper(limit=limit)
+    except Exception as e:
+        return {"error": str(e), "status": "failed"}
+
+
+@mcp.tool()
+async def redis_sre_get_schedule(schedule_id: str) -> Dict[str, Any]:
+    """Get a configured schedule by id."""
+    from redis_sre_agent.core.schedule_helpers import get_schedule_helper
+
+    try:
+        return await get_schedule_helper(schedule_id)
+    except Exception as e:
+        return {"error": str(e), "id": schedule_id, "status": "failed"}
+
+
+@mcp.tool()
+async def redis_sre_create_schedule(
+    name: str,
+    interval_type: str,
+    interval_value: int,
+    instructions: str,
+    redis_instance_id: Optional[str] = None,
+    description: Optional[str] = None,
+    enabled: bool = True,
+) -> Dict[str, Any]:
+    """Create a new schedule."""
+    from redis_sre_agent.core.schedule_helpers import create_schedule_helper
+
+    try:
+        return await create_schedule_helper(
+            name=name,
+            interval_type=interval_type,
+            interval_value=interval_value,
+            instructions=instructions,
+            redis_instance_id=redis_instance_id,
+            description=description,
+            enabled=enabled,
+        )
+    except Exception as e:
+        return {"error": str(e), "status": "failed"}
+
+
+@mcp.tool()
+async def redis_sre_update_schedule(
+    schedule_id: str,
+    name: Optional[str] = None,
+    description: Optional[str] = None,
+    instructions: Optional[str] = None,
+    redis_instance_id: Optional[str] = None,
+    interval_type: Optional[str] = None,
+    interval_value: Optional[int] = None,
+    enabled: Optional[bool] = None,
+    recalc_next_run: bool = True,
+) -> Dict[str, Any]:
+    """Update an existing schedule."""
+    from redis_sre_agent.core.schedule_helpers import update_schedule_helper
+
+    try:
+        return await update_schedule_helper(
+            schedule_id,
+            name=name,
+            description=description,
+            instructions=instructions,
+            redis_instance_id=redis_instance_id,
+            interval_type=interval_type,
+            interval_value=interval_value,
+            enabled=enabled,
+            recalc_next_run=recalc_next_run,
+        )
+    except Exception as e:
+        return {"error": str(e), "id": schedule_id, "status": "failed"}
+
+
+@mcp.tool()
+async def redis_sre_enable_schedule(schedule_id: str) -> Dict[str, Any]:
+    """Enable a schedule."""
+    from redis_sre_agent.core.schedule_helpers import enable_schedule_helper
+
+    try:
+        return await enable_schedule_helper(schedule_id)
+    except Exception as e:
+        return {"error": str(e), "id": schedule_id, "status": "failed"}
+
+
+@mcp.tool()
+async def redis_sre_disable_schedule(schedule_id: str) -> Dict[str, Any]:
+    """Disable a schedule."""
+    from redis_sre_agent.core.schedule_helpers import disable_schedule_helper
+
+    try:
+        return await disable_schedule_helper(schedule_id)
+    except Exception as e:
+        return {"error": str(e), "id": schedule_id, "status": "failed"}
+
+
+@mcp.tool()
+async def redis_sre_delete_schedule(
+    schedule_id: str,
+    confirm: bool = False,
+) -> Dict[str, Any]:
+    """Delete a schedule."""
+    from redis_sre_agent.core.schedule_helpers import delete_schedule_helper
+
+    try:
+        return await delete_schedule_helper(schedule_id, confirm=confirm)
+    except Exception as e:
+        return {"error": str(e), "id": schedule_id, "status": "failed"}
+
+
+@mcp.tool()
+async def redis_sre_run_schedule_now(schedule_id: str) -> Dict[str, Any]:
+    """Trigger a schedule to run immediately."""
+    from redis_sre_agent.core.schedule_helpers import run_schedule_now_helper
+
+    try:
+        return await run_schedule_now_helper(schedule_id)
+    except Exception as e:
+        return {"error": str(e), "id": schedule_id, "status": "failed"}
+
+
+@mcp.tool()
+async def redis_sre_list_schedule_runs(
+    schedule_id: str,
+    limit: int = 50,
+) -> Dict[str, Any]:
+    """List recent runs for a schedule."""
+    from redis_sre_agent.core.schedule_helpers import list_schedule_runs_helper
+
+    try:
+        return await list_schedule_runs_helper(schedule_id, limit=limit)
+    except Exception as e:
+        return {"error": str(e), "id": schedule_id, "status": "failed"}
+
+
+@mcp.tool()
 async def redis_sre_run_pipeline_scrape(
     artifacts_path: str = "./artifacts",
     scrapers: Optional[List[str]] = None,

--- a/specs/natural-language-target-discovery-spec.md
+++ b/specs/natural-language-target-discovery-spec.md
@@ -1,0 +1,552 @@
+# Natural-Language Target Discovery and Authenticated Tool Loading
+
+Status: Proposed
+
+## Summary
+
+Design a single target-discovery mechanism that lets the agent start with zero explicit
+`instance_id` or `cluster_id`, interpret natural language like "check prod checkout cache" or
+"investigate the us-east enterprise cluster", discover one or more matching Redis targets from
+stored metadata, and dynamically attach authenticated tooling for those targets without exposing
+connection strings, credentials, or API keys to the LLM.
+
+At the same time, collapse the current three-agent split:
+
+- keep `chat`
+- keep `deep triage`
+- remove the separate `knowledge-only` agent
+
+The `chat` agent becomes the default general-purpose agent. It always has knowledge tools and
+target-discovery tools. When no target is resolved, it behaves like today's knowledge agent.
+When one or more targets are resolved, it dynamically gains target-scoped tools.
+
+## Problem
+
+Today the system has three different ways to get scope:
+
+1. The caller passes `instance_id`
+2. The caller passes `cluster_id`
+3. The system extracts a raw `redis://...` URL from the message and creates an instance
+
+That leaves several gaps:
+
+- There is no metadata-based natural-language search across instances and clusters.
+- The agent cannot start from "prod cache in us-east" and resolve scope on its own.
+- The knowledge agent and chat agent are split even though both should be able to begin without
+  target information.
+- Tool loading happens up front; the toolset cannot expand naturally after a target is discovered.
+- Current instance and cluster search only supports narrow filtering plus name wildcard matching.
+- The desired authenticated clients exist only after a target is chosen, but the current design
+  does not model "discover now, attach tools later" as a first-class flow.
+
+## Goals
+
+- Allow `chat` and `deep triage` to begin with no explicit target identifiers.
+- Resolve instances, clusters, or multiple targets from natural language plus stored metadata.
+- Keep authentication details out of LLM prompts, tool schemas, tool results, traces, and thread
+  metadata.
+- Support dynamic loading of authenticated tools after target discovery.
+- Support multiple simultaneous target bindings in one conversation or triage run.
+- Preserve the current distinction between instance-scoped tooling and cluster-scoped tooling.
+- Reuse stored `RedisInstance` and `RedisCluster` records as the source of truth for credentials
+  and other private connection data.
+
+## Non-goals
+
+- Replacing the current `RedisInstance` / `RedisCluster` storage models.
+- Designing a full semantic vector search experience for targets in v1.
+- Accepting raw credentials from natural language as the primary happy path.
+  If a user pastes secrets into chat, that remains a separate sanitization problem.
+- Redesigning provider internals beyond what is needed for dynamic target attachment.
+
+## Current-State Observations
+
+- `process_agent_turn()` currently prefers explicit `instance_id` / `cluster_id`, then thread
+  context, then `_extract_instance_details_from_message()` if the prompt contains a raw Redis URL.
+- `route_to_appropriate_agent()` still routes to `knowledge_only` when no target scope exists.
+- `ChatAgent` and `KnowledgeOnlyAgent` both use `ToolManager`, but only `ChatAgent` can load
+  instance-scoped or cluster-scoped providers.
+- `ToolManager` can load providers for a `RedisInstance` or `RedisCluster`, but only at agent
+  construction time.
+- `query_instances()` and `query_clusters()` only support tag filters plus wildcard matching on
+  `name`, which is too weak for natural-language resolution.
+
+## Proposed Design
+
+## 1. Two-agent model only
+
+Replace the current routing model with two agents:
+
+- `chat`
+- `deep triage`
+
+`chat` becomes the default entry point for:
+
+- general Redis knowledge questions
+- natural-language target discovery
+- quick diagnostics
+- follow-up investigation on one or more attached targets
+
+`deep triage` remains the heavier orchestration path for comprehensive analysis, but it uses the
+same target-discovery mechanism before it begins planning tool work.
+
+### Routing rule
+
+- If the request explicitly asks for deep or exhaustive analysis, route to `deep triage`.
+- Otherwise route to `chat`.
+- Do not route to a separate `knowledge-only` agent.
+
+If no target is resolved, `chat` simply uses knowledge tools and answers as a general Redis/SRE
+assistant.
+
+## 2. Introduce a unified target catalog
+
+Add a new denormalized search index for discovery:
+
+- `sre_targets`
+
+Each document represents either:
+
+- an instance-backed target
+- a cluster-backed target
+
+Suggested document shape:
+
+- `target_id`
+- `target_kind`: `instance | cluster`
+- `resource_id`: underlying `RedisInstance.id` or `RedisCluster.id`
+- `display_name`
+- `name`
+- `environment`
+- `status`
+- `instance_type` or `cluster_type`
+- `usage`
+- `description`
+- `notes`
+- `repo_url`
+- `monitoring_identifier`
+- `logging_identifier`
+- `cluster_id`
+- `redis_cloud_subscription_id`
+- `redis_cloud_database_id`
+- `redis_cloud_database_name`
+- `search_text`
+- `search_aliases`
+- `capabilities`
+- `updated_at`
+
+### Searchable content
+
+`search_text` should be built only from safe metadata, for example:
+
+- instance name
+- cluster name
+- environment
+- usage
+- description
+- notes
+- repo URL host/repo slug
+- monitoring identifier
+- logging identifier
+- Redis Cloud database name
+- known aliases stored in extension metadata
+
+No secrets belong in this index. Specifically exclude:
+
+- `connection_url`
+- `admin_url`
+- usernames
+- passwords
+- API keys
+- secret extension data
+
+### Why a new index instead of reusing `sre_instances` and `sre_clusters`
+
+The unified index simplifies:
+
+- cross-kind search in one query
+- consistent ranking
+- capability-aware filtering
+- future support for richer aliases and relevance tuning
+
+The existing instance and cluster indices remain authoritative for CRUD and direct lookups.
+
+## 3. Add an always-on target discovery tool
+
+Add a new always-on provider, loaded alongside knowledge and utilities:
+
+- `TargetDiscoveryToolProvider`
+
+### Primary v1 tool
+
+Expose one primary tool:
+
+- `resolve_redis_targets`
+
+Suggested contract:
+
+```json
+{
+  "query": "prod checkout cache in us-east",
+  "allow_multiple": true,
+  "max_results": 5,
+  "attach_tools": true,
+  "preferred_capabilities": ["diagnostics", "admin", "cloud"]
+}
+```
+
+Suggested result shape:
+
+```json
+{
+  "status": "resolved",
+  "clarification_required": false,
+  "matches": [
+    {
+      "target_handle": "tgt_01H...",
+      "target_kind": "instance",
+      "resource_id": "redis-prod-checkout-cache",
+      "display_name": "checkout-cache-prod",
+      "environment": "production",
+      "target_type": "oss_single",
+      "capabilities": ["redis", "metrics", "logs"],
+      "confidence": 0.94,
+      "match_reasons": [
+        "matched environment=production",
+        "matched usage=cache",
+        "matched alias=checkout"
+      ]
+    }
+  ],
+  "attached_target_handles": ["tgt_01H..."],
+  "toolset_generation": 4
+}
+```
+
+### Important behavior
+
+The tool does two things:
+
+1. searches and ranks candidate targets
+2. optionally attaches authenticated target handles to the current session
+
+The LLM sees only safe metadata and opaque handles. The actual credentials never appear in the
+tool output.
+
+### Ambiguity policy
+
+- If there is one high-confidence match, auto-attach it.
+- If there are several plausible matches and the user asked for multiple targets, attach the top
+  bounded set and explain what was attached.
+- If there are several plausible matches and the user appears to want one target, return
+  `clarification_required=true` and ask the agent to clarify before using live tools.
+
+## 4. Use opaque target handles, not secrets
+
+Resolved targets should be represented in agent state by opaque handles:
+
+- `tgt_<opaque_id>`
+
+Each handle maps server-side to safe binding metadata:
+
+- `target_handle`
+- `target_kind`
+- `resource_id`
+- `capabilities`
+- `thread_id`
+- `task_id`
+- `created_at`
+- `expires_at`
+
+This binding can live in Redis as ephemeral session state. It does not need to store secrets.
+Because the underlying `RedisInstance` and `RedisCluster` records already store encrypted secrets,
+the binding only needs to remember which resource was chosen.
+
+### Secret-safe resolution path
+
+1. `resolve_redis_targets` returns safe match metadata plus target handles.
+2. The agent records attached handles in thread/task context.
+3. `ToolManager` uses the handle to fetch the underlying instance or cluster by ID.
+4. Provider initialization decrypts secrets server-side only when constructing clients.
+5. Tool schemas and tool results reference handles and display names, not credentials.
+
+## 5. Add dynamic authenticated tool loading
+
+Extend `ToolManager` into a target-aware manager that can load tools in phases:
+
+- base tools
+  - knowledge
+  - utilities
+  - target discovery
+  - MCP tools that do not require target scope
+- target-scoped tools
+  - loaded after one or more target handles are attached
+
+### Required capability
+
+The manager must support:
+
+- initial load with no target
+- attaching one target
+- attaching multiple targets
+- rebuilding the bound tool list when the target set changes
+
+### Tool loading rules
+
+For an attached instance handle:
+
+- load Redis command diagnostics
+- load metrics/logs/host telemetry providers as appropriate
+- load Redis Cloud provider when the instance represents a Redis Cloud database and credentials
+  are available through a secret-safe auth source
+
+For an attached cluster handle:
+
+- load Redis Enterprise admin provider when cluster type is `redis_enterprise`
+- load Redis Cloud subscription-level provider when cluster type is `redis_cloud` and a cloud auth
+  source exists
+- optionally expose cluster-linked instance tools when the agent explicitly expands into database
+  diagnostics
+
+### Multi-target naming
+
+Tool names must be target-scoped and secret-safe. They should include the opaque handle or another
+stable safe suffix, never a host or credential-bearing URL.
+
+Example shape:
+
+- `redis_diag_tgt_a1b2_info`
+- `re_admin_tgt_c3d4_list_bdbs`
+- `redis_cloud_tgt_e5f6_get_database`
+
+The display label shown to the LLM can still mention the safe display name:
+
+- "Redis diagnostics for checkout-cache-prod"
+
+## 6. Search and ranking strategy
+
+The resolver should be deterministic and metadata-first, not LLM-only.
+
+### Proposed pipeline
+
+1. Parse lightweight intent from the query
+   - environment terms: `prod`, `staging`, `dev`
+   - kind hints: `cluster`, `instance`, `database`
+   - topology hints: `enterprise`, `cloud`, `oss`
+   - usage hints: `cache`, `queue`, `session`, `analytics`
+   - entity tokens: names, aliases, repo names, cloud database names
+2. Search `sre_targets` with:
+   - exact tag matches where possible
+   - wildcard / full-text search on safe text fields
+3. Score matches using weighted metadata evidence
+4. Return ranked candidates plus an attach decision
+
+### Ranking inputs
+
+- exact name or alias match
+- environment match
+- usage match
+- target kind match
+- instance or cluster type match
+- monitoring/logging identifier match
+- cloud database name match
+- recency / status as tie-breakers
+
+### Why not pure LLM selection
+
+The LLM should choose whether to call the resolver, not perform secret-bearing lookup logic. The
+resolver must remain deterministic, inspectable, testable, and independent from model variance.
+
+## 7. Session and thread state
+
+Thread context should evolve from a single active ID to a target set:
+
+- `attached_target_handles: List[str]`
+- `active_target_handle: Optional[str]`
+- `target_toolset_generation: int`
+
+Retain compatibility fields during migration:
+
+- `instance_id`
+- `cluster_id`
+
+### Session semantics
+
+- A new session starts with no attached targets.
+- `resolve_redis_targets(..., attach_tools=true)` adds or replaces attached handles depending on
+  agent intent.
+- Follow-up turns reuse attached handles unless the user changes scope.
+- `deep triage` persists the same safe handle set on the task/thread so later follow-ups can
+  continue without rediscovery.
+
+## 8. Agent behavior
+
+## Chat
+
+`chat` should follow this pattern:
+
+1. start with base tools only
+2. if the user intent needs live Redis scope, call `resolve_redis_targets`
+3. if targets are attached, refresh the toolset
+4. continue the same turn using the newly loaded target-scoped tools
+5. if no target is resolved, continue as a knowledge-oriented chat
+
+This replaces today's split between `ChatAgent` and `KnowledgeOnlyAgent`.
+
+## Deep triage
+
+`deep triage` should use the same resolver first, then decide the work plan:
+
+- single instance target: standard instance triage
+- single cluster target: cluster triage, with optional expansion into linked instances
+- multiple targets: bounded fan-out with per-target evidence and aggregated synthesis
+
+The deep triage planner should be able to request additional target expansion if it starts with a
+cluster and later determines that per-database diagnostics are required.
+
+## 9. Authentication model
+
+The design should support three authenticated client families:
+
+- Redis client
+- Redis Enterprise Admin API client
+- Redis Cloud API client
+
+### Credential sources
+
+The LLM never receives these values directly. The runtime resolves them from stored records and
+secret sources:
+
+- `RedisInstance.connection_url`
+- `RedisCluster.admin_url`, `admin_username`, `admin_password`
+- Redis Cloud credentials from a secret-safe auth source
+  - environment-backed in v1 is acceptable
+  - later this can expand to cluster or extension-backed secrets
+
+### Client factories
+
+Introduce a small internal abstraction:
+
+- `AuthenticatedTargetContext`
+
+It exposes safe runtime factories such as:
+
+- `get_redis_client()`
+- `get_enterprise_client()`
+- `get_cloud_client()`
+
+These factories live below the LLM boundary. Providers may use them directly, or the tool manager
+may continue constructing providers from `RedisInstance` / `RedisCluster` models as long as the
+credential resolution stays server-side.
+
+## 10. API and MCP surface
+
+Target state should be discoverable through the main task-based chat and triage flows, not just
+through low-level list/get tools.
+
+### Public direction
+
+Move the product surface toward:
+
+- `redis_sre_chat`
+- `redis_sre_deep_triage`
+
+Compatibility wrappers can remain for:
+
+- `redis_sre_general_chat`
+- `redis_sre_database_chat`
+- `redis_sre_knowledge_query`
+
+But internally they should map onto the new two-agent design.
+
+### Optional helper tools
+
+The primary v1 feature only requires `resolve_redis_targets`, but these may be useful:
+
+- `list_attached_redis_targets`
+- `detach_redis_targets`
+- `expand_cluster_targets_to_instances`
+
+Those helpers are optional follow-ons, not prerequisites.
+
+## 11. Implementation sketch
+
+## Phase 1: Search foundation
+
+- Add `sre_targets` index and builder.
+- Backfill target documents from existing instances and clusters.
+- Add alias support from safe extension metadata.
+- Implement deterministic resolver service with ranking and ambiguity thresholds.
+
+## Phase 2: Tool provider
+
+- Add `TargetDiscoveryToolProvider`.
+- Expose `resolve_redis_targets`.
+- Persist safe target bindings in thread/task/session state.
+
+## Phase 3: Dynamic tool manager
+
+- Extend `ToolManager` to attach multiple targets and rebuild tool definitions.
+- Add target-scoped tool naming.
+- Ensure result envelopes and traces remain secret-safe.
+
+## Phase 4: Agent unification
+
+- Merge knowledge-only behavior into `chat`.
+- Remove `knowledge_only` from router decisions.
+- Update `process_agent_turn()` to use target handles instead of only `instance_id` /
+  `cluster_id`.
+
+## Phase 5: Deep triage integration
+
+- Resolve targets before triage planning.
+- Support bounded multi-target fan-out.
+- Support cluster-to-instance expansion where needed.
+
+## 12. Testing requirements
+
+Add tests for:
+
+- target catalog indexing from instances and clusters
+- resolver ranking and ambiguity handling
+- secret-safe tool output
+- dynamic toolset refresh after resolution
+- chat with zero initial scope resolving a target mid-turn
+- chat with no live target staying in knowledge mode
+- deep triage resolving one target from natural language
+- deep triage resolving multiple targets from natural language
+- cluster resolution followed by instance expansion
+
+Add regression coverage that ensures:
+
+- secrets never appear in resolver tool results
+- secrets never appear in stored traces or thread metadata
+- current explicit `instance_id` / `cluster_id` paths still work during migration
+
+## 13. Risks and tradeoffs
+
+- Dynamic tool rebinding adds complexity to the LangGraph loop.
+- Multi-target tool naming can increase prompt/toolset size if not bounded carefully.
+- Redis Cloud auth is less mature than instance and enterprise cluster auth today, so the first
+  implementation may need to keep cloud attachment behind capability checks.
+- A unified target catalog introduces denormalization; it must be kept in sync whenever instances
+  or clusters change.
+
+## 14. Recommended v1 decisions
+
+- Build `sre_targets` as a new unified metadata index.
+- Add exactly one primary tool: `resolve_redis_targets`.
+- Keep handles opaque and secret-free.
+- Merge `knowledge-only` behavior into `chat`.
+- Make routing binary: `chat` vs `deep triage`.
+- Use deterministic metadata search and scoring in v1.
+- Bound auto-attached targets to a small maximum, for example 3.
+
+## Open Questions
+
+- Should cluster selection automatically attach linked instances, or should that remain an
+  explicit expansion step?
+- Should Redis Cloud credentials remain environment-scoped in v1, or should this work also define
+  cluster-backed cloud secrets?
+- Should attached target handles live only for a thread, or also be shareable across threads in a
+  user session?

--- a/tests/unit/core/test_cache_helpers.py
+++ b/tests/unit/core/test_cache_helpers.py
@@ -1,0 +1,141 @@
+"""Tests for cache and version helpers."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from redis_sre_agent.core.cache_helpers import (
+    cache_clear_helper,
+    cache_stats_helper,
+    get_tool_cache,
+    version_helper,
+)
+
+
+class TestCacheStatsHelper:
+    """Test cache statistics helper behavior."""
+
+    def test_get_tool_cache_builds_all_instances_scope(self):
+        """Tool-cache construction should default to the all-instances scope."""
+        redis_client = object()
+
+        with (
+            patch("redis_sre_agent.core.cache_helpers.get_redis_client", return_value=redis_client),
+            patch("redis_sre_agent.core.cache_helpers.ToolCache") as mock_tool_cache,
+        ):
+            cache = get_tool_cache()
+
+        assert cache == mock_tool_cache.return_value
+        mock_tool_cache.assert_called_once_with(
+            redis_client=redis_client,
+            instance_id="__all__",
+        )
+
+    @pytest.mark.asyncio
+    async def test_cache_stats_helper_defaults_to_all_instances(self):
+        """Stats without an instance should default to aggregate cache stats."""
+        cache = MagicMock()
+        cache.stats_all = AsyncMock(return_value={"total_keys": 7, "instances": ["redis-prod-1"]})
+
+        with patch(
+            "redis_sre_agent.core.cache_helpers.get_tool_cache",
+            return_value=cache,
+        ) as mock_get_cache:
+            result = await cache_stats_helper()
+
+        assert result == {"total_keys": 7, "instances": ["redis-prod-1"]}
+        mock_get_cache.assert_called_once_with("__all__")
+        cache.stats_all.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_cache_stats_helper_returns_instance_stats(self):
+        """Instance-specific stats should use the instance cache scope."""
+        cache = MagicMock()
+        cache.stats = AsyncMock(
+            return_value={"instance_id": "redis-prod-1", "cached_keys": 3, "enabled": True}
+        )
+
+        with patch(
+            "redis_sre_agent.core.cache_helpers.get_tool_cache",
+            return_value=cache,
+        ) as mock_get_cache:
+            result = await cache_stats_helper(instance_id="redis-prod-1")
+
+        assert result["instance_id"] == "redis-prod-1"
+        assert result["cached_keys"] == 3
+        mock_get_cache.assert_called_once_with("redis-prod-1")
+        cache.stats.assert_awaited_once()
+
+
+class TestCacheClearHelper:
+    """Test cache clear helper behavior."""
+
+    @pytest.mark.asyncio
+    async def test_cache_clear_helper_requires_confirmation(self):
+        """Cache clears should require explicit confirmation."""
+        result = await cache_clear_helper(instance_id="redis-prod-1", confirm=False)
+
+        assert result == {
+            "error": "Confirmation required",
+            "status": "cancelled",
+            "instance_id": "redis-prod-1",
+        }
+
+    @pytest.mark.asyncio
+    async def test_cache_clear_helper_requires_scope(self):
+        """Cache clears should reject missing scope."""
+        result = await cache_clear_helper(confirm=True)
+
+        assert result == {
+            "error": "Must specify instance_id or clear_all=True",
+            "status": "failed",
+        }
+
+    @pytest.mark.asyncio
+    async def test_cache_clear_helper_clears_all_instances(self):
+        """Aggregate cache clears should call clear_all on the all-instances scope."""
+        cache = MagicMock()
+        cache.clear_all = AsyncMock(return_value=11)
+
+        with patch(
+            "redis_sre_agent.core.cache_helpers.get_tool_cache",
+            return_value=cache,
+        ) as mock_get_cache:
+            result = await cache_clear_helper(clear_all=True, confirm=True)
+
+        assert result == {"status": "cleared", "scope": "all", "deleted": 11}
+        mock_get_cache.assert_called_once_with("__all__")
+        cache.clear_all.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_cache_clear_helper_clears_single_instance(self):
+        """Instance-scoped cache clears should call clear on that instance."""
+        cache = MagicMock()
+        cache.clear = AsyncMock(return_value=4)
+
+        with patch(
+            "redis_sre_agent.core.cache_helpers.get_tool_cache",
+            return_value=cache,
+        ) as mock_get_cache:
+            result = await cache_clear_helper(instance_id="redis-prod-1", confirm=True)
+
+        assert result == {
+            "status": "cleared",
+            "scope": "instance",
+            "instance_id": "redis-prod-1",
+            "deleted": 4,
+        }
+        mock_get_cache.assert_called_once_with("redis-prod-1")
+        cache.clear.assert_awaited_once()
+
+
+class TestVersionHelper:
+    """Test version metadata helper."""
+
+    def test_version_helper_returns_package_metadata(self, monkeypatch):
+        """Version helper should expose the installed package version."""
+        monkeypatch.setattr("redis_sre_agent.core.cache_helpers.__version__", "0.0-test")
+        assert version_helper() == {
+            "name": "redis-sre-agent",
+            "version": "0.0-test",
+        }

--- a/tests/unit/core/test_cli_mcp_parity.py
+++ b/tests/unit/core/test_cli_mcp_parity.py
@@ -1,0 +1,132 @@
+"""Tests for CLI to MCP parity auditing helpers."""
+
+import pytest
+
+
+class TestCliMcpParityHelpers:
+    def test_walk_click_commands_skips_missing_children(self):
+        import click
+
+        from redis_sre_agent.core.cli_mcp_parity import _walk_click_commands
+
+        class BrokenGroup(click.MultiCommand):
+            def list_commands(self, ctx):
+                return ["missing", "present"]
+
+            def get_command(self, ctx, name):
+                if name == "present":
+                    return click.Command(name)
+                return None
+
+        assert _walk_click_commands(BrokenGroup("broken"), ("root",)) == {"root present"}
+
+    def test_list_cli_command_paths_discovers_leaf_commands(self):
+        from redis_sre_agent.core.cli_mcp_parity import list_cli_command_paths
+
+        paths = list_cli_command_paths()
+
+        assert "version" in paths
+        assert "query" in paths
+        assert "pipeline show-batch" in paths
+        assert "thread trace" in paths
+        assert "worker status" in paths
+        assert "mcp list-tools" in paths
+
+    def test_list_in_scope_cli_command_paths_excludes_admin_commands(self):
+        from redis_sre_agent.core.cli_mcp_parity import list_in_scope_cli_command_paths
+
+        paths = list_in_scope_cli_command_paths()
+
+        assert "worker start" not in paths
+        assert "worker status" not in paths
+        assert "worker stop" not in paths
+        assert "mcp serve" not in paths
+        assert "mcp list-tools" not in paths
+        assert "thread trace" in paths
+        assert "pipeline show-batch" in paths
+
+    def test_audit_cli_mcp_parity_passes_for_current_surface(self):
+        from redis_sre_agent.core.cli_mcp_parity import audit_cli_mcp_parity
+
+        report = audit_cli_mcp_parity()
+
+        assert report["status"] == "ok"
+        assert report["missing_cli_mappings"] == []
+        assert report["missing_mcp_tools"] == {}
+        assert report["stale_exclusions"] == []
+        assert "worker status" in report["excluded_cli_commands"]
+        assert "mcp list-tools" in report["excluded_cli_commands"]
+
+    def test_audit_cli_mcp_parity_reports_unmapped_cli_commands(self):
+        from redis_sre_agent.core.cli_mcp_parity import audit_cli_mcp_parity
+
+        report = audit_cli_mcp_parity(
+            cli_command_paths={"version", "new command"},
+            mcp_tool_names={"redis_sre_version"},
+        )
+
+        assert report["status"] == "failed"
+        assert report["missing_cli_mappings"] == ["new command"]
+        assert report["missing_mcp_tools"] == {}
+
+    def test_audit_cli_mcp_parity_reports_missing_mcp_tools(self):
+        from redis_sre_agent.core.cli_mcp_parity import audit_cli_mcp_parity
+
+        report = audit_cli_mcp_parity(
+            cli_command_paths={"version"},
+            mcp_tool_names=set(),
+        )
+
+        assert report["status"] == "failed"
+        assert report["missing_cli_mappings"] == []
+        assert report["missing_mcp_tools"] == {"version": "redis_sre_version"}
+
+    def test_audit_cli_mcp_parity_reports_stale_exclusions(self, monkeypatch: pytest.MonkeyPatch):
+        import redis_sre_agent.core.cli_mcp_parity as parity
+
+        monkeypatch.setattr(
+            parity,
+            "EXCLUDED_CLI_COMMAND_PATHS",
+            parity.EXCLUDED_CLI_COMMAND_PATHS | {"worker restart"},
+        )
+
+        report = parity.audit_cli_mcp_parity(
+            cli_command_paths={"worker status", "version"},
+            mcp_tool_names={"redis_sre_version"},
+        )
+
+        assert report["status"] == "failed"
+        assert report["stale_exclusions"] == [
+            "mcp list-tools",
+            "mcp serve",
+            "worker restart",
+            "worker start",
+            "worker stop",
+        ]
+
+    def test_list_mcp_tool_names_reads_registered_tool_names(self):
+        from redis_sre_agent.core.cli_mcp_parity import list_mcp_tool_names
+
+        tool_names = list_mcp_tool_names()
+
+        assert "redis_sre_query" in tool_names
+        assert "redis_sre_version" in tool_names
+        assert "redis_sre_get_pipeline_status" in tool_names
+
+    def test_list_cli_command_paths_skips_missing_top_level_commands(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        import redis_sre_agent.core.cli_mcp_parity as parity
+
+        original_get_command = parity.main.get_command
+
+        def fake_get_command(ctx, name):
+            if name == "version":
+                return None
+            return original_get_command(ctx, name)
+
+        monkeypatch.setattr(parity.main, "get_command", fake_get_command)
+
+        paths = parity.list_cli_command_paths()
+
+        assert "version" not in paths

--- a/tests/unit/core/test_cluster_helpers.py
+++ b/tests/unit/core/test_cluster_helpers.py
@@ -1,0 +1,356 @@
+"""Tests for cluster MCP helpers."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from pydantic import SecretStr
+
+from redis_sre_agent.core.cluster_helpers import (
+    _mask_cluster_payload,
+    backfill_instance_links_helper,
+    create_cluster_helper,
+    delete_cluster_helper,
+    get_cluster_helper,
+    list_clusters_helper,
+    update_cluster_helper,
+)
+from redis_sre_agent.core.clusters import ClusterQueryResult, RedisCluster, RedisClusterType
+from redis_sre_agent.core.migrations.instances_to_clusters import InstanceToClusterMigrationSummary
+
+
+def _cluster(**overrides) -> RedisCluster:
+    data = {
+        "id": "cluster-1",
+        "name": "prod-cluster",
+        "cluster_type": RedisClusterType.redis_enterprise,
+        "environment": "production",
+        "description": "Primary cluster",
+        "admin_url": "https://cluster.example.com:9443",
+        "admin_username": "admin@example.com",
+        "admin_password": SecretStr("secret"),
+        "created_by": "user",
+    }
+    data.update(overrides)
+    return RedisCluster(**data)
+
+
+class TestMaskClusterPayload:
+    def test_mask_cluster_payload_masks_password(self):
+        payload = _mask_cluster_payload(_cluster())
+
+        assert payload["admin_password"] == "***"
+
+
+class TestClusterReadHelpers:
+    @pytest.mark.asyncio
+    async def test_list_clusters_helper_masks_payloads(self):
+        result = ClusterQueryResult(clusters=[_cluster()], total=1, limit=10, offset=0)
+
+        with patch(
+            "redis_sre_agent.core.cluster_helpers.core_clusters.query_clusters",
+            new_callable=AsyncMock,
+            return_value=result,
+        ) as mock_query:
+            payload = await list_clusters_helper(environment="production", limit=10, offset=0)
+
+        assert payload["total"] == 1
+        assert payload["clusters"][0]["admin_password"] == "***"
+        mock_query.assert_awaited_once_with(
+            environment="production",
+            status=None,
+            cluster_type=None,
+            user_id=None,
+            search=None,
+            limit=10,
+            offset=0,
+        )
+
+    @pytest.mark.asyncio
+    async def test_get_cluster_helper_returns_masked_payload(self):
+        with patch(
+            "redis_sre_agent.core.cluster_helpers.core_clusters.get_cluster_by_id",
+            new_callable=AsyncMock,
+            return_value=_cluster(),
+        ):
+            payload = await get_cluster_helper("cluster-1")
+
+        assert payload["id"] == "cluster-1"
+        assert payload["admin_password"] == "***"
+
+    @pytest.mark.asyncio
+    async def test_get_cluster_helper_returns_error_when_missing(self):
+        with patch(
+            "redis_sre_agent.core.cluster_helpers.core_clusters.get_cluster_by_id",
+            new_callable=AsyncMock,
+            return_value=None,
+        ):
+            payload = await get_cluster_helper("cluster-404")
+
+        assert payload == {"error": "Cluster not found", "id": "cluster-404"}
+
+
+class TestClusterMutationHelpers:
+    @pytest.mark.asyncio
+    async def test_create_cluster_helper_creates_cluster(self):
+        with (
+            patch(
+                "redis_sre_agent.core.cluster_helpers.core_clusters.get_clusters",
+                new_callable=AsyncMock,
+                return_value=[],
+            ),
+            patch(
+                "redis_sre_agent.core.cluster_helpers.core_clusters.save_clusters",
+                new_callable=AsyncMock,
+                return_value=True,
+            ) as mock_save,
+            patch("redis_sre_agent.core.cluster_helpers.datetime") as mock_datetime,
+        ):
+            mock_datetime.now.return_value.timestamp.return_value = 1700000000
+
+            payload = await create_cluster_helper(
+                name="prod-cluster",
+                cluster_type="redis_enterprise",
+                environment="production",
+                description="Primary cluster",
+                admin_url="https://cluster.example.com:9443",
+                admin_username="admin@example.com",
+                admin_password="secret",
+            )
+
+        assert payload == {"id": "cluster-production-1700000000", "status": "created"}
+        saved_cluster = mock_save.await_args.args[0][0]
+        assert saved_cluster.name == "prod-cluster"
+
+    @pytest.mark.asyncio
+    async def test_create_cluster_helper_rejects_duplicate_names(self):
+        with patch(
+            "redis_sre_agent.core.cluster_helpers.core_clusters.get_clusters",
+            new_callable=AsyncMock,
+            return_value=[_cluster()],
+        ):
+            with pytest.raises(RuntimeError, match="already exists"):
+                await create_cluster_helper(
+                    name="prod-cluster",
+                    environment="production",
+                    description="Primary cluster",
+                )
+
+    @pytest.mark.asyncio
+    async def test_create_cluster_helper_requires_enterprise_admin_fields(self):
+        with patch(
+            "redis_sre_agent.core.cluster_helpers.core_clusters.get_clusters",
+            new_callable=AsyncMock,
+            return_value=[],
+        ):
+            with pytest.raises(RuntimeError, match="cluster_type=redis_enterprise requires"):
+                await create_cluster_helper(
+                    name="prod-cluster",
+                    cluster_type="redis_enterprise",
+                    environment="production",
+                    description="Primary cluster",
+                )
+
+    @pytest.mark.asyncio
+    async def test_create_cluster_helper_raises_when_save_fails(self):
+        with (
+            patch(
+                "redis_sre_agent.core.cluster_helpers.core_clusters.get_clusters",
+                new_callable=AsyncMock,
+                return_value=[],
+            ),
+            patch(
+                "redis_sre_agent.core.cluster_helpers.core_clusters.save_clusters",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+            patch("redis_sre_agent.core.cluster_helpers.datetime") as mock_datetime,
+        ):
+            mock_datetime.now.return_value.timestamp.return_value = 1700000000
+
+            with pytest.raises(RuntimeError, match="Failed to save cluster"):
+                await create_cluster_helper(
+                    name="prod-cluster",
+                    environment="production",
+                    description="Primary cluster",
+                )
+
+    @pytest.mark.asyncio
+    async def test_update_cluster_helper_updates_existing_cluster(self):
+        existing = _cluster()
+
+        with (
+            patch(
+                "redis_sre_agent.core.cluster_helpers.core_clusters.get_clusters",
+                new_callable=AsyncMock,
+                return_value=[existing],
+            ),
+            patch(
+                "redis_sre_agent.core.cluster_helpers.core_clusters.save_clusters",
+                new_callable=AsyncMock,
+                return_value=True,
+            ) as mock_save,
+        ):
+            payload = await update_cluster_helper(
+                "cluster-1",
+                name="prod-cluster-2",
+                environment="staging",
+                status="healthy",
+            )
+
+        assert payload == {"id": "cluster-1", "status": "updated"}
+        updated = mock_save.await_args.args[0][0]
+        assert updated.name == "prod-cluster-2"
+        assert updated.environment == "staging"
+
+    @pytest.mark.asyncio
+    async def test_update_cluster_helper_updates_all_optional_fields(self):
+        existing = _cluster()
+
+        with (
+            patch(
+                "redis_sre_agent.core.cluster_helpers.core_clusters.get_clusters",
+                new_callable=AsyncMock,
+                return_value=[existing],
+            ),
+            patch(
+                "redis_sre_agent.core.cluster_helpers.core_clusters.save_clusters",
+                new_callable=AsyncMock,
+                return_value=True,
+            ) as mock_save,
+        ):
+            await update_cluster_helper(
+                "cluster-1",
+                cluster_type="redis_enterprise",
+                description="Updated description",
+                notes="Updated notes",
+                admin_url="https://new.example.com:9443",
+                admin_username="new-admin@example.com",
+                admin_password="new-secret",
+                version="7.4.0",
+                last_checked="2026-03-25T00:00:00+00:00",
+                created_by="agent",
+                user_id="user-2",
+            )
+
+        updated = mock_save.await_args.args[0][0]
+        assert updated.cluster_type == RedisClusterType.redis_enterprise
+        assert updated.description == "Updated description"
+        assert updated.notes == "Updated notes"
+        assert updated.admin_url == "https://new.example.com:9443"
+        assert updated.admin_username == "new-admin@example.com"
+        assert updated.admin_password.get_secret_value() == "new-secret"
+        assert updated.version == "7.4.0"
+        assert updated.last_checked == "2026-03-25T00:00:00+00:00"
+        assert updated.created_by == "agent"
+        assert updated.user_id == "user-2"
+
+    @pytest.mark.asyncio
+    async def test_update_cluster_helper_rejects_missing_cluster(self):
+        with patch(
+            "redis_sre_agent.core.cluster_helpers.core_clusters.get_clusters",
+            new_callable=AsyncMock,
+            return_value=[],
+        ):
+            with pytest.raises(RuntimeError, match="Cluster not found"):
+                await update_cluster_helper("cluster-404")
+
+    @pytest.mark.asyncio
+    async def test_update_cluster_helper_raises_when_save_fails(self):
+        with (
+            patch(
+                "redis_sre_agent.core.cluster_helpers.core_clusters.get_clusters",
+                new_callable=AsyncMock,
+                return_value=[_cluster()],
+            ),
+            patch(
+                "redis_sre_agent.core.cluster_helpers.core_clusters.save_clusters",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+        ):
+            with pytest.raises(RuntimeError, match="Failed to save updated cluster"):
+                await update_cluster_helper("cluster-1", description="Updated")
+
+    @pytest.mark.asyncio
+    async def test_delete_cluster_helper_requires_confirmation(self):
+        payload = await delete_cluster_helper("cluster-1", confirm=False)
+
+        assert payload == {
+            "error": "Confirmation required",
+            "id": "cluster-1",
+            "status": "cancelled",
+        }
+
+    @pytest.mark.asyncio
+    async def test_delete_cluster_helper_rejects_missing_cluster(self):
+        with patch(
+            "redis_sre_agent.core.cluster_helpers.core_clusters.get_clusters",
+            new_callable=AsyncMock,
+            return_value=[],
+        ):
+            with pytest.raises(RuntimeError, match="Cluster not found"):
+                await delete_cluster_helper("cluster-404", confirm=True)
+
+    @pytest.mark.asyncio
+    async def test_delete_cluster_helper_deletes_cluster(self):
+        with (
+            patch(
+                "redis_sre_agent.core.cluster_helpers.core_clusters.get_clusters",
+                new_callable=AsyncMock,
+                return_value=[_cluster()],
+            ),
+            patch(
+                "redis_sre_agent.core.cluster_helpers.core_clusters.save_clusters",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            patch(
+                "redis_sre_agent.core.cluster_helpers.core_clusters.delete_cluster_index_doc",
+                new_callable=AsyncMock,
+                side_effect=RuntimeError("ignore me"),
+            ),
+        ):
+            payload = await delete_cluster_helper("cluster-1", confirm=True)
+
+        assert payload == {"id": "cluster-1", "status": "deleted"}
+
+    @pytest.mark.asyncio
+    async def test_delete_cluster_helper_raises_when_save_fails(self):
+        with (
+            patch(
+                "redis_sre_agent.core.cluster_helpers.core_clusters.get_clusters",
+                new_callable=AsyncMock,
+                return_value=[_cluster()],
+            ),
+            patch(
+                "redis_sre_agent.core.cluster_helpers.core_clusters.save_clusters",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+        ):
+            with pytest.raises(RuntimeError, match="Failed to save after deletion"):
+                await delete_cluster_helper("cluster-1", confirm=True)
+
+    @pytest.mark.asyncio
+    async def test_backfill_instance_links_helper_returns_summary(self):
+        summary = InstanceToClusterMigrationSummary(
+            scanned=4,
+            eligible=3,
+            clusters_created=1,
+            clusters_reused=1,
+            instances_linked=2,
+        )
+
+        with patch(
+            "redis_sre_agent.core.cluster_helpers.run_instances_to_clusters_migration",
+            new_callable=AsyncMock,
+            return_value=summary,
+        ) as mock_backfill:
+            payload = await backfill_instance_links_helper(dry_run=True, force=False)
+
+        assert payload["clusters_created"] == 1
+        mock_backfill.assert_awaited_once_with(
+            dry_run=True,
+            force=False,
+            source="mcp_cluster_backfill",
+        )

--- a/tests/unit/core/test_index_helpers.py
+++ b/tests/unit/core/test_index_helpers.py
@@ -43,9 +43,7 @@ class TestListIndicesHelper:
     async def test_list_indices_helper_collects_index_status(self):
         existing_idx = AsyncMock()
         existing_idx.exists = AsyncMock(return_value=True)
-        existing_idx._redis_client.execute_command = AsyncMock(
-            return_value=[b"num_docs", b"7"]
-        )
+        existing_idx._redis_client.execute_command = AsyncMock(return_value=[b"num_docs", b"7"])
         existing_get = AsyncMock(return_value=existing_idx)
 
         missing_idx = AsyncMock()
@@ -210,7 +208,10 @@ class TestIndexOperationsHelpers:
             "redis_sre_agent.core.index_helpers.sync_index_schemas",
             new_callable=AsyncMock,
         ) as mock_sync:
-            mock_sync.return_value = {"success": True, "indices": {"knowledge": {"action": "created"}}}
+            mock_sync.return_value = {
+                "success": True,
+                "indices": {"knowledge": {"action": "created"}},
+            }
 
             result = await sync_index_schemas_helper(index_name=None, confirm=True)
 

--- a/tests/unit/core/test_index_helpers.py
+++ b/tests/unit/core/test_index_helpers.py
@@ -1,0 +1,218 @@
+"""Tests for index MCP helpers."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from redis_sre_agent.core.index_helpers import (
+    _decode,
+    _normalize_index_name,
+    get_index_schema_status_helper,
+    list_indices_helper,
+    recreate_indices_helper,
+    sync_index_schemas_helper,
+)
+
+
+class TestNormalizeIndexName:
+    """Test index-name normalization logic."""
+
+    def test_normalize_index_name_accepts_none_all_and_valid_names(self):
+        assert _normalize_index_name(None) is None
+        assert _normalize_index_name("all") is None
+        assert _normalize_index_name("knowledge") == "knowledge"
+
+    def test_normalize_index_name_rejects_invalid_names(self):
+        with pytest.raises(ValueError, match="Invalid index_name"):
+            _normalize_index_name("bogus")
+
+
+class TestDecode:
+    """Test value decoding helpers."""
+
+    def test_decode_handles_bytes_strings_and_none(self):
+        assert _decode(b"docs") == "docs"
+        assert _decode("docs") == "docs"
+        assert _decode(None) == ""
+
+
+class TestListIndicesHelper:
+    """Test index listing behavior."""
+
+    @pytest.mark.asyncio
+    async def test_list_indices_helper_collects_index_status(self):
+        existing_idx = AsyncMock()
+        existing_idx.exists = AsyncMock(return_value=True)
+        existing_idx._redis_client.execute_command = AsyncMock(
+            return_value=[b"num_docs", b"7"]
+        )
+        existing_get = AsyncMock(return_value=existing_idx)
+
+        missing_idx = AsyncMock()
+        missing_idx.exists = AsyncMock(return_value=False)
+        missing_get = AsyncMock(return_value=missing_idx)
+
+        broken_get = AsyncMock(side_effect=RuntimeError("boom"))
+
+        with patch(
+            "redis_sre_agent.core.index_helpers._iter_index_configs",
+            return_value=iter(
+                [
+                    ("knowledge", "idx:knowledge", existing_get, {}),
+                    ("threads", "idx:threads", missing_get, {}),
+                    ("tasks", "idx:tasks", broken_get, {}),
+                ]
+            ),
+        ):
+            result = await list_indices_helper()
+
+        assert result == {
+            "success": False,
+            "requested_index": "all",
+            "indices": [
+                {
+                    "name": "knowledge",
+                    "index_name": "idx:knowledge",
+                    "exists": True,
+                    "num_docs": 7,
+                },
+                {
+                    "name": "threads",
+                    "index_name": "idx:threads",
+                    "exists": False,
+                    "num_docs": 0,
+                },
+                {
+                    "name": "tasks",
+                    "index_name": "idx:tasks",
+                    "exists": False,
+                    "error": "boom",
+                },
+            ],
+        }
+
+    @pytest.mark.asyncio
+    async def test_list_indices_helper_handles_ft_info_errors(self):
+        existing_idx = AsyncMock()
+        existing_idx.exists = AsyncMock(return_value=True)
+        existing_idx._redis_client.execute_command = AsyncMock(side_effect=RuntimeError("bad info"))
+        existing_get = AsyncMock(return_value=existing_idx)
+        config = MagicMock()
+
+        with patch(
+            "redis_sre_agent.core.index_helpers._iter_index_configs",
+            return_value=iter([("knowledge", "idx:knowledge", existing_get, {})]),
+        ):
+            result = await list_indices_helper(index_name="knowledge", config=config)
+
+        assert result == {
+            "success": True,
+            "requested_index": "knowledge",
+            "indices": [
+                {
+                    "name": "knowledge",
+                    "index_name": "idx:knowledge",
+                    "exists": True,
+                    "num_docs": "?",
+                }
+            ],
+        }
+        existing_get.assert_awaited_once_with(config=config)
+
+    @pytest.mark.asyncio
+    async def test_list_indices_helper_filters_to_requested_index(self):
+        knowledge_idx = AsyncMock()
+        knowledge_idx.exists = AsyncMock(return_value=False)
+        knowledge_get = AsyncMock(return_value=knowledge_idx)
+        skipped_get = AsyncMock()
+
+        with patch(
+            "redis_sre_agent.core.index_helpers._iter_index_configs",
+            return_value=iter(
+                [
+                    ("knowledge", "idx:knowledge", knowledge_get, {}),
+                    ("threads", "idx:threads", skipped_get, {}),
+                ]
+            ),
+        ):
+            result = await list_indices_helper(index_name="knowledge")
+
+        assert result == {
+            "success": True,
+            "requested_index": "knowledge",
+            "indices": [
+                {
+                    "name": "knowledge",
+                    "index_name": "idx:knowledge",
+                    "exists": False,
+                    "num_docs": 0,
+                }
+            ],
+        }
+        knowledge_get.assert_awaited_once_with(config=None)
+        skipped_get.assert_not_called()
+
+
+class TestIndexOperationsHelpers:
+    """Test schema/status/recreate/sync helper behavior."""
+
+    @pytest.mark.asyncio
+    async def test_get_index_schema_status_helper_delegates(self):
+        with patch(
+            "redis_sre_agent.core.index_helpers.get_index_schema_status",
+            new_callable=AsyncMock,
+        ) as mock_status:
+            mock_status.return_value = {"success": True, "indices": {}}
+
+            result = await get_index_schema_status_helper(index_name="all")
+
+        assert result == {"success": True, "indices": {}}
+        mock_status.assert_awaited_once_with(index_name=None, config=None)
+
+    @pytest.mark.asyncio
+    async def test_recreate_indices_helper_requires_confirmation(self):
+        result = await recreate_indices_helper(index_name="knowledge", confirm=False)
+
+        assert result == {
+            "success": False,
+            "status": "cancelled",
+            "error": "Confirmation required",
+            "index_name": "knowledge",
+        }
+
+    @pytest.mark.asyncio
+    async def test_recreate_indices_helper_delegates(self):
+        with patch(
+            "redis_sre_agent.core.index_helpers.recreate_indices",
+            new_callable=AsyncMock,
+        ) as mock_recreate:
+            mock_recreate.return_value = {"success": True, "indices": {"knowledge": "recreated"}}
+
+            result = await recreate_indices_helper(index_name="knowledge", confirm=True)
+
+        assert result == {"success": True, "indices": {"knowledge": "recreated"}}
+        mock_recreate.assert_awaited_once_with(index_name="knowledge", config=None)
+
+    @pytest.mark.asyncio
+    async def test_sync_index_schemas_helper_requires_confirmation(self):
+        result = await sync_index_schemas_helper(index_name="all", confirm=False)
+
+        assert result == {
+            "success": False,
+            "status": "cancelled",
+            "error": "Confirmation required",
+            "index_name": "all",
+        }
+
+    @pytest.mark.asyncio
+    async def test_sync_index_schemas_helper_delegates(self):
+        with patch(
+            "redis_sre_agent.core.index_helpers.sync_index_schemas",
+            new_callable=AsyncMock,
+        ) as mock_sync:
+            mock_sync.return_value = {"success": True, "indices": {"knowledge": {"action": "created"}}}
+
+            result = await sync_index_schemas_helper(index_name=None, confirm=True)
+
+        assert result == {"success": True, "indices": {"knowledge": {"action": "created"}}}
+        mock_sync.assert_awaited_once_with(index_name=None, config=None)

--- a/tests/unit/core/test_instance_inspection_helpers.py
+++ b/tests/unit/core/test_instance_inspection_helpers.py
@@ -1,0 +1,135 @@
+"""Tests for instance inspection helpers."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from pydantic import SecretStr
+
+from redis_sre_agent.core.instance_inspection_helpers import (
+    _connection_url_value,
+    check_instance_helper,
+    check_redis_url_helper,
+    get_instance_helper,
+)
+from redis_sre_agent.core.instances import RedisInstance, RedisInstanceType
+
+
+def _build_instance() -> RedisInstance:
+    return RedisInstance(
+        id="redis-prod-1",
+        name="Production Redis",
+        connection_url=SecretStr("redis://user:pass@redis.example.com:6379/0"),
+        environment="production",
+        usage="cache",
+        description="Primary cache",
+        instance_type=RedisInstanceType.redis_cloud,
+        admin_url="https://admin.example.com",
+        admin_username="admin",
+        admin_password=SecretStr("super-secret"),
+        cluster_id="cluster-123",
+    )
+
+
+class TestGetInstanceHelper:
+    """Test shared helpers for instance inspection."""
+
+    @pytest.mark.asyncio
+    async def test_get_instance_helper_returns_masked_payload(self):
+        """Instance retrieval should return a masked, machine-friendly payload."""
+        with patch(
+            "redis_sre_agent.core.instance_inspection_helpers.get_instance_by_id",
+            new_callable=AsyncMock,
+            return_value=_build_instance(),
+        ):
+            result = await get_instance_helper("redis-prod-1")
+
+        assert result["id"] == "redis-prod-1"
+        assert result["name"] == "Production Redis"
+        assert result["connection_url"] == "redis://***:***@redis.example.com:6379/0"
+        assert result["admin_password"] == "***"
+        assert result["cluster_id"] == "cluster-123"
+
+    @pytest.mark.asyncio
+    async def test_get_instance_helper_returns_not_found_payload(self):
+        """Missing instances should return an error payload."""
+        with patch(
+            "redis_sre_agent.core.instance_inspection_helpers.get_instance_by_id",
+            new_callable=AsyncMock,
+            return_value=None,
+        ):
+            result = await get_instance_helper("missing")
+
+        assert result == {"error": "Instance not found", "id": "missing"}
+
+
+class TestConnectionHelpers:
+    """Test shared helpers for instance and URL connectivity checks."""
+
+    def test_connection_url_value_accepts_plain_strings(self):
+        """Plain-string URLs should pass through unchanged."""
+        assert _connection_url_value("redis://plain-host:6379/0") == "redis://plain-host:6379/0"
+
+    @pytest.mark.asyncio
+    async def test_test_redis_url_helper_masks_url(self):
+        """URL tests should mask credentials in the returned payload."""
+        with patch(
+            "redis_sre_agent.core.instance_inspection_helpers.test_redis_connection",
+            new_callable=AsyncMock,
+            return_value=True,
+        ) as mock_test:
+            result = await check_redis_url_helper("redis://user:pass@redis.example.com:6379/0")
+
+        assert result == {
+            "success": True,
+            "message": "Successfully connected",
+            "url": "redis://***:***@redis.example.com:6379/0",
+        }
+        mock_test.assert_awaited_once_with(url="redis://user:pass@redis.example.com:6379/0")
+
+    @pytest.mark.asyncio
+    async def test_test_instance_helper_success(self):
+        """Instance tests should resolve the instance and check its connection URL."""
+        with (
+            patch(
+                "redis_sre_agent.core.instance_inspection_helpers.get_instance_by_id",
+                new_callable=AsyncMock,
+                return_value=_build_instance(),
+            ),
+            patch(
+                "redis_sre_agent.core.instance_inspection_helpers.test_redis_connection",
+                new_callable=AsyncMock,
+                return_value=False,
+            ) as mock_test,
+        ):
+            result = await check_instance_helper("redis-prod-1")
+
+        assert result == {
+            "success": False,
+            "message": "Failed to connect",
+            "instance_id": "redis-prod-1",
+            "name": "Production Redis",
+        }
+        mock_test.assert_awaited_once_with(url="redis://user:pass@redis.example.com:6379/0")
+
+    @pytest.mark.asyncio
+    async def test_test_instance_helper_not_found(self):
+        """Missing instances should return an error payload without probing Redis."""
+        with (
+            patch(
+                "redis_sre_agent.core.instance_inspection_helpers.get_instance_by_id",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch(
+                "redis_sre_agent.core.instance_inspection_helpers.test_redis_connection",
+                new_callable=AsyncMock,
+            ) as mock_test,
+        ):
+            result = await check_instance_helper("missing")
+
+        assert result == {
+            "success": False,
+            "error": "Instance not found",
+            "id": "missing",
+        }
+        mock_test.assert_not_awaited()

--- a/tests/unit/core/test_instance_mutation_helpers.py
+++ b/tests/unit/core/test_instance_mutation_helpers.py
@@ -1,0 +1,303 @@
+"""Tests for instance mutation helpers."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from pydantic import SecretStr
+
+from redis_sre_agent.core.instance_mutation_helpers import (
+    _normalize_cluster_id,
+    _validate_instance_cluster_link,
+    delete_instance_helper,
+    update_instance_helper,
+)
+from redis_sre_agent.core.instances import RedisInstance, RedisInstanceType
+
+
+def _build_instance() -> RedisInstance:
+    return RedisInstance(
+        id="redis-prod-1",
+        name="Production Redis",
+        connection_url=SecretStr("redis://user:pass@redis.example.com:6379/0"),
+        environment="production",
+        usage="cache",
+        description="Primary cache",
+        instance_type=RedisInstanceType.redis_cloud,
+        cluster_id="cluster-123",
+        extension_data={"existing": "value", "remove-me": True},
+    )
+
+
+class TestUpdateInstanceHelper:
+    """Test shared helpers for updating instances."""
+
+    @pytest.mark.asyncio
+    async def test_update_instance_helper_updates_and_masks_payload(self):
+        """Updates should persist and return a masked payload."""
+        cluster = MagicMock()
+        cluster.cluster_type = RedisInstanceType.redis_cloud
+
+        with (
+            patch(
+                "redis_sre_agent.core.instance_mutation_helpers.get_instances",
+                new_callable=AsyncMock,
+                return_value=[_build_instance()],
+            ),
+            patch(
+                "redis_sre_agent.core.instance_mutation_helpers.get_cluster_by_id",
+                new_callable=AsyncMock,
+                return_value=cluster,
+            ),
+            patch(
+                "redis_sre_agent.core.instance_mutation_helpers.save_instances",
+                new_callable=AsyncMock,
+                return_value=True,
+            ) as mock_save,
+        ):
+            result = await update_instance_helper(
+                "redis-prod-1",
+                description="Updated description",
+                cluster_id=" cluster-123 ",
+                set_extensions={"new-key": {"nested": True}},
+                unset_extensions=["remove-me"],
+            )
+
+        assert result["id"] == "redis-prod-1"
+        assert result["status"] == "updated"
+        assert result["description"] == "Updated description"
+        assert result["connection_url"] == "redis://***:***@redis.example.com:6379/0"
+        assert result["cluster_id"] == "cluster-123"
+        assert result["extension_data"] == {
+            "existing": "value",
+            "new-key": {"nested": True},
+        }
+        saved_instances = mock_save.await_args.args[0]
+        assert saved_instances[0].description == "Updated description"
+        assert saved_instances[0].extension_data == {
+            "existing": "value",
+            "new-key": {"nested": True},
+        }
+
+    @pytest.mark.asyncio
+    async def test_update_instance_helper_covers_all_optional_fields(self):
+        """Optional update fields should all flow into the saved instance."""
+        with (
+            patch(
+                "redis_sre_agent.core.instance_mutation_helpers.get_instances",
+                new_callable=AsyncMock,
+                return_value=[_build_instance()],
+            ),
+            patch(
+                "redis_sre_agent.core.instance_mutation_helpers.save_instances",
+                new_callable=AsyncMock,
+                return_value=True,
+            ) as mock_save,
+        ):
+            result = await update_instance_helper(
+                "redis-prod-1",
+                name="Renamed Redis",
+                connection_url="redis://new-user:new-pass@redis.example.com:6380/0",
+                environment="staging",
+                usage="session",
+                repo_url="https://github.com/example/repo",
+                notes="note",
+                monitoring_identifier="monitoring-name",
+                logging_identifier="logging-name",
+                instance_type="redis_cloud",
+                admin_url="https://admin.example.com",
+                admin_username="admin",
+                admin_password="secret",
+                redis_cloud_subscription_id=99,
+                redis_cloud_database_id=42,
+                redis_cloud_subscription_type="PRO",
+                redis_cloud_database_name="db-name",
+                status="healthy",
+                version="8.0.1",
+                memory="2gb",
+                connections=17,
+                user_id="user-123",
+            )
+
+        assert result["name"] == "Renamed Redis"
+        assert result["environment"] == "staging"
+        assert result["usage"] == "session"
+        assert result["repo_url"] == "https://github.com/example/repo"
+        assert result["notes"] == "note"
+        assert result["monitoring_identifier"] == "monitoring-name"
+        assert result["logging_identifier"] == "logging-name"
+        assert result["instance_type"] == "redis_cloud"
+        assert result["admin_url"] == "https://admin.example.com"
+        assert result["admin_username"] == "admin"
+        assert result["admin_password"] == "***"
+        assert result["redis_cloud_subscription_id"] == 99
+        assert result["redis_cloud_database_id"] == 42
+        assert result["redis_cloud_subscription_type"] == "pro"
+        assert result["redis_cloud_database_name"] == "db-name"
+        assert result["status"] == "updated"
+        assert result["version"] == "8.0.1"
+        assert result["memory"] == "2gb"
+        assert result["connections"] == 17
+        assert result["user_id"] == "user-123"
+        saved_instance = mock_save.await_args.args[0][0]
+        assert saved_instance.name == "Renamed Redis"
+        assert saved_instance.environment == "staging"
+        assert saved_instance.usage == "session"
+        assert saved_instance.redis_cloud_subscription_type == "pro"
+
+    @pytest.mark.asyncio
+    async def test_update_instance_helper_returns_not_found_payload(self):
+        """Missing instances should return a structured error payload."""
+        with patch(
+            "redis_sre_agent.core.instance_mutation_helpers.get_instances",
+            new_callable=AsyncMock,
+            return_value=[],
+        ):
+            result = await update_instance_helper("missing")
+
+        assert result == {"error": "Instance not found", "id": "missing"}
+
+    @pytest.mark.asyncio
+    async def test_update_instance_helper_raises_for_save_failure(self):
+        """Save failures should raise so the MCP wrapper can surface them."""
+        with (
+            patch(
+                "redis_sre_agent.core.instance_mutation_helpers.get_instances",
+                new_callable=AsyncMock,
+                return_value=[_build_instance()],
+            ),
+            patch(
+                "redis_sre_agent.core.instance_mutation_helpers.save_instances",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+        ):
+            with pytest.raises(RuntimeError, match="Failed to save updated instance"):
+                await update_instance_helper("redis-prod-1", notes="updated")
+
+    @pytest.mark.asyncio
+    async def test_update_instance_helper_raises_for_incompatible_cluster(self):
+        """Cluster validation should reject incompatible instance types."""
+        cluster = MagicMock()
+        cluster.cluster_type = RedisInstanceType.redis_enterprise
+
+        with (
+            patch(
+                "redis_sre_agent.core.instance_mutation_helpers.get_instances",
+                new_callable=AsyncMock,
+                return_value=[_build_instance()],
+            ),
+            patch(
+                "redis_sre_agent.core.instance_mutation_helpers.get_cluster_by_id",
+                new_callable=AsyncMock,
+                return_value=cluster,
+            ),
+        ):
+            with pytest.raises(RuntimeError, match="incompatible"):
+                await update_instance_helper("redis-prod-1", cluster_id="cluster-123")
+
+    @pytest.mark.asyncio
+    async def test_validate_instance_cluster_link_accepts_none(self):
+        """Blank cluster ids should normalize to None without lookup."""
+        with patch(
+            "redis_sre_agent.core.instance_mutation_helpers.get_cluster_by_id",
+            new_callable=AsyncMock,
+        ) as mock_get_cluster:
+            result = await _validate_instance_cluster_link(cluster_id=None, instance_type=None)
+
+        assert result is None
+        mock_get_cluster.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_validate_instance_cluster_link_raises_when_cluster_missing(self):
+        """Missing clusters should raise a clear error."""
+        with patch(
+            "redis_sre_agent.core.instance_mutation_helpers.get_cluster_by_id",
+            new_callable=AsyncMock,
+            return_value=None,
+        ):
+            with pytest.raises(RuntimeError, match="Cluster with ID 'cluster-123' not found"):
+                await _validate_instance_cluster_link(
+                    cluster_id="cluster-123",
+                    instance_type="redis_cloud",
+                )
+
+
+class TestDeleteInstanceHelper:
+    """Test shared helpers for deleting instances."""
+
+    @pytest.mark.asyncio
+    async def test_delete_instance_helper_requires_confirmation(self):
+        """Deletes should require explicit confirmation."""
+        result = await delete_instance_helper("redis-prod-1", confirm=False)
+
+        assert result == {
+            "error": "Confirmation required",
+            "id": "redis-prod-1",
+            "status": "cancelled",
+        }
+
+    @pytest.mark.asyncio
+    async def test_delete_instance_helper_returns_not_found_payload(self):
+        """Missing instances should return a structured error payload."""
+        with patch(
+            "redis_sre_agent.core.instance_mutation_helpers.get_instances",
+            new_callable=AsyncMock,
+            return_value=[],
+        ):
+            result = await delete_instance_helper("missing", confirm=True)
+
+        assert result == {"error": "Instance not found", "id": "missing"}
+
+    @pytest.mark.asyncio
+    async def test_delete_instance_helper_deletes_and_swallows_index_failures(self):
+        """Deletes should persist even if index cleanup fails."""
+        with (
+            patch(
+                "redis_sre_agent.core.instance_mutation_helpers.get_instances",
+                new_callable=AsyncMock,
+                return_value=[_build_instance()],
+            ),
+            patch(
+                "redis_sre_agent.core.instance_mutation_helpers.save_instances",
+                new_callable=AsyncMock,
+                return_value=True,
+            ) as mock_save,
+            patch(
+                "redis_sre_agent.core.instance_mutation_helpers.delete_instance_index_doc",
+                new_callable=AsyncMock,
+                side_effect=RuntimeError("boom"),
+            ) as mock_delete_index,
+        ):
+            result = await delete_instance_helper("redis-prod-1", confirm=True)
+
+        assert result == {"id": "redis-prod-1", "status": "deleted"}
+        assert mock_save.await_args.args[0] == []
+        mock_delete_index.assert_awaited_once_with("redis-prod-1")
+
+    @pytest.mark.asyncio
+    async def test_delete_instance_helper_raises_for_save_failure(self):
+        """Delete save failures should raise for the wrapper."""
+        with (
+            patch(
+                "redis_sre_agent.core.instance_mutation_helpers.get_instances",
+                new_callable=AsyncMock,
+                return_value=[_build_instance()],
+            ),
+            patch(
+                "redis_sre_agent.core.instance_mutation_helpers.save_instances",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+        ):
+            with pytest.raises(RuntimeError, match="Failed to save after deletion"):
+                await delete_instance_helper("redis-prod-1", confirm=True)
+
+
+class TestInstanceMutationInternals:
+    """Test small internal helpers that feed the mutation paths."""
+
+    def test_normalize_cluster_id_handles_none_and_blank(self):
+        """Cluster ids should trim and collapse blanks to None."""
+        assert _normalize_cluster_id(None) is None
+        assert _normalize_cluster_id("  ") is None
+        assert _normalize_cluster_id(" cluster-123 ") == "cluster-123"

--- a/tests/unit/core/test_pipeline_execution_helpers.py
+++ b/tests/unit/core/test_pipeline_execution_helpers.py
@@ -1,0 +1,520 @@
+"""Tests for task-backed pipeline execution helpers."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from redis_sre_agent.core.pipeline_execution_helpers import (
+    _build_pipeline_task_message,
+    get_redis_url,
+    queue_pipeline_operation_task,
+    run_pipeline_operation_helper,
+)
+
+
+class TestRunPipelineOperationHelper:
+    """Test pipeline operation execution helpers."""
+
+    @pytest.mark.asyncio
+    async def test_run_scrape_operation(self):
+        """Scrape operation should build scraper config and run the orchestrator."""
+        mock_orchestrator = MagicMock()
+        mock_orchestrator.run_scraping_pipeline = AsyncMock(
+            return_value={"batch_date": "2026-03-25", "total_documents": 4, "success": True}
+        )
+        emitter = AsyncMock()
+
+        with patch(
+            "redis_sre_agent.core.pipeline_execution_helpers.PipelineOrchestrator",
+            return_value=mock_orchestrator,
+        ) as mock_cls:
+            result = await run_pipeline_operation_helper(
+                operation="scrape",
+                artifacts_path="/tmp/artifacts",
+                scrapers=["redis_docs"],
+                latest_only=True,
+                docs_path="/tmp/docs",
+                progress_emitter=emitter,
+            )
+
+        assert result["operation"] == "scrape"
+        assert result["total_documents"] == 4
+        mock_cls.assert_called_once_with(
+            "/tmp/artifacts",
+            {
+                "redis_docs": {"latest_only": True},
+                "redis_docs_local": {"latest_only": True, "docs_repo_path": "/tmp/docs"},
+            },
+            scrapers=["redis_docs"],
+        )
+        mock_orchestrator.run_scraping_pipeline.assert_awaited_once_with(["redis_docs"])
+        assert emitter.emit.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_run_ingest_operation(self):
+        """Ingest operation should pass latest-only config and batch date."""
+        mock_orchestrator = MagicMock()
+        mock_orchestrator.run_ingestion_pipeline = AsyncMock(
+            return_value={"batch_date": "2026-03-25", "chunks_indexed": 12, "success": True}
+        )
+
+        with patch(
+            "redis_sre_agent.core.pipeline_execution_helpers.PipelineOrchestrator",
+            return_value=mock_orchestrator,
+        ) as mock_cls:
+            result = await run_pipeline_operation_helper(
+                operation="ingest",
+                batch_date="2026-03-25",
+                artifacts_path="/tmp/artifacts",
+                latest_only=True,
+            )
+
+        assert result["operation"] == "ingest"
+        assert result["chunks_indexed"] == 12
+        mock_cls.assert_called_once_with(
+            "/tmp/artifacts",
+            {"ingestion": {"latest_only": True}},
+        )
+        mock_orchestrator.run_ingestion_pipeline.assert_awaited_once_with("2026-03-25")
+
+    @pytest.mark.asyncio
+    async def test_run_full_operation(self):
+        """Full operation should configure scrape and ingest settings."""
+        mock_orchestrator = MagicMock()
+        mock_orchestrator.run_full_pipeline = AsyncMock(
+            return_value={"batch_date": "2026-03-25", "success": True}
+        )
+
+        with patch(
+            "redis_sre_agent.core.pipeline_execution_helpers.PipelineOrchestrator",
+            return_value=mock_orchestrator,
+        ) as mock_cls:
+            result = await run_pipeline_operation_helper(
+                operation="full",
+                artifacts_path="/tmp/artifacts",
+                scrapers=["redis_docs_local"],
+                latest_only=True,
+                docs_path="/tmp/docs",
+            )
+
+        assert result["operation"] == "full"
+        mock_cls.assert_called_once_with(
+            "/tmp/artifacts",
+            {
+                "redis_docs": {"latest_only": True},
+                "redis_docs_local": {"latest_only": True, "docs_repo_path": "/tmp/docs"},
+                "ingestion": {"latest_only": True},
+            },
+            scrapers=["redis_docs_local"],
+        )
+        mock_orchestrator.run_full_pipeline.assert_awaited_once_with(["redis_docs_local"])
+
+    @pytest.mark.asyncio
+    async def test_run_cleanup_operation(self):
+        """Cleanup operation should run through the orchestrator."""
+        mock_orchestrator = MagicMock()
+        mock_orchestrator.cleanup_old_batches = AsyncMock(
+            return_value={"cutoff_date": "2026-03-01", "batches_removed": ["2026-02-01"]}
+        )
+
+        with patch(
+            "redis_sre_agent.core.pipeline_execution_helpers.PipelineOrchestrator",
+            return_value=mock_orchestrator,
+        ) as mock_cls:
+            result = await run_pipeline_operation_helper(
+                operation="cleanup",
+                artifacts_path="/tmp/artifacts",
+                keep_days=14,
+            )
+
+        assert result["operation"] == "cleanup"
+        assert result["batches_removed"] == ["2026-02-01"]
+        mock_cls.assert_called_once_with("/tmp/artifacts")
+        mock_orchestrator.cleanup_old_batches.assert_awaited_once_with(14)
+
+    @pytest.mark.asyncio
+    async def test_run_runbooks_list_urls(self):
+        """Runbooks list mode should return configured URLs directly."""
+        mock_generator = MagicMock()
+        mock_generator.get_configured_urls.return_value = ["https://example.com/runbook"]
+        mock_orchestrator = MagicMock(scrapers={"runbook_generator": mock_generator})
+
+        with patch(
+            "redis_sre_agent.core.pipeline_execution_helpers.PipelineOrchestrator",
+            return_value=mock_orchestrator,
+        ) as mock_cls:
+            result = await run_pipeline_operation_helper(
+                operation="runbooks",
+                artifacts_path="/tmp/artifacts",
+                list_urls=True,
+            )
+
+        assert result == {
+            "operation": "runbooks",
+            "mode": "list_urls",
+            "configured_urls": ["https://example.com/runbook"],
+        }
+        mock_cls.assert_called_once_with("/tmp/artifacts", scrapers=["runbook_generator"])
+
+    @pytest.mark.asyncio
+    async def test_run_runbooks_test_url(self):
+        """Runbooks test mode should proxy URL extraction results."""
+        mock_generator = MagicMock()
+        mock_generator.test_url_extraction = AsyncMock(
+            return_value={"url": "https://example.com", "success": True}
+        )
+        mock_orchestrator = MagicMock(scrapers={"runbook_generator": mock_generator})
+
+        with patch(
+            "redis_sre_agent.core.pipeline_execution_helpers.PipelineOrchestrator",
+            return_value=mock_orchestrator,
+        ):
+            result = await run_pipeline_operation_helper(
+                operation="runbooks",
+                artifacts_path="/tmp/artifacts",
+                test_url="https://example.com",
+            )
+
+        assert result == {
+            "operation": "runbooks",
+            "mode": "test_url",
+            "url": "https://example.com",
+            "result": {"url": "https://example.com", "success": True},
+        }
+        mock_generator.test_url_extraction.assert_awaited_once_with("https://example.com")
+
+    @pytest.mark.asyncio
+    async def test_run_runbooks_single_url(self):
+        """Runbooks single-url mode should add the URL and run a dedicated job."""
+        primary_generator = MagicMock()
+        primary_generator.add_runbook_url = AsyncMock(return_value=True)
+        primary_generator.config = {"runbook_urls": ["https://default.example"]}
+        primary_orchestrator = MagicMock(scrapers={"runbook_generator": primary_generator})
+
+        single_generator = MagicMock()
+        single_generator.run_scraping_job = AsyncMock(
+            return_value={"documents_scraped": 2, "documents_saved": 2}
+        )
+        single_orchestrator = MagicMock(scrapers={"runbook_generator": single_generator})
+
+        with patch(
+            "redis_sre_agent.core.pipeline_execution_helpers.PipelineOrchestrator",
+            side_effect=[primary_orchestrator, single_orchestrator],
+        ) as mock_cls:
+            result = await run_pipeline_operation_helper(
+                operation="runbooks",
+                artifacts_path="/tmp/artifacts",
+                url="https://example.com/runbook",
+            )
+
+        assert result == {
+            "operation": "runbooks",
+            "mode": "single_url",
+            "url": "https://example.com/runbook",
+            "url_added": True,
+            "documents_scraped": 2,
+            "documents_saved": 2,
+        }
+        primary_generator.add_runbook_url.assert_awaited_once_with("https://example.com/runbook")
+        assert mock_cls.call_count == 2
+        single_generator.run_scraping_job.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_run_runbooks_default_generation(self):
+        """Runbooks default mode should process configured URLs."""
+        mock_generator = MagicMock()
+        mock_generator.run_scraping_job = AsyncMock(return_value={"documents_scraped": 3})
+        mock_orchestrator = MagicMock(scrapers={"runbook_generator": mock_generator})
+
+        with patch(
+            "redis_sre_agent.core.pipeline_execution_helpers.PipelineOrchestrator",
+            return_value=mock_orchestrator,
+        ):
+            result = await run_pipeline_operation_helper(
+                operation="runbooks",
+                artifacts_path="/tmp/artifacts",
+            )
+
+        assert result == {
+            "operation": "runbooks",
+            "mode": "configured_urls",
+            "documents_scraped": 3,
+        }
+        mock_generator.run_scraping_job.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_run_prepare_sources_prepare_only(self, tmp_path):
+        """Prepare-sources mode should prepare artifacts without ingesting them."""
+        source_dir = tmp_path / "source_documents"
+        source_dir.mkdir()
+        (source_dir / "guide.md").write_text("# Guide\n", encoding="utf-8")
+        (source_dir / "README.md").write_text("# Ignore me\n", encoding="utf-8")
+
+        mock_pipeline = MagicMock()
+        mock_pipeline.prepare_source_artifacts = AsyncMock(return_value=1)
+        mock_pipeline.ingest_prepared_batch = AsyncMock()
+
+        with patch(
+            "redis_sre_agent.core.pipeline_execution_helpers.IngestionPipeline",
+            return_value=mock_pipeline,
+        ):
+            result = await run_pipeline_operation_helper(
+                operation="prepare_sources",
+                source_dir=str(source_dir),
+                batch_date="2026-03-25",
+                prepare_only=True,
+                artifacts_path=str(tmp_path / "artifacts"),
+            )
+
+        assert result["operation"] == "prepare_sources"
+        assert result["prepared_count"] == 1
+        assert result["batch_date"] == "2026-03-25"
+        assert result["ingestion"] == {"performed": False}
+        assert result["source_documents"] == ["guide.md"]
+        mock_pipeline.ingest_prepared_batch.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_run_prepare_sources_with_ingestion(self, tmp_path):
+        """Prepare-sources should summarize ingestion results when requested."""
+        source_dir = tmp_path / "source_documents"
+        source_dir.mkdir()
+        (source_dir / "a.md").write_text("# A\n", encoding="utf-8")
+        (source_dir / "nested").mkdir()
+        (source_dir / "nested" / "b.md").write_text("# B\n", encoding="utf-8")
+
+        mock_pipeline = MagicMock()
+        mock_pipeline.prepare_source_artifacts = AsyncMock(return_value=2)
+        mock_pipeline.ingest_prepared_batch = AsyncMock(
+            return_value=[
+                {"status": "success", "chunks_indexed": 4},
+                {"status": "error", "error": "failed"},
+            ]
+        )
+
+        with patch(
+            "redis_sre_agent.core.pipeline_execution_helpers.IngestionPipeline",
+            return_value=mock_pipeline,
+        ):
+            result = await run_pipeline_operation_helper(
+                operation="prepare_sources",
+                source_dir=str(source_dir),
+                artifacts_path=str(tmp_path / "artifacts"),
+            )
+
+        assert result["operation"] == "prepare_sources"
+        assert result["prepared_count"] == 2
+        assert result["ingestion"]["performed"] is True
+        assert result["ingestion"]["successful_documents"] == 1
+        assert result["ingestion"]["failed_documents"] == 1
+        assert result["ingestion"]["total_chunks_indexed"] == 4
+        assert result["source_documents"] == ["a.md", "nested/b.md"]
+
+    @pytest.mark.asyncio
+    async def test_run_prepare_sources_requires_existing_directory(self, tmp_path):
+        """Prepare-sources should fail on missing directories."""
+        with pytest.raises(ValueError, match="does not exist"):
+            await run_pipeline_operation_helper(
+                operation="prepare_sources",
+                source_dir=str(tmp_path / "missing"),
+            )
+
+    @pytest.mark.asyncio
+    async def test_run_prepare_sources_requires_markdown_files(self, tmp_path):
+        """Prepare-sources should fail when no markdown files are present."""
+        source_dir = tmp_path / "source_documents"
+        source_dir.mkdir()
+        (source_dir / "README.md").write_text("# Ignore me\n", encoding="utf-8")
+
+        with pytest.raises(ValueError, match="No markdown files found"):
+            await run_pipeline_operation_helper(
+                operation="prepare_sources",
+                source_dir=str(source_dir),
+            )
+
+    @pytest.mark.asyncio
+    async def test_run_prepare_sources_validates_batch_date(self, tmp_path):
+        """Prepare-sources should validate batch-date formatting."""
+        source_dir = tmp_path / "source_documents"
+        source_dir.mkdir()
+        (source_dir / "guide.md").write_text("# Guide\n", encoding="utf-8")
+
+        with pytest.raises(ValueError, match="Invalid batch date format"):
+            await run_pipeline_operation_helper(
+                operation="prepare_sources",
+                source_dir=str(source_dir),
+                batch_date="03-25-2026",
+            )
+
+    @pytest.mark.asyncio
+    async def test_run_runbooks_rejects_multiple_modes(self):
+        """Runbooks helper should reject mutually-exclusive modes."""
+        with pytest.raises(ValueError, match="Only one of"):
+            await run_pipeline_operation_helper(
+                operation="runbooks",
+                url="https://example.com",
+                test_url="https://example.com/test",
+            )
+
+    @pytest.mark.asyncio
+    async def test_run_unknown_operation(self):
+        """Unknown operations should fail clearly."""
+        with pytest.raises(ValueError, match="Unknown pipeline operation"):
+            await run_pipeline_operation_helper(operation="unknown")
+
+
+class TestQueuePipelineOperationTask:
+    """Test task queueing helpers for pipeline operations."""
+
+    @pytest.mark.asyncio
+    async def test_queue_pipeline_operation_task(self):
+        """Queue helper should create a task and enqueue the Docket job."""
+        mock_client = AsyncMock()
+        mock_result = {
+            "thread_id": "thread-123",
+            "task_id": "task-456",
+            "status": "queued",
+            "message": "Task created",
+        }
+
+        with (
+            patch(
+                "redis_sre_agent.core.pipeline_execution_helpers.get_redis_client",
+                return_value=mock_client,
+            ),
+            patch(
+                "redis_sre_agent.core.pipeline_execution_helpers.create_task",
+                new_callable=AsyncMock,
+            ) as mock_create_task,
+            patch(
+                "redis_sre_agent.core.pipeline_execution_helpers.get_redis_url",
+                new_callable=AsyncMock,
+                return_value="redis://test",
+            ),
+            patch("redis_sre_agent.core.pipeline_execution_helpers.Docket") as mock_docket,
+        ):
+            mock_create_task.return_value = mock_result
+            docket_instance = AsyncMock()
+            docket_instance.__aenter__.return_value = docket_instance
+            docket_instance.__aexit__.return_value = False
+            queued = AsyncMock()
+            docket_instance.add.return_value = queued
+            mock_docket.return_value = docket_instance
+
+            result = await queue_pipeline_operation_task(
+                operation="scrape",
+                user_id="user-123",
+                artifacts_path="/tmp/artifacts",
+                scrapers=["redis_docs"],
+                latest_only=True,
+            )
+
+        assert result == {
+            "thread_id": "thread-123",
+            "task_id": "task-456",
+            "status": "queued",
+            "message": "Pipeline scrape task queued for processing",
+            "operation": "scrape",
+        }
+        mock_create_task.assert_awaited_once_with(
+            message="Run pipeline scrape",
+            context={
+                "task_type": "pipeline",
+                "pipeline_operation": "scrape",
+                "user_id": "user-123",
+            },
+            redis_client=mock_client,
+        )
+        queued.assert_awaited_once_with(
+            operation="scrape",
+            task_id="task-456",
+            thread_id="thread-123",
+            artifacts_path="/tmp/artifacts",
+            scrapers=["redis_docs"],
+            latest_only=True,
+        )
+
+    @pytest.mark.asyncio
+    async def test_queue_pipeline_operation_task_formats_messages(self):
+        """Queue helper should produce operation-specific task subjects."""
+        mock_client = AsyncMock()
+        mock_result = {
+            "thread_id": "thread-123",
+            "task_id": "task-456",
+            "status": "queued",
+        }
+
+        with (
+            patch(
+                "redis_sre_agent.core.pipeline_execution_helpers.get_redis_client",
+                return_value=mock_client,
+            ),
+            patch(
+                "redis_sre_agent.core.pipeline_execution_helpers.create_task",
+                new_callable=AsyncMock,
+            ) as mock_create_task,
+            patch(
+                "redis_sre_agent.core.pipeline_execution_helpers.get_redis_url",
+                new_callable=AsyncMock,
+                return_value="redis://test",
+            ),
+            patch("redis_sre_agent.core.pipeline_execution_helpers.Docket") as mock_docket,
+        ):
+            mock_create_task.return_value = mock_result
+            docket_instance = AsyncMock()
+            docket_instance.__aenter__.return_value = docket_instance
+            docket_instance.__aexit__.return_value = False
+            docket_instance.add.return_value = AsyncMock()
+            mock_docket.return_value = docket_instance
+
+            await queue_pipeline_operation_task(
+                operation="cleanup",
+                keep_days=7,
+                artifacts_path="/tmp/artifacts",
+            )
+
+        assert mock_create_task.call_args.kwargs["message"] == (
+            "Cleanup pipeline batches older than 7 days"
+        )
+
+
+class TestPipelineExecutionHelperUtilities:
+    """Test small helper utilities for full branch coverage."""
+
+    def test_build_pipeline_task_message_variants(self):
+        """Task subjects should match the requested pipeline operation."""
+        assert _build_pipeline_task_message("ingest", {}) == "Run pipeline ingest"
+        assert (
+            _build_pipeline_task_message("ingest", {"batch_date": "2026-03-25"})
+            == "Run pipeline ingest for batch 2026-03-25"
+        )
+        assert (
+            _build_pipeline_task_message("prepare_sources", {})
+            == "Prepare source documents from source_documents"
+        )
+        assert (
+            _build_pipeline_task_message("runbooks", {"url": "https://example.com"})
+            == "Generate pipeline runbooks for https://example.com"
+        )
+        assert (
+            _build_pipeline_task_message("runbooks", {"test_url": "https://example.com/test"})
+            == "Test pipeline runbook extraction for https://example.com/test"
+        )
+        assert (
+            _build_pipeline_task_message("runbooks", {"list_urls": True})
+            == "List configured pipeline runbook URLs"
+        )
+        assert _build_pipeline_task_message("runbooks", {}) == "Generate pipeline runbooks"
+        assert _build_pipeline_task_message("scrape", {}) == "Run pipeline scrape"
+
+    @pytest.mark.asyncio
+    async def test_get_redis_url_wrapper(self):
+        """Redis URL wrapper should delegate to the Docket task helper."""
+        with patch(
+            "redis_sre_agent.core.docket_tasks.get_redis_url",
+            new_callable=AsyncMock,
+            return_value="redis://test",
+        ) as mock_get:
+            result = await get_redis_url()
+
+        assert result == "redis://test"
+        mock_get.assert_awaited_once()

--- a/tests/unit/core/test_pipeline_helpers.py
+++ b/tests/unit/core/test_pipeline_helpers.py
@@ -1,0 +1,102 @@
+"""Tests for pipeline helper functions."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from redis_sre_agent.core.pipeline_helpers import (
+    get_pipeline_batch_helper,
+    get_pipeline_status_helper,
+)
+
+
+@pytest.mark.asyncio
+async def test_get_pipeline_status_helper_delegates_to_orchestrator():
+    """Status helper returns orchestrator payload."""
+    from unittest.mock import AsyncMock, patch
+
+    mock_orchestrator = AsyncMock()
+    mock_orchestrator.get_pipeline_status.return_value = {"available_batches": ["2026-03-25"]}
+
+    with patch(
+        "redis_sre_agent.core.pipeline_helpers.PipelineOrchestrator",
+        return_value=mock_orchestrator,
+    ) as mock_cls:
+        result = await get_pipeline_status_helper("/tmp/artifacts")
+
+        assert result == {"available_batches": ["2026-03-25"]}
+        mock_cls.assert_called_once_with("/tmp/artifacts")
+        mock_orchestrator.get_pipeline_status.assert_awaited_once_with()
+
+
+@pytest.mark.asyncio
+async def test_get_pipeline_batch_helper_missing_manifest(tmp_path):
+    """Batch helper returns error payload when manifest is absent."""
+    result = await get_pipeline_batch_helper("2026-03-25", artifacts_path=str(tmp_path))
+
+    assert result["batch_date"] == "2026-03-25"
+    assert "error" in result
+
+
+@pytest.mark.asyncio
+async def test_get_pipeline_batch_helper_without_ingestion_manifest(tmp_path):
+    """Batch helper reports not_ingested when only batch manifest exists."""
+    batch_dir = tmp_path / "2026-03-25"
+    batch_dir.mkdir(parents=True)
+    (batch_dir / "batch_manifest.json").write_text(
+        json.dumps(
+            {
+                "created_at": "2026-03-25T00:00:00+00:00",
+                "total_documents": 3,
+                "categories": {"oss": 2},
+                "document_types": {"documentation": 3},
+                "sources": ["https://redis.io"],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = await get_pipeline_batch_helper("2026-03-25", artifacts_path=str(tmp_path))
+
+    assert result["total_documents"] == 3
+    assert result["ingestion"]["available"] is False
+    assert result["ingestion"]["status"] == "not_ingested"
+
+
+@pytest.mark.asyncio
+async def test_get_pipeline_batch_helper_with_ingestion_manifest(tmp_path):
+    """Batch helper includes ingestion details when manifest exists."""
+    batch_dir = tmp_path / "2026-03-25"
+    batch_dir.mkdir(parents=True)
+    (batch_dir / "batch_manifest.json").write_text(
+        json.dumps(
+            {
+                "created_at": "2026-03-25T00:00:00+00:00",
+                "total_documents": 5,
+                "categories": {"oss": 4},
+                "document_types": {"documentation": 5},
+                "sources": ["https://redis.io"],
+            }
+        ),
+        encoding="utf-8",
+    )
+    (batch_dir / "ingestion_manifest.json").write_text(
+        json.dumps(
+            {
+                "success": True,
+                "documents_processed": 5,
+                "chunks_created": 12,
+                "chunks_indexed": 10,
+                "categories_processed": {"oss": {"documents_processed": 5}},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = await get_pipeline_batch_helper("2026-03-25", artifacts_path=str(tmp_path))
+
+    assert result["ingestion"]["available"] is True
+    assert result["ingestion"]["status"] == "success"
+    assert result["ingestion"]["chunks_created"] == 12

--- a/tests/unit/core/test_query_helpers.py
+++ b/tests/unit/core/test_query_helpers.py
@@ -1,0 +1,311 @@
+"""Tests for unified query MCP helpers."""
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from redis_sre_agent.core.query_helpers import (
+    _get_query_task_callable,
+    _normalize_agent_selection,
+    get_redis_url,
+    queue_query_task_helper,
+)
+from redis_sre_agent.core.tasks import TaskStatus
+
+
+class TestNormalizeAgentSelection:
+    """Test query agent normalization."""
+
+    def test_normalize_agent_selection_accepts_supported_values(self):
+        assert _normalize_agent_selection(None) == "auto"
+        assert _normalize_agent_selection("AUTO") == "auto"
+        assert _normalize_agent_selection("chat") == "chat"
+        assert _normalize_agent_selection("triage") == "triage"
+        assert _normalize_agent_selection("knowledge") == "knowledge"
+
+    def test_normalize_agent_selection_rejects_invalid_values(self):
+        with pytest.raises(ValueError, match="Invalid agent"):
+            _normalize_agent_selection("bogus")
+
+
+class TestHelperShims:
+    """Test import-cycle shims used by query helpers."""
+
+    @pytest.mark.asyncio
+    async def test_get_redis_url_delegates(self):
+        with patch(
+            "redis_sre_agent.core.docket_tasks.get_redis_url",
+            new_callable=AsyncMock,
+            return_value="redis://localhost:6379/0",
+        ) as mock_get_redis_url:
+            result = await get_redis_url()
+
+        assert result == "redis://localhost:6379/0"
+        mock_get_redis_url.assert_awaited_once_with()
+
+    def test_get_query_task_callable_returns_process_agent_turn(self):
+        from redis_sre_agent.core.docket_tasks import process_agent_turn
+
+        assert _get_query_task_callable() is process_agent_turn
+
+
+class TestQueueQueryTaskHelper:
+    """Test unified query task queuing."""
+
+    @pytest.mark.asyncio
+    async def test_queue_query_task_helper_creates_and_submits_task(self):
+        redis_client = AsyncMock()
+        mock_manager = AsyncMock()
+        mock_manager.get_metadata = AsyncMock(return_value=SimpleNamespace(filename="pkg.tar.gz"))
+        mock_manager.extract = AsyncMock(return_value=Path("/tmp/extracted/pkg-1"))
+        task_callable = AsyncMock()
+        docket_instance = AsyncMock()
+        docket_instance.__aenter__.return_value = docket_instance
+        docket_instance.__aexit__.return_value = False
+        docket_instance.add.return_value = task_callable
+
+        with (
+            patch("redis_sre_agent.core.query_helpers.get_redis_client", return_value=redis_client),
+            patch(
+                "redis_sre_agent.core.query_helpers.get_instance_by_id",
+                new_callable=AsyncMock,
+                return_value=SimpleNamespace(id="redis-prod-1"),
+            ),
+            patch(
+                "redis_sre_agent.core.query_helpers.get_support_package_manager",
+                return_value=mock_manager,
+            ),
+            patch(
+                "redis_sre_agent.core.query_helpers.create_task",
+                new_callable=AsyncMock,
+                return_value={
+                    "thread_id": "thread-123",
+                    "task_id": "task-123",
+                    "status": TaskStatus.QUEUED,
+                },
+            ) as mock_create_task,
+            patch(
+                "redis_sre_agent.core.query_helpers.get_redis_url",
+                new_callable=AsyncMock,
+                return_value="redis://localhost:6379/0",
+            ),
+            patch(
+                "redis_sre_agent.core.query_helpers._get_query_task_callable",
+                return_value="process-agent-turn",
+            ),
+            patch("redis_sre_agent.core.query_helpers.Docket", return_value=docket_instance),
+        ):
+            result = await queue_query_task_helper(
+                query="Investigate memory usage",
+                instance_id="redis-prod-1",
+                support_package_id="pkg-1",
+                user_id="user-1",
+                agent="auto",
+            )
+
+        assert result == {
+            "thread_id": "thread-123",
+            "task_id": "task-123",
+            "status": "queued",
+            "message": "Query task queued for processing",
+            "agent": "auto",
+        }
+        mock_create_task.assert_awaited_once_with(
+            message="Investigate memory usage",
+            thread_id=None,
+            context={
+                "instance_id": "redis-prod-1",
+                "support_package_id": "pkg-1",
+                "support_package_path": "/tmp/extracted/pkg-1",
+                "user_id": "user-1",
+            },
+            redis_client=redis_client,
+        )
+        task_callable.assert_awaited_once_with(
+            thread_id="thread-123",
+            message="Investigate memory usage",
+            context={
+                "instance_id": "redis-prod-1",
+                "support_package_id": "pkg-1",
+                "support_package_path": "/tmp/extracted/pkg-1",
+                "user_id": "user-1",
+            },
+            task_id="task-123",
+        )
+
+    @pytest.mark.asyncio
+    async def test_queue_query_task_helper_supports_thread_continuation_and_agent_override(self):
+        redis_client = AsyncMock()
+        thread_manager = AsyncMock()
+        thread_manager.get_thread = AsyncMock(return_value=SimpleNamespace(thread_id="thread-123"))
+        task_callable = AsyncMock()
+        docket_instance = AsyncMock()
+        docket_instance.__aenter__.return_value = docket_instance
+        docket_instance.__aexit__.return_value = False
+        docket_instance.add.return_value = task_callable
+
+        with (
+            patch("redis_sre_agent.core.query_helpers.get_redis_client", return_value=redis_client),
+            patch(
+                "redis_sre_agent.core.query_helpers.ThreadManager",
+                return_value=thread_manager,
+            ),
+            patch(
+                "redis_sre_agent.core.query_helpers.create_task",
+                new_callable=AsyncMock,
+                return_value={
+                    "thread_id": "thread-123",
+                    "task_id": "task-123",
+                    "status": TaskStatus.QUEUED,
+                },
+            ) as mock_create_task,
+            patch(
+                "redis_sre_agent.core.query_helpers.get_redis_url",
+                new_callable=AsyncMock,
+                return_value="redis://localhost:6379/0",
+            ),
+            patch(
+                "redis_sre_agent.core.query_helpers._get_query_task_callable",
+                return_value="process-agent-turn",
+            ),
+            patch("redis_sre_agent.core.query_helpers.Docket", return_value=docket_instance),
+        ):
+            result = await queue_query_task_helper(
+                query="Follow up",
+                thread_id="thread-123",
+                agent="knowledge",
+            )
+
+        assert result["agent"] == "knowledge"
+        mock_create_task.assert_awaited_once_with(
+            message="Follow up",
+            thread_id="thread-123",
+            context=None,
+            redis_client=redis_client,
+        )
+        task_callable.assert_awaited_once_with(
+            thread_id="thread-123",
+            message="Follow up",
+            context={"requested_agent_type": "knowledge"},
+            task_id="task-123",
+        )
+
+    @pytest.mark.asyncio
+    async def test_queue_query_task_helper_supports_cluster_context_and_awaitable_docket_add(self):
+        redis_client = AsyncMock()
+        task_callable = AsyncMock()
+        docket_instance = AsyncMock()
+        docket_instance.__aenter__.return_value = docket_instance
+        docket_instance.__aexit__.return_value = False
+        docket_instance.add = AsyncMock(return_value=task_callable)
+
+        with (
+            patch("redis_sre_agent.core.query_helpers.get_redis_client", return_value=redis_client),
+            patch(
+                "redis_sre_agent.core.query_helpers.get_cluster_by_id",
+                new_callable=AsyncMock,
+                return_value=SimpleNamespace(id="cluster-1"),
+            ),
+            patch(
+                "redis_sre_agent.core.query_helpers.create_task",
+                new_callable=AsyncMock,
+                return_value={
+                    "thread_id": "thread-123",
+                    "task_id": "task-123",
+                    "status": TaskStatus.QUEUED,
+                },
+            ) as mock_create_task,
+            patch(
+                "redis_sre_agent.core.query_helpers.get_redis_url",
+                new_callable=AsyncMock,
+                return_value="redis://localhost:6379/0",
+            ),
+            patch(
+                "redis_sre_agent.core.query_helpers._get_query_task_callable",
+                return_value="process-agent-turn",
+            ),
+            patch("redis_sre_agent.core.query_helpers.Docket", return_value=docket_instance),
+        ):
+            result = await queue_query_task_helper(
+                query="Check cluster",
+                cluster_id="cluster-1",
+            )
+
+        assert result["agent"] == "auto"
+        mock_create_task.assert_awaited_once_with(
+            message="Check cluster",
+            thread_id=None,
+            context={"cluster_id": "cluster-1"},
+            redis_client=redis_client,
+        )
+        task_callable.assert_awaited_once_with(
+            thread_id="thread-123",
+            message="Check cluster",
+            context={"cluster_id": "cluster-1"},
+            task_id="task-123",
+        )
+
+    @pytest.mark.asyncio
+    async def test_queue_query_task_helper_rejects_multiple_targets(self):
+        with pytest.raises(ValueError, match="only one of instance_id or cluster_id"):
+            await queue_query_task_helper(
+                query="Investigate",
+                instance_id="redis-prod-1",
+                cluster_id="cluster-1",
+            )
+
+    @pytest.mark.asyncio
+    async def test_queue_query_task_helper_rejects_missing_thread(self):
+        redis_client = AsyncMock()
+        thread_manager = AsyncMock()
+        thread_manager.get_thread = AsyncMock(return_value=None)
+
+        with (
+            patch("redis_sre_agent.core.query_helpers.get_redis_client", return_value=redis_client),
+            patch(
+                "redis_sre_agent.core.query_helpers.ThreadManager",
+                return_value=thread_manager,
+            ),
+            pytest.raises(ValueError, match="Thread thread-404 not found"),
+        ):
+            await queue_query_task_helper(query="Follow up", thread_id="thread-404")
+
+    @pytest.mark.asyncio
+    async def test_queue_query_task_helper_rejects_missing_instance(self):
+        with (
+            patch(
+                "redis_sre_agent.core.query_helpers.get_instance_by_id",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            pytest.raises(ValueError, match="Instance not found: redis-missing"),
+        ):
+            await queue_query_task_helper(query="Investigate", instance_id="redis-missing")
+
+    @pytest.mark.asyncio
+    async def test_queue_query_task_helper_rejects_missing_cluster(self):
+        with (
+            patch(
+                "redis_sre_agent.core.query_helpers.get_cluster_by_id",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            pytest.raises(ValueError, match="Cluster not found: cluster-missing"),
+        ):
+            await queue_query_task_helper(query="Investigate", cluster_id="cluster-missing")
+
+    @pytest.mark.asyncio
+    async def test_queue_query_task_helper_rejects_missing_support_package(self):
+        mock_manager = AsyncMock()
+        mock_manager.get_metadata = AsyncMock(return_value=None)
+
+        with (
+            patch(
+                "redis_sre_agent.core.query_helpers.get_support_package_manager",
+                return_value=mock_manager,
+            ),
+            pytest.raises(ValueError, match="Support package not found: pkg-missing"),
+        ):
+            await queue_query_task_helper(query="Investigate", support_package_id="pkg-missing")

--- a/tests/unit/core/test_runbook_execution_helpers.py
+++ b/tests/unit/core/test_runbook_execution_helpers.py
@@ -1,0 +1,536 @@
+"""Tests for runbook execution helpers."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from redis_sre_agent.agent.runbook_generator import (
+    GeneratedRunbook,
+    ResearchResult,
+    RunbookEvaluation,
+)
+from redis_sre_agent.core.runbook_execution_helpers import (
+    _build_runbook_task_message,
+    get_redis_url,
+    queue_runbook_operation_task,
+    run_runbook_operation_helper,
+)
+
+
+class TestRunRunbookOperationHelper:
+    """Test shared runbook execution helpers."""
+
+    @pytest.fixture
+    def generated_runbook(self):
+        return GeneratedRunbook(
+            title="Redis Memory Pressure - Operational Runbook",
+            content="# Redis Memory Pressure\n\nRunbook content",
+            category="operational_runbook",
+            severity="warning",
+            sources=["source-1"],
+            generation_timestamp="2026-03-25T12:00:00",
+        )
+
+    @pytest.fixture
+    def evaluation(self):
+        return RunbookEvaluation(
+            overall_score=4.2,
+            technical_accuracy=4,
+            completeness=4,
+            actionability=5,
+            production_readiness=4,
+            strengths=["Clear structure"],
+            weaknesses=["Needs more examples"],
+            recommendations=["Add another remediation option"],
+            evaluation_summary="Production-ready with minor gaps.",
+        )
+
+    @pytest.fixture
+    def research(self):
+        return ResearchResult(
+            tavily_findings=[{"title": "External source"}],
+            knowledge_base_results=[{"title": "Internal source"}],
+            research_summary="Research summary",
+        )
+
+    @pytest.mark.asyncio
+    async def test_generate_runbook_saves_and_ingests(
+        self, tmp_path, generated_runbook, evaluation, research
+    ):
+        """Generate mode should serialize results, save output, and ingest on request."""
+        mock_generator = MagicMock()
+        mock_generator.generate_runbook = AsyncMock(
+            return_value={
+                "success": True,
+                "runbook": generated_runbook,
+                "evaluation": evaluation,
+                "research": research,
+                "iterations": 1,
+            }
+        )
+
+        with (
+            patch(
+                "redis_sre_agent.core.runbook_execution_helpers.RunbookGenerator",
+                return_value=mock_generator,
+            ),
+            patch(
+                "redis_sre_agent.core.runbook_execution_helpers.ingest_sre_document_helper",
+                new_callable=AsyncMock,
+            ) as mock_ingest,
+        ):
+            result = await run_runbook_operation_helper(
+                operation="generate",
+                topic="Memory Pressure",
+                scenario_description="Redis memory saturation on primaries",
+                output_file=str(tmp_path / "runbook.md"),
+                requirements=["Include INFO memory output"],
+                ingest=True,
+            )
+
+        assert result["operation"] == "generate"
+        assert result["success"] is True
+        assert result["saved_path"] == str(tmp_path / "runbook.md")
+        assert result["runbook"]["title"] == generated_runbook.title
+        assert result["evaluation"]["overall_score"] == 4.2
+        assert result["research"]["research_summary"] == "Research summary"
+        assert (tmp_path / "runbook.md").read_text(encoding="utf-8") == generated_runbook.content
+        mock_ingest.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_generate_runbook_without_save_or_ingest(
+        self, generated_runbook, evaluation, research
+    ):
+        """Generate mode should skip persistence when not requested."""
+        mock_generator = MagicMock()
+        mock_generator.generate_runbook = AsyncMock(
+            return_value={
+                "success": True,
+                "runbook": generated_runbook,
+                "evaluation": evaluation,
+                "research": research,
+                "iterations": 2,
+            }
+        )
+
+        with (
+            patch(
+                "redis_sre_agent.core.runbook_execution_helpers.RunbookGenerator",
+                return_value=mock_generator,
+            ),
+            patch(
+                "redis_sre_agent.core.runbook_execution_helpers.ingest_sre_document_helper",
+                new_callable=AsyncMock,
+            ) as mock_ingest,
+        ):
+            result = await run_runbook_operation_helper(
+                operation="generate",
+                topic="Replication Lag",
+                scenario_description="Replication delay during failover",
+                auto_save=False,
+                ingest=False,
+            )
+
+        assert result["saved_path"] is None
+        mock_ingest.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_generate_runbook_unsuccessful_result(self):
+        """Generate mode should return a structured failure payload."""
+        mock_generator = MagicMock()
+        mock_generator.generate_runbook = AsyncMock(
+            return_value={"success": False, "iterations": 0}
+        )
+
+        with patch(
+            "redis_sre_agent.core.runbook_execution_helpers.RunbookGenerator",
+            return_value=mock_generator,
+        ):
+            result = await run_runbook_operation_helper(
+                operation="generate",
+                topic="Replication Lag",
+                scenario_description="Replication delay during failover",
+            )
+
+        assert result == {"operation": "generate", "success": False, "iterations": 0}
+
+    @pytest.mark.asyncio
+    async def test_evaluate_runbooks_success(self, tmp_path, evaluation):
+        """Evaluate mode should score markdown files and optionally save JSON output."""
+        input_dir = tmp_path / "runbooks"
+        input_dir.mkdir()
+        (input_dir / "one.md").write_text("# One\n\ncontent", encoding="utf-8")
+        (input_dir / "two.md").write_text("# Two\n\ncontent", encoding="utf-8")
+
+        mock_generator = MagicMock()
+        mock_generator._evaluate_runbook = AsyncMock(side_effect=[evaluation, evaluation])
+
+        output_file = tmp_path / "evaluation.json"
+        with patch(
+            "redis_sre_agent.core.runbook_execution_helpers.RunbookGenerator",
+            return_value=mock_generator,
+        ):
+            result = await run_runbook_operation_helper(
+                operation="evaluate",
+                input_dir=str(input_dir),
+                output_file=str(output_file),
+            )
+
+        assert result["operation"] == "evaluate"
+        assert result["total_runbooks"] == 2
+        assert result["average_score"] == 4.2
+        assert result["excellent"] == 2
+        assert result["output_file"] == str(output_file)
+        assert output_file.exists()
+
+    @pytest.mark.asyncio
+    async def test_evaluate_runbooks_with_partial_failures(self, tmp_path, evaluation):
+        """Evaluate mode should collect file-level failures and continue."""
+        input_dir = tmp_path / "runbooks"
+        input_dir.mkdir()
+        (input_dir / "one.md").write_text("# One\n\ncontent", encoding="utf-8")
+        (input_dir / "two.md").write_text("# Two\n\ncontent", encoding="utf-8")
+
+        mock_generator = MagicMock()
+        mock_generator._evaluate_runbook = AsyncMock(
+            side_effect=[evaluation, Exception("evaluation failed")]
+        )
+
+        with patch(
+            "redis_sre_agent.core.runbook_execution_helpers.RunbookGenerator",
+            return_value=mock_generator,
+        ):
+            result = await run_runbook_operation_helper(
+                operation="evaluate",
+                input_dir=str(input_dir),
+            )
+
+        assert result["total_runbooks"] == 1
+        assert result["errors"] == [{"filename": "two.md", "error": "evaluation failed"}]
+
+    @pytest.mark.asyncio
+    async def test_evaluate_runbooks_requires_markdown_files(self, tmp_path):
+        """Evaluate mode should fail when no markdown files are available."""
+        input_dir = tmp_path / "runbooks"
+        input_dir.mkdir()
+
+        with pytest.raises(ValueError, match="No markdown files found"):
+            await run_runbook_operation_helper(operation="evaluate", input_dir=str(input_dir))
+
+    @pytest.mark.asyncio
+    async def test_runbook_unknown_operation(self):
+        """Unknown operations should fail clearly."""
+        with pytest.raises(ValueError, match="Unknown runbook operation"):
+            await run_runbook_operation_helper(operation="unknown")
+
+    @pytest.mark.asyncio
+    async def test_generate_runbook_requires_arguments(self):
+        """Generate mode should validate required inputs."""
+        with pytest.raises(ValueError, match="topic and scenario_description are required"):
+            await run_runbook_operation_helper(operation="generate", topic="Memory Pressure")
+
+    @pytest.mark.asyncio
+    async def test_generate_runbook_emits_progress(self, generated_runbook, evaluation, research):
+        """Generate mode should emit start and completion progress updates."""
+        mock_generator = MagicMock()
+        mock_generator.generate_runbook = AsyncMock(
+            return_value={
+                "success": True,
+                "runbook": generated_runbook,
+                "evaluation": evaluation,
+                "research": research,
+                "iterations": 1,
+            }
+        )
+        progress_emitter = AsyncMock()
+
+        with patch(
+            "redis_sre_agent.core.runbook_execution_helpers.RunbookGenerator",
+            return_value=mock_generator,
+        ):
+            await run_runbook_operation_helper(
+                operation="generate",
+                topic="Memory Pressure",
+                scenario_description="Redis memory saturation on primaries",
+                auto_save=False,
+                progress_emitter=progress_emitter,
+            )
+
+        assert progress_emitter.emit.await_count == 2
+
+
+class TestQueueRunbookOperationTask:
+    """Test runbook task queueing helper."""
+
+    @pytest.mark.asyncio
+    async def test_queue_runbook_operation_task(self):
+        """Queue helper should create a task and enqueue the Docket job."""
+        mock_client = AsyncMock()
+        mock_status = MagicMock()
+        mock_status.value = "queued"
+        mock_result = {
+            "thread_id": "thread-123",
+            "task_id": "task-456",
+            "status": mock_status,
+        }
+
+        with (
+            patch(
+                "redis_sre_agent.core.runbook_execution_helpers.get_redis_client",
+                return_value=mock_client,
+            ),
+            patch(
+                "redis_sre_agent.core.runbook_execution_helpers.create_task",
+                new_callable=AsyncMock,
+            ) as mock_create_task,
+            patch(
+                "redis_sre_agent.core.runbook_execution_helpers.get_redis_url",
+                new_callable=AsyncMock,
+                return_value="redis://test",
+            ),
+            patch("redis_sre_agent.core.runbook_execution_helpers.Docket") as mock_docket,
+        ):
+            mock_create_task.return_value = mock_result
+            docket_instance = AsyncMock()
+            docket_instance.__aenter__.return_value = docket_instance
+            docket_instance.__aexit__.return_value = False
+            queued = AsyncMock()
+            docket_instance.add.return_value = queued
+            mock_docket.return_value = docket_instance
+
+            result = await queue_runbook_operation_task(
+                operation="generate",
+                user_id="user-123",
+                topic="Memory Pressure",
+                scenario_description="Redis memory saturation on primaries",
+            )
+
+        assert result == {
+            "thread_id": "thread-123",
+            "task_id": "task-456",
+            "status": "queued",
+            "message": "Runbook generate task queued for processing",
+            "operation": "generate",
+        }
+        mock_create_task.assert_awaited_once_with(
+            message="Generate runbook for Memory Pressure",
+            context={
+                "task_type": "runbook",
+                "runbook_operation": "generate",
+                "user_id": "user-123",
+            },
+            redis_client=mock_client,
+        )
+        queued.assert_awaited_once()
+
+
+class TestRunbookExecutionHelperUtilities:
+    """Test small helper utilities for full branch coverage."""
+
+    def test_build_runbook_task_message_variants(self):
+        """Task subjects should match the requested runbook operation."""
+        assert _build_runbook_task_message("generate", {"topic": "Memory Pressure"}) == (
+            "Generate runbook for Memory Pressure"
+        )
+        assert _build_runbook_task_message("generate", {}) == "Generate runbook"
+        assert _build_runbook_task_message("evaluate", {}) == (
+            "Evaluate runbooks in source_documents/runbooks"
+        )
+        assert (
+            _build_runbook_task_message("evaluate", {"input_dir": "/tmp/runbooks"})
+            == "Evaluate runbooks in /tmp/runbooks"
+        )
+        assert _build_runbook_task_message("other", {}) == "Runbook operation other"
+
+    @pytest.mark.asyncio
+    async def test_generate_runbook_auto_save_slugifies_topic(self, tmp_path, monkeypatch):
+        """Auto-save mode should use the default runbook path."""
+        generated_runbook = GeneratedRunbook(
+            title="Redis Memory Pressure - Operational Runbook",
+            content="# Redis Memory Pressure\n\nRunbook content",
+            category="operational_runbook",
+            severity="warning",
+            sources=["source-1"],
+            generation_timestamp="2026-03-25T12:00:00",
+        )
+        evaluation = RunbookEvaluation(
+            overall_score=4.2,
+            technical_accuracy=4,
+            completeness=4,
+            actionability=5,
+            production_readiness=4,
+            strengths=["Clear structure"],
+            weaknesses=["Needs more examples"],
+            recommendations=["Add another remediation option"],
+            evaluation_summary="Production-ready with minor gaps.",
+        )
+        research = ResearchResult(
+            tavily_findings=[{"title": "External source"}],
+            knowledge_base_results=[{"title": "Internal source"}],
+            research_summary="Research summary",
+        )
+        mock_generator = MagicMock()
+        mock_generator.generate_runbook = AsyncMock(
+            return_value={
+                "success": True,
+                "runbook": generated_runbook,
+                "evaluation": evaluation,
+                "research": research,
+                "iterations": 1,
+            }
+        )
+
+        monkeypatch.chdir(tmp_path)
+        with patch(
+            "redis_sre_agent.core.runbook_execution_helpers.RunbookGenerator",
+            return_value=mock_generator,
+        ):
+            result = await run_runbook_operation_helper(
+                operation="generate",
+                topic="Memory / Pressure",
+                scenario_description="Redis memory saturation on primaries",
+            )
+
+        assert result["saved_path"] == "source_documents/runbooks/memory-pressure.md"
+        assert (tmp_path / "source_documents/runbooks/memory-pressure.md").read_text(
+            encoding="utf-8"
+        ) == generated_runbook.content
+
+    @pytest.mark.asyncio
+    async def test_generate_runbook_ingest_without_saved_path(self):
+        """Ingest mode should fall back to a generated source when not saving."""
+        generated_runbook = GeneratedRunbook(
+            title="Redis Memory Pressure - Operational Runbook",
+            content="# Redis Memory Pressure\n\nRunbook content",
+            category="operational_runbook",
+            severity="warning",
+            sources=["source-1"],
+            generation_timestamp="2026-03-25T12:00:00",
+        )
+        evaluation = RunbookEvaluation(
+            overall_score=4.2,
+            technical_accuracy=4,
+            completeness=4,
+            actionability=5,
+            production_readiness=4,
+            strengths=["Clear structure"],
+            weaknesses=["Needs more examples"],
+            recommendations=["Add another remediation option"],
+            evaluation_summary="Production-ready with minor gaps.",
+        )
+        research = ResearchResult(
+            tavily_findings=[{"title": "External source"}],
+            knowledge_base_results=[{"title": "Internal source"}],
+            research_summary="Research summary",
+        )
+        mock_generator = MagicMock()
+        mock_generator.generate_runbook = AsyncMock(
+            return_value={
+                "success": True,
+                "runbook": generated_runbook,
+                "evaluation": evaluation,
+                "research": research,
+                "iterations": 1,
+            }
+        )
+
+        with (
+            patch(
+                "redis_sre_agent.core.runbook_execution_helpers.RunbookGenerator",
+                return_value=mock_generator,
+            ),
+            patch(
+                "redis_sre_agent.core.runbook_execution_helpers.ingest_sre_document_helper",
+                new_callable=AsyncMock,
+            ) as mock_ingest,
+        ):
+            await run_runbook_operation_helper(
+                operation="generate",
+                topic="Memory Pressure",
+                scenario_description="Redis memory saturation on primaries",
+                auto_save=False,
+                ingest=True,
+            )
+
+        assert mock_ingest.await_args.kwargs["source"] == "generated_runbook"
+
+    @pytest.mark.asyncio
+    async def test_evaluate_runbooks_uses_filename_when_heading_missing(self, tmp_path):
+        """Evaluation should fall back to the filename when no Markdown heading exists."""
+        input_dir = tmp_path / "runbooks"
+        input_dir.mkdir()
+        (input_dir / "plain-name.md").write_text("content only", encoding="utf-8")
+
+        evaluation = RunbookEvaluation(
+            overall_score=4.2,
+            technical_accuracy=4,
+            completeness=4,
+            actionability=5,
+            production_readiness=4,
+            strengths=["Clear structure"],
+            weaknesses=["Needs more examples"],
+            recommendations=["Add another remediation option"],
+            evaluation_summary="Production-ready with minor gaps.",
+        )
+        mock_generator = MagicMock()
+        mock_generator._evaluate_runbook = AsyncMock(return_value=evaluation)
+
+        with patch(
+            "redis_sre_agent.core.runbook_execution_helpers.RunbookGenerator",
+            return_value=mock_generator,
+        ):
+            result = await run_runbook_operation_helper(
+                operation="evaluate",
+                input_dir=str(input_dir),
+            )
+
+        assert result["results"][0]["title"] == "plain-name"
+
+    @pytest.mark.asyncio
+    async def test_get_redis_url_wrapper(self):
+        """Redis URL wrapper should delegate to the Docket task helper."""
+        with patch(
+            "redis_sre_agent.core.docket_tasks.get_redis_url",
+            new_callable=AsyncMock,
+            return_value="redis://test",
+        ) as mock_get:
+            result = await get_redis_url()
+
+        assert result == "redis://test"
+        mock_get.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_generate_runbook_without_optional_objects(self):
+        """Generate mode should preserve missing optional result objects."""
+        generated_runbook = GeneratedRunbook(
+            title="Redis Memory Pressure - Operational Runbook",
+            content="# Redis Memory Pressure\n\nRunbook content",
+            category="operational_runbook",
+            severity="warning",
+            sources=["source-1"],
+            generation_timestamp="2026-03-25T12:00:00",
+        )
+        mock_generator = MagicMock()
+        mock_generator.generate_runbook = AsyncMock(
+            return_value={
+                "success": True,
+                "runbook": generated_runbook,
+                "evaluation": None,
+                "research": {"kind": "inline"},
+                "iterations": 1,
+            }
+        )
+
+        with patch(
+            "redis_sre_agent.core.runbook_execution_helpers.RunbookGenerator",
+            return_value=mock_generator,
+        ):
+            result = await run_runbook_operation_helper(
+                operation="generate",
+                topic="Memory Pressure",
+                scenario_description="Redis memory saturation on primaries",
+                auto_save=False,
+            )
+
+        assert result["evaluation"] is None
+        assert result["research"] == {"kind": "inline"}

--- a/tests/unit/core/test_schedule_helpers.py
+++ b/tests/unit/core/test_schedule_helpers.py
@@ -1,0 +1,745 @@
+"""Tests for schedule MCP helpers."""
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from redis_sre_agent.core.tasks import TaskMetadata, TaskState, TaskStatus
+
+
+def _schedule(**overrides):
+    data = {
+        "id": "schedule-1",
+        "name": "Nightly Check",
+        "description": "Run a nightly health check",
+        "interval_type": "hours",
+        "interval_value": 12,
+        "instructions": "Check memory usage",
+        "enabled": True,
+        "created_at": "2026-03-25T00:00:00+00:00",
+        "updated_at": "2026-03-25T00:00:00+00:00",
+        "last_run_at": None,
+        "next_run_at": "2026-03-25T12:00:00+00:00",
+        "redis_instance_id": "redis-prod-1",
+    }
+    data.update(overrides)
+    return data
+
+
+class TestScheduleReadHelpers:
+    @pytest.mark.asyncio
+    async def test_list_schedules_helper_applies_limit(self):
+        from redis_sre_agent.core.schedule_helpers import list_schedules_helper
+
+        schedules = [_schedule(id="schedule-1"), _schedule(id="schedule-2")]
+
+        with patch(
+            "redis_sre_agent.core.schedule_helpers.core_schedules.list_schedules",
+            new_callable=AsyncMock,
+            return_value=schedules,
+        ) as mock_list:
+            result = await list_schedules_helper(limit=1)
+
+        assert result == {"schedules": [schedules[0]], "total": 2, "limit": 1}
+        mock_list.assert_awaited_once_with()
+
+    @pytest.mark.asyncio
+    async def test_get_schedule_helper_returns_schedule(self):
+        from redis_sre_agent.core.schedule_helpers import get_schedule_helper
+
+        with patch(
+            "redis_sre_agent.core.schedule_helpers.core_schedules.get_schedule",
+            new_callable=AsyncMock,
+            return_value=_schedule(),
+        ):
+            result = await get_schedule_helper("schedule-1")
+
+        assert result["id"] == "schedule-1"
+
+    @pytest.mark.asyncio
+    async def test_get_schedule_helper_returns_error_when_missing(self):
+        from redis_sre_agent.core.schedule_helpers import get_schedule_helper
+
+        with patch(
+            "redis_sre_agent.core.schedule_helpers.core_schedules.get_schedule",
+            new_callable=AsyncMock,
+            return_value=None,
+        ):
+            result = await get_schedule_helper("schedule-404")
+
+        assert result == {"error": "Schedule not found", "id": "schedule-404"}
+
+
+class TestScheduleMutationHelpers:
+    @pytest.mark.asyncio
+    async def test_create_schedule_helper_creates_schedule(self):
+        from redis_sre_agent.core.schedule_helpers import create_schedule_helper
+
+        with (
+            patch(
+                "redis_sre_agent.core.schedule_helpers.core_schedules.store_schedule",
+                new_callable=AsyncMock,
+                return_value=True,
+            ) as mock_store,
+            patch("redis_sre_agent.core.schedule_helpers.datetime") as mock_datetime,
+        ):
+            mock_now = datetime(2026, 3, 25, 12, 0, tzinfo=timezone.utc)
+            mock_datetime.now.return_value = mock_now
+
+            result = await create_schedule_helper(
+                name="Nightly Check",
+                interval_type="hours",
+                interval_value=12,
+                instructions="Check memory usage",
+                redis_instance_id="redis-prod-1",
+                description="Run a nightly health check",
+                enabled=True,
+            )
+
+        assert result["status"] == "created"
+        stored = mock_store.await_args.args[0]
+        assert stored["name"] == "Nightly Check"
+        assert stored["next_run_at"] is not None
+
+    @pytest.mark.asyncio
+    async def test_create_schedule_helper_raises_when_store_fails(self):
+        from redis_sre_agent.core.schedule_helpers import create_schedule_helper
+
+        with patch(
+            "redis_sre_agent.core.schedule_helpers.core_schedules.store_schedule",
+            new_callable=AsyncMock,
+            return_value=False,
+        ):
+            with pytest.raises(RuntimeError, match="Failed to store schedule"):
+                await create_schedule_helper(
+                    name="Nightly Check",
+                    interval_type="hours",
+                    interval_value=12,
+                    instructions="Check memory usage",
+                )
+
+    @pytest.mark.asyncio
+    async def test_update_schedule_helper_recalculates_next_run(self):
+        from redis_sre_agent.core.schedule_helpers import update_schedule_helper
+
+        with (
+            patch(
+                "redis_sre_agent.core.schedule_helpers.core_schedules.get_schedule",
+                new_callable=AsyncMock,
+                return_value=_schedule(enabled=False, next_run_at=None),
+            ),
+            patch(
+                "redis_sre_agent.core.schedule_helpers.core_schedules.store_schedule",
+                new_callable=AsyncMock,
+                return_value=True,
+            ) as mock_store,
+        ):
+            result = await update_schedule_helper(
+                "schedule-1",
+                interval_value=24,
+                enabled=True,
+                recalc_next_run=True,
+            )
+
+        assert result == {"id": "schedule-1", "status": "updated"}
+        stored = mock_store.await_args.args[0]
+        assert stored["interval_value"] == 24
+        assert stored["enabled"] is True
+        assert stored["next_run_at"] is not None
+
+    @pytest.mark.asyncio
+    async def test_update_schedule_helper_updates_all_optional_fields(self):
+        from redis_sre_agent.core.schedule_helpers import update_schedule_helper
+
+        with (
+            patch(
+                "redis_sre_agent.core.schedule_helpers.core_schedules.get_schedule",
+                new_callable=AsyncMock,
+                return_value=_schedule(),
+            ),
+            patch(
+                "redis_sre_agent.core.schedule_helpers.core_schedules.store_schedule",
+                new_callable=AsyncMock,
+                return_value=True,
+            ) as mock_store,
+        ):
+            await update_schedule_helper(
+                "schedule-1",
+                name="Updated Name",
+                description="Updated description",
+                instructions="Updated instructions",
+                redis_instance_id="redis-prod-2",
+                interval_type="days",
+                interval_value=2,
+                enabled=False,
+                recalc_next_run=False,
+            )
+
+        stored = mock_store.await_args.args[0]
+        assert stored["name"] == "Updated Name"
+        assert stored["description"] == "Updated description"
+        assert stored["instructions"] == "Updated instructions"
+        assert stored["redis_instance_id"] == "redis-prod-2"
+        assert stored["interval_type"] == "days"
+        assert stored["interval_value"] == 2
+        assert stored["enabled"] is False
+
+    @pytest.mark.asyncio
+    async def test_update_schedule_helper_raises_for_missing_schedule(self):
+        from redis_sre_agent.core.schedule_helpers import update_schedule_helper
+
+        with patch(
+            "redis_sre_agent.core.schedule_helpers.core_schedules.get_schedule",
+            new_callable=AsyncMock,
+            return_value=None,
+        ):
+            with pytest.raises(RuntimeError, match="Schedule not found"):
+                await update_schedule_helper("schedule-404", name="Updated")
+
+    @pytest.mark.asyncio
+    async def test_update_schedule_helper_raises_when_store_fails(self):
+        from redis_sre_agent.core.schedule_helpers import update_schedule_helper
+
+        with (
+            patch(
+                "redis_sre_agent.core.schedule_helpers.core_schedules.get_schedule",
+                new_callable=AsyncMock,
+                return_value=_schedule(),
+            ),
+            patch(
+                "redis_sre_agent.core.schedule_helpers.core_schedules.store_schedule",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+        ):
+            with pytest.raises(RuntimeError, match="Failed to store updated schedule"):
+                await update_schedule_helper("schedule-1", description="Updated")
+
+    @pytest.mark.asyncio
+    async def test_enable_schedule_helper_sets_missing_next_run(self):
+        from redis_sre_agent.core.schedule_helpers import enable_schedule_helper
+
+        with (
+            patch(
+                "redis_sre_agent.core.schedule_helpers.core_schedules.get_schedule",
+                new_callable=AsyncMock,
+                return_value=_schedule(enabled=False, next_run_at=None),
+            ),
+            patch(
+                "redis_sre_agent.core.schedule_helpers.core_schedules.store_schedule",
+                new_callable=AsyncMock,
+                return_value=True,
+            ) as mock_store,
+        ):
+            result = await enable_schedule_helper("schedule-1")
+
+        assert result == {"id": "schedule-1", "status": "enabled"}
+        stored = mock_store.await_args.args[0]
+        assert stored["enabled"] is True
+        assert stored["next_run_at"] is not None
+
+    @pytest.mark.asyncio
+    async def test_enable_schedule_helper_raises_for_missing_schedule(self):
+        from redis_sre_agent.core.schedule_helpers import enable_schedule_helper
+
+        with patch(
+            "redis_sre_agent.core.schedule_helpers.core_schedules.get_schedule",
+            new_callable=AsyncMock,
+            return_value=None,
+        ):
+            with pytest.raises(RuntimeError, match="Schedule not found"):
+                await enable_schedule_helper("schedule-404")
+
+    @pytest.mark.asyncio
+    async def test_enable_schedule_helper_raises_when_store_fails(self):
+        from redis_sre_agent.core.schedule_helpers import enable_schedule_helper
+
+        with (
+            patch(
+                "redis_sre_agent.core.schedule_helpers.core_schedules.get_schedule",
+                new_callable=AsyncMock,
+                return_value=_schedule(),
+            ),
+            patch(
+                "redis_sre_agent.core.schedule_helpers.core_schedules.store_schedule",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+        ):
+            with pytest.raises(RuntimeError, match="Failed to store enabled schedule"):
+                await enable_schedule_helper("schedule-1")
+
+    @pytest.mark.asyncio
+    async def test_disable_schedule_helper_updates_schedule(self):
+        from redis_sre_agent.core.schedule_helpers import disable_schedule_helper
+
+        with (
+            patch(
+                "redis_sre_agent.core.schedule_helpers.core_schedules.get_schedule",
+                new_callable=AsyncMock,
+                return_value=_schedule(),
+            ),
+            patch(
+                "redis_sre_agent.core.schedule_helpers.core_schedules.store_schedule",
+                new_callable=AsyncMock,
+                return_value=True,
+            ) as mock_store,
+        ):
+            result = await disable_schedule_helper("schedule-1")
+
+        assert result == {"id": "schedule-1", "status": "disabled"}
+        assert mock_store.await_args.args[0]["enabled"] is False
+
+    @pytest.mark.asyncio
+    async def test_disable_schedule_helper_raises_for_missing_schedule(self):
+        from redis_sre_agent.core.schedule_helpers import disable_schedule_helper
+
+        with patch(
+            "redis_sre_agent.core.schedule_helpers.core_schedules.get_schedule",
+            new_callable=AsyncMock,
+            return_value=None,
+        ):
+            with pytest.raises(RuntimeError, match="Schedule not found"):
+                await disable_schedule_helper("schedule-404")
+
+    @pytest.mark.asyncio
+    async def test_disable_schedule_helper_raises_when_store_fails(self):
+        from redis_sre_agent.core.schedule_helpers import disable_schedule_helper
+
+        with (
+            patch(
+                "redis_sre_agent.core.schedule_helpers.core_schedules.get_schedule",
+                new_callable=AsyncMock,
+                return_value=_schedule(),
+            ),
+            patch(
+                "redis_sre_agent.core.schedule_helpers.core_schedules.store_schedule",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+        ):
+            with pytest.raises(RuntimeError, match="Failed to store disabled schedule"):
+                await disable_schedule_helper("schedule-1")
+
+    @pytest.mark.asyncio
+    async def test_delete_schedule_helper_requires_confirmation(self):
+        from redis_sre_agent.core.schedule_helpers import delete_schedule_helper
+
+        result = await delete_schedule_helper("schedule-1", confirm=False)
+
+        assert result == {
+            "error": "Confirmation required",
+            "id": "schedule-1",
+            "status": "cancelled",
+        }
+
+    @pytest.mark.asyncio
+    async def test_delete_schedule_helper_deletes_schedule(self):
+        from redis_sre_agent.core.schedule_helpers import delete_schedule_helper
+
+        with (
+            patch(
+                "redis_sre_agent.core.schedule_helpers.core_schedules.get_schedule",
+                new_callable=AsyncMock,
+                return_value=_schedule(),
+            ),
+            patch(
+                "redis_sre_agent.core.schedule_helpers.core_schedules.delete_schedule",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+        ):
+            result = await delete_schedule_helper("schedule-1", confirm=True)
+
+        assert result == {"id": "schedule-1", "status": "deleted"}
+
+    @pytest.mark.asyncio
+    async def test_delete_schedule_helper_raises_for_missing_schedule(self):
+        from redis_sre_agent.core.schedule_helpers import delete_schedule_helper
+
+        with patch(
+            "redis_sre_agent.core.schedule_helpers.core_schedules.get_schedule",
+            new_callable=AsyncMock,
+            return_value=None,
+        ):
+            with pytest.raises(RuntimeError, match="Schedule not found"):
+                await delete_schedule_helper("schedule-404", confirm=True)
+
+    @pytest.mark.asyncio
+    async def test_delete_schedule_helper_raises_when_delete_fails(self):
+        from redis_sre_agent.core.schedule_helpers import delete_schedule_helper
+
+        with (
+            patch(
+                "redis_sre_agent.core.schedule_helpers.core_schedules.get_schedule",
+                new_callable=AsyncMock,
+                return_value=_schedule(),
+            ),
+            patch(
+                "redis_sre_agent.core.schedule_helpers.core_schedules.delete_schedule",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+        ):
+            with pytest.raises(RuntimeError, match="Delete failed or schedule not found"):
+                await delete_schedule_helper("schedule-1", confirm=True)
+
+
+class TestScheduleRunHelpers:
+    @pytest.mark.asyncio
+    async def test_run_schedule_now_helper_enqueues_run(self):
+        from redis_sre_agent.core.schedule_helpers import run_schedule_now_helper
+
+        thread_manager = AsyncMock()
+        thread_manager.create_thread.return_value = "thread-1"
+        thread_manager.set_thread_subject.return_value = True
+
+        docket_instance = AsyncMock()
+        docket_instance.__aenter__.return_value = docket_instance
+        docket_instance.__aexit__.return_value = False
+        queued = AsyncMock(return_value="docket-1")
+        docket_instance.add = MagicMock(return_value=queued)
+
+        with (
+            patch(
+                "redis_sre_agent.core.schedule_helpers.core_schedules.get_schedule",
+                new_callable=AsyncMock,
+                return_value=_schedule(),
+            ),
+            patch(
+                "redis_sre_agent.core.schedule_helpers.get_redis_client",
+                return_value=AsyncMock(),
+            ),
+            patch(
+                "redis_sre_agent.core.schedule_helpers.ThreadManager",
+                return_value=thread_manager,
+            ),
+            patch(
+                "redis_sre_agent.core.schedule_helpers.get_redis_url",
+                new_callable=AsyncMock,
+                return_value="redis://test",
+            ),
+            patch("redis_sre_agent.core.schedule_helpers.Docket", return_value=docket_instance),
+        ):
+            result = await run_schedule_now_helper("schedule-1")
+
+        assert result["status"] == "pending"
+        assert result["thread_id"] == "thread-1"
+        assert result["docket_task_id"] == "docket-1"
+        queued.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_run_schedule_now_helper_returns_error_when_missing_schedule(self):
+        from redis_sre_agent.core.schedule_helpers import run_schedule_now_helper
+
+        with patch(
+            "redis_sre_agent.core.schedule_helpers.core_schedules.get_schedule",
+            new_callable=AsyncMock,
+            return_value=None,
+        ):
+            result = await run_schedule_now_helper("schedule-404")
+
+        assert result == {"error": "Schedule not found", "id": "schedule-404"}
+
+    @pytest.mark.asyncio
+    async def test_run_schedule_now_helper_handles_duplicate_submission(self):
+        from redis_sre_agent.core.schedule_helpers import run_schedule_now_helper
+
+        thread_manager = AsyncMock()
+        thread_manager.create_thread.return_value = "thread-1"
+        thread_manager.set_thread_subject.return_value = True
+
+        docket_instance = AsyncMock()
+        docket_instance.__aenter__.return_value = docket_instance
+        docket_instance.__aexit__.return_value = False
+        queued = AsyncMock(side_effect=RuntimeError("duplicate key"))
+        docket_instance.add = MagicMock(return_value=queued)
+
+        with (
+            patch(
+                "redis_sre_agent.core.schedule_helpers.core_schedules.get_schedule",
+                new_callable=AsyncMock,
+                return_value=_schedule(),
+            ),
+            patch(
+                "redis_sre_agent.core.schedule_helpers.get_redis_client",
+                return_value=AsyncMock(),
+            ),
+            patch(
+                "redis_sre_agent.core.schedule_helpers.ThreadManager",
+                return_value=thread_manager,
+            ),
+            patch(
+                "redis_sre_agent.core.schedule_helpers.get_redis_url",
+                new_callable=AsyncMock,
+                return_value="redis://test",
+            ),
+            patch("redis_sre_agent.core.schedule_helpers.Docket", return_value=docket_instance),
+        ):
+            result = await run_schedule_now_helper("schedule-1")
+
+        assert result["docket_task_id"] == "already_running"
+
+    @pytest.mark.asyncio
+    async def test_run_schedule_now_helper_ignores_subject_update_failure(self):
+        from redis_sre_agent.core.schedule_helpers import run_schedule_now_helper
+
+        thread_manager = AsyncMock()
+        thread_manager.create_thread.return_value = "thread-1"
+        thread_manager.set_thread_subject.side_effect = RuntimeError("ignore me")
+
+        docket_instance = AsyncMock()
+        docket_instance.__aenter__.return_value = docket_instance
+        docket_instance.__aexit__.return_value = False
+        queued = AsyncMock(return_value="docket-1")
+        docket_instance.add = MagicMock(return_value=queued)
+
+        with (
+            patch(
+                "redis_sre_agent.core.schedule_helpers.core_schedules.get_schedule",
+                new_callable=AsyncMock,
+                return_value=_schedule(name="", instructions="First line\nSecond line"),
+            ),
+            patch(
+                "redis_sre_agent.core.schedule_helpers.get_redis_client",
+                return_value=AsyncMock(),
+            ),
+            patch(
+                "redis_sre_agent.core.schedule_helpers.ThreadManager",
+                return_value=thread_manager,
+            ),
+            patch(
+                "redis_sre_agent.core.schedule_helpers.get_redis_url",
+                new_callable=AsyncMock,
+                return_value="redis://test",
+            ),
+            patch("redis_sre_agent.core.schedule_helpers.Docket", return_value=docket_instance),
+        ):
+            result = await run_schedule_now_helper("schedule-1")
+
+        assert result["docket_task_id"] == "docket-1"
+
+    @pytest.mark.asyncio
+    async def test_run_schedule_now_helper_reraises_non_duplicate_submission_error(self):
+        from redis_sre_agent.core.schedule_helpers import run_schedule_now_helper
+
+        thread_manager = AsyncMock()
+        thread_manager.create_thread.return_value = "thread-1"
+        thread_manager.set_thread_subject.return_value = True
+
+        docket_instance = AsyncMock()
+        docket_instance.__aenter__.return_value = docket_instance
+        docket_instance.__aexit__.return_value = False
+        queued = AsyncMock(side_effect=RuntimeError("boom"))
+        docket_instance.add = MagicMock(return_value=queued)
+
+        with (
+            patch(
+                "redis_sre_agent.core.schedule_helpers.core_schedules.get_schedule",
+                new_callable=AsyncMock,
+                return_value=_schedule(),
+            ),
+            patch(
+                "redis_sre_agent.core.schedule_helpers.get_redis_client",
+                return_value=AsyncMock(),
+            ),
+            patch(
+                "redis_sre_agent.core.schedule_helpers.ThreadManager",
+                return_value=thread_manager,
+            ),
+            patch(
+                "redis_sre_agent.core.schedule_helpers.get_redis_url",
+                new_callable=AsyncMock,
+                return_value="redis://test",
+            ),
+            patch("redis_sre_agent.core.schedule_helpers.Docket", return_value=docket_instance),
+        ):
+            with pytest.raises(RuntimeError, match="boom"):
+                await run_schedule_now_helper("schedule-1")
+
+    @pytest.mark.asyncio
+    async def test_list_schedule_runs_helper_returns_runs(self):
+        from redis_sre_agent.core.schedule_helpers import list_schedule_runs_helper
+
+        redis_client = AsyncMock()
+        redis_client.zrevrange.return_value = [b"task-1"]
+
+        thread_manager = AsyncMock()
+        thread_manager.list_threads.return_value = [
+            {
+                "thread_id": "thread-1",
+                "created_at": "2026-03-25T00:00:00+00:00",
+                "updated_at": "2026-03-25T00:10:00+00:00",
+                "subject": "Nightly Check",
+            },
+            {
+                "thread_id": "thread-2",
+                "created_at": "2026-03-24T00:00:00+00:00",
+                "updated_at": "2026-03-24T00:10:00+00:00",
+                "subject": "Other",
+            },
+        ]
+        thread_manager.get_thread.side_effect = [
+            SimpleNamespace(
+                context={"schedule_id": "schedule-1", "scheduled_at": "2026-03-25T00:00:00+00:00"}
+            ),
+            SimpleNamespace(context={"schedule_id": "schedule-2"}),
+        ]
+
+        task_manager = AsyncMock()
+        task_manager.get_task_state.return_value = TaskState(
+            task_id="task-1",
+            thread_id="thread-1",
+            status=TaskStatus.DONE,
+            metadata=TaskMetadata(
+                created_at="2026-03-25T00:00:01+00:00",
+                updated_at="2026-03-25T00:05:00+00:00",
+            ),
+        )
+
+        with (
+            patch(
+                "redis_sre_agent.core.schedule_helpers.core_schedules.get_schedule",
+                new_callable=AsyncMock,
+                return_value=_schedule(),
+            ),
+            patch(
+                "redis_sre_agent.core.schedule_helpers.get_redis_client",
+                return_value=redis_client,
+            ),
+            patch(
+                "redis_sre_agent.core.schedule_helpers.ThreadManager",
+                return_value=thread_manager,
+            ),
+            patch(
+                "redis_sre_agent.core.schedule_helpers.TaskManager",
+                return_value=task_manager,
+            ),
+        ):
+            result = await list_schedule_runs_helper("schedule-1", limit=5)
+
+        assert result["schedule_id"] == "schedule-1"
+        assert result["total"] == 1
+        assert result["runs"][0]["task_id"] == "task-1"
+        assert result["runs"][0]["status"] == "done"
+
+    @pytest.mark.asyncio
+    async def test_list_schedule_runs_helper_handles_missing_task_lookup(self):
+        from redis_sre_agent.core.schedule_helpers import list_schedule_runs_helper
+
+        redis_client = AsyncMock()
+        redis_client.zrevrange.side_effect = RuntimeError("ignore me")
+
+        thread_manager = AsyncMock()
+        thread_manager.list_threads.return_value = [
+            {
+                "thread_id": "thread-1",
+                "created_at": "2026-03-25T00:00:00+00:00",
+                "updated_at": "2026-03-25T00:10:00+00:00",
+                "subject": None,
+            }
+        ]
+        thread_manager.get_thread.return_value = SimpleNamespace(
+            context={"schedule_id": "schedule-1"}
+        )
+
+        with (
+            patch(
+                "redis_sre_agent.core.schedule_helpers.core_schedules.get_schedule",
+                new_callable=AsyncMock,
+                return_value=_schedule(),
+            ),
+            patch(
+                "redis_sre_agent.core.schedule_helpers.get_redis_client",
+                return_value=redis_client,
+            ),
+            patch(
+                "redis_sre_agent.core.schedule_helpers.ThreadManager",
+                return_value=thread_manager,
+            ),
+            patch(
+                "redis_sre_agent.core.schedule_helpers.TaskManager",
+                return_value=AsyncMock(),
+            ),
+        ):
+            result = await list_schedule_runs_helper("schedule-1", limit=5)
+
+        assert result["runs"][0]["task_id"] is None
+        assert result["runs"][0]["status"] == "queued"
+        assert result["runs"][0]["subject"] == "Scheduled Run"
+
+    @pytest.mark.asyncio
+    async def test_list_schedule_runs_helper_handles_task_fetch_error(self):
+        from redis_sre_agent.core.schedule_helpers import list_schedule_runs_helper
+
+        redis_client = AsyncMock()
+        redis_client.zrevrange.return_value = [b"task-1"]
+
+        thread_manager = AsyncMock()
+        thread_manager.list_threads.return_value = [
+            {
+                "thread_id": "thread-1",
+                "created_at": "2026-03-25T00:00:00+00:00",
+                "updated_at": "2026-03-25T00:10:00+00:00",
+                "subject": "Nightly Check",
+            }
+        ]
+        thread_manager.get_thread.return_value = SimpleNamespace(
+            context={"schedule_id": "schedule-1"}
+        )
+
+        task_manager = AsyncMock()
+        task_manager.get_task_state.side_effect = RuntimeError("ignore me")
+
+        with (
+            patch(
+                "redis_sre_agent.core.schedule_helpers.core_schedules.get_schedule",
+                new_callable=AsyncMock,
+                return_value=_schedule(),
+            ),
+            patch(
+                "redis_sre_agent.core.schedule_helpers.get_redis_client",
+                return_value=redis_client,
+            ),
+            patch(
+                "redis_sre_agent.core.schedule_helpers.ThreadManager",
+                return_value=thread_manager,
+            ),
+            patch(
+                "redis_sre_agent.core.schedule_helpers.TaskManager",
+                return_value=task_manager,
+            ),
+        ):
+            result = await list_schedule_runs_helper("schedule-1", limit=5)
+
+        assert result["runs"][0]["task_id"] == "task-1"
+        assert result["runs"][0]["status"] == "queued"
+
+    @pytest.mark.asyncio
+    async def test_list_schedule_runs_helper_returns_error_when_missing_schedule(self):
+        from redis_sre_agent.core.schedule_helpers import list_schedule_runs_helper
+
+        with patch(
+            "redis_sre_agent.core.schedule_helpers.core_schedules.get_schedule",
+            new_callable=AsyncMock,
+            return_value=None,
+        ):
+            result = await list_schedule_runs_helper("schedule-404")
+
+        assert result == {"error": "Schedule not found", "id": "schedule-404"}
+
+    def test_normalize_task_status_handles_strings_and_enums(self):
+        from redis_sre_agent.core.schedule_helpers import (
+            _build_schedule_subject,
+            _normalize_task_status,
+        )
+
+        assert _normalize_task_status(TaskStatus.IN_PROGRESS) == "in_progress"
+        assert _normalize_task_status("done") == "done"
+        assert _normalize_task_status(None) == "queued"
+        assert _build_schedule_subject({"name": "", "instructions": "First line\nSecond line"}) == (
+            "First line"
+        )
+        assert _build_schedule_subject({"name": "", "instructions": ""}) == "Scheduled Run"

--- a/tests/unit/core/test_support_package_helpers.py
+++ b/tests/unit/core/test_support_package_helpers.py
@@ -1,0 +1,84 @@
+"""Tests for support-package helper configuration."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from redis_sre_agent.core.support_package_helpers import get_support_package_manager
+
+
+def test_get_support_package_manager_uses_local_storage(tmp_path, monkeypatch):
+    """Local storage is selected by default."""
+    monkeypatch.setattr(
+        "redis_sre_agent.core.support_package_helpers.settings.support_package_storage_type",
+        "local",
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "redis_sre_agent.core.support_package_helpers.settings.support_package_artifacts_dir",
+        tmp_path,
+        raising=False,
+    )
+
+    with (
+        patch("redis_sre_agent.core.support_package_helpers.LocalStorage") as mock_local,
+        patch("redis_sre_agent.core.support_package_helpers.SupportPackageManager") as mock_manager,
+    ):
+        get_support_package_manager()
+
+        mock_local.assert_called_once_with(base_path=tmp_path / "storage")
+        mock_manager.assert_called_once_with(
+            storage=mock_local.return_value,
+            extract_dir=tmp_path / "extracted",
+        )
+
+
+def test_get_support_package_manager_uses_s3_storage(tmp_path, monkeypatch):
+    """S3 storage is selected when configured."""
+    monkeypatch.setattr(
+        "redis_sre_agent.core.support_package_helpers.settings.support_package_storage_type",
+        "s3",
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "redis_sre_agent.core.support_package_helpers.settings.support_package_artifacts_dir",
+        tmp_path,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "redis_sre_agent.core.support_package_helpers.settings.support_package_s3_bucket",
+        "bucket",
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "redis_sre_agent.core.support_package_helpers.settings.support_package_s3_prefix",
+        "prefix/",
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "redis_sre_agent.core.support_package_helpers.settings.support_package_s3_region",
+        "us-west-2",
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "redis_sre_agent.core.support_package_helpers.settings.support_package_s3_endpoint",
+        "https://s3.example.com",
+        raising=False,
+    )
+
+    with (
+        patch("redis_sre_agent.core.support_package_helpers.S3Storage") as mock_s3,
+        patch("redis_sre_agent.core.support_package_helpers.SupportPackageManager") as mock_manager,
+    ):
+        get_support_package_manager()
+
+        mock_s3.assert_called_once_with(
+            bucket="bucket",
+            prefix="prefix/",
+            region="us-west-2",
+            endpoint_url="https://s3.example.com",
+        )
+        mock_manager.assert_called_once_with(
+            storage=mock_s3.return_value,
+            extract_dir=tmp_path / "extracted",
+        )

--- a/tests/unit/core/test_task_inspection_helpers.py
+++ b/tests/unit/core/test_task_inspection_helpers.py
@@ -1,0 +1,183 @@
+"""Tests for task inspection helpers."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from redis_sre_agent.core.task_inspection_helpers import get_task_helper, list_tasks_helper
+from redis_sre_agent.core.tasks import TaskStatus
+
+
+class TestListTasksHelper:
+    """Test shared helpers for task list inspection."""
+
+    @pytest.mark.asyncio
+    async def test_list_tasks_helper_defaults(self):
+        """Default listing should preserve CLI-like queued/in-progress behavior."""
+        with patch(
+            "redis_sre_agent.core.task_inspection_helpers.list_tasks",
+            new_callable=AsyncMock,
+        ) as mock_list:
+            mock_list.return_value = [
+                {
+                    "task_id": "task-123",
+                    "thread_id": "thread-456",
+                    "status": TaskStatus.IN_PROGRESS,
+                    "updates": [],
+                    "result": None,
+                    "tool_calls": None,
+                    "error_message": None,
+                    "metadata": {"subject": "Health check"},
+                    "context": {},
+                }
+            ]
+
+            result = await list_tasks_helper()
+
+        assert result == {
+            "tasks": [
+                {
+                    "task_id": "task-123",
+                    "thread_id": "thread-456",
+                    "status": "in_progress",
+                    "updates": [],
+                    "result": None,
+                    "tool_calls": [],
+                    "error_message": None,
+                    "metadata": {"subject": "Health check"},
+                    "context": {},
+                }
+            ],
+            "count": 1,
+            "user_id": None,
+            "status": None,
+            "show_all": False,
+            "limit": 50,
+        }
+        mock_list.assert_awaited_once_with(
+            user_id=None,
+            status_filter=None,
+            show_all=False,
+            limit=50,
+        )
+
+    @pytest.mark.asyncio
+    async def test_list_tasks_helper_with_status_string(self):
+        """Explicit status filters should be validated and normalized."""
+        with patch(
+            "redis_sre_agent.core.task_inspection_helpers.list_tasks",
+            new_callable=AsyncMock,
+            return_value=[],
+        ) as mock_list:
+            result = await list_tasks_helper(status="done", limit=250, user_id="user-123")
+
+        assert result["tasks"] == []
+        assert result["status"] == "done"
+        assert result["limit"] == 100
+        mock_list.assert_awaited_once_with(
+            user_id="user-123",
+            status_filter=TaskStatus.DONE,
+            show_all=False,
+            limit=100,
+        )
+
+    @pytest.mark.asyncio
+    async def test_list_tasks_helper_show_all_and_min_limit(self):
+        """Show-all queries should clamp low limits and skip status filtering."""
+        with patch(
+            "redis_sre_agent.core.task_inspection_helpers.list_tasks",
+            new_callable=AsyncMock,
+            return_value=[],
+        ) as mock_list:
+            result = await list_tasks_helper(show_all=True, limit=0)
+
+        assert result["show_all"] is True
+        assert result["limit"] == 1
+        mock_list.assert_awaited_once_with(
+            user_id=None,
+            status_filter=None,
+            show_all=True,
+            limit=1,
+        )
+
+    @pytest.mark.asyncio
+    async def test_list_tasks_helper_invalid_status(self):
+        """Invalid status filters should fail clearly."""
+        with pytest.raises(ValueError, match="Invalid task status filter"):
+            await list_tasks_helper(status="bogus")
+
+
+class TestGetTaskHelper:
+    """Test shared helpers for single-task inspection."""
+
+    @pytest.mark.asyncio
+    async def test_get_task_helper_normalizes_payload(self):
+        """Single-task helper should normalize status enums and tool calls."""
+        with patch(
+            "redis_sre_agent.core.task_inspection_helpers.get_task_by_id",
+            new_callable=AsyncMock,
+        ) as mock_get:
+            mock_get.return_value = {
+                "task_id": "task-123",
+                "thread_id": "thread-456",
+                "status": TaskStatus.DONE,
+                "updates": [{"message": "done"}],
+                "result": {"summary": "ok"},
+                "tool_calls": [{"name": "redis_info"}],
+                "error_message": None,
+                "metadata": {"subject": "Health check"},
+                "context": {"kind": "triage"},
+            }
+
+            result = await get_task_helper("task-123")
+
+        assert result["status"] == "done"
+        assert result["tool_calls"] == [{"name": "redis_info"}]
+        mock_get.assert_awaited_once_with(task_id="task-123")
+
+    @pytest.mark.asyncio
+    async def test_get_task_helper_preserves_string_status(self):
+        """String statuses should pass through without conversion."""
+        with patch(
+            "redis_sre_agent.core.task_inspection_helpers.get_task_by_id",
+            new_callable=AsyncMock,
+        ) as mock_get:
+            mock_get.return_value = {
+                "task_id": "task-123",
+                "thread_id": "thread-456",
+                "status": "queued",
+                "updates": [],
+                "result": None,
+                "tool_calls": None,
+                "error_message": None,
+                "metadata": {},
+                "context": {},
+            }
+
+            result = await get_task_helper("task-123")
+
+        assert result["status"] == "queued"
+        assert result["tool_calls"] == []
+
+    @pytest.mark.asyncio
+    async def test_get_task_helper_preserves_missing_status(self):
+        """Missing statuses should remain null rather than stringified."""
+        with patch(
+            "redis_sre_agent.core.task_inspection_helpers.get_task_by_id",
+            new_callable=AsyncMock,
+        ) as mock_get:
+            mock_get.return_value = {
+                "task_id": "task-123",
+                "thread_id": "thread-456",
+                "status": None,
+                "updates": [],
+                "result": None,
+                "tool_calls": None,
+                "error_message": None,
+                "metadata": {},
+                "context": {},
+            }
+
+            result = await get_task_helper("task-123")
+
+        assert result["status"] is None

--- a/tests/unit/core/test_task_purge_helpers.py
+++ b/tests/unit/core/test_task_purge_helpers.py
@@ -1,0 +1,156 @@
+"""Tests for task purge helpers."""
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from redis_sre_agent.core.task_purge_helpers import _decode, _parse_duration, purge_tasks_helper
+
+
+class TestParseDuration:
+    """Test duration parsing used by task purging."""
+
+    def test_parse_duration_supports_suffixes(self):
+        assert _parse_duration("7d") == timedelta(days=7)
+        assert _parse_duration("24h") == timedelta(hours=24)
+        assert _parse_duration("15m") == timedelta(minutes=15)
+        assert _parse_duration("30s") == timedelta(seconds=30)
+        assert _parse_duration("45") == timedelta(seconds=45)
+
+    def test_parse_duration_rejects_invalid_values(self):
+        with pytest.raises(ValueError, match="Invalid duration"):
+            _parse_duration("nope")
+
+    def test_decode_handles_strings_and_none(self):
+        assert _decode("task-1") == "task-1"
+        assert _decode(None) == ""
+
+
+class TestPurgeTasksHelper:
+    """Test bulk task purge helper behavior."""
+
+    @pytest.mark.asyncio
+    async def test_purge_tasks_helper_requires_scope(self):
+        result = await purge_tasks_helper(confirm=True)
+
+        assert result == {
+            "error": "Refusing to purge without a scope. Provide older_than/status or purge_all.",
+            "status": "failed",
+        }
+
+    @pytest.mark.asyncio
+    async def test_purge_tasks_helper_requires_confirmation_when_not_dry_run(self):
+        result = await purge_tasks_helper(status="done", confirm=False)
+
+        assert result == {
+            "error": "Confirmation required",
+            "status": "cancelled",
+            "dry_run": False,
+        }
+
+    @pytest.mark.asyncio
+    async def test_purge_tasks_helper_supports_dry_run_without_confirmation(self):
+        redis_client = AsyncMock()
+        redis_client.scan = AsyncMock(
+            side_effect=[
+                (0, [b"sre_tasks:task-1"]),
+            ]
+        )
+        redis_client.hmget = AsyncMock(return_value=[b"done", b"1", b"1"])
+
+        result = await purge_tasks_helper(
+            status="done",
+            dry_run=True,
+            redis_client=redis_client,
+        )
+
+        assert result == {
+            "status": "dry_run",
+            "scanned": 1,
+            "deleted": 0,
+            "matched": ["task-1"],
+            "dry_run": True,
+        }
+
+    @pytest.mark.asyncio
+    async def test_purge_tasks_helper_deletes_matching_tasks(self):
+        cutoff = datetime.now(timezone.utc) - timedelta(days=2)
+        redis_client = AsyncMock()
+        redis_client.scan = AsyncMock(
+            side_effect=[
+                (1, [b"sre_tasks:task-1"]),
+                (0, [b"sre_tasks:task-2"]),
+            ]
+        )
+        redis_client.hmget = AsyncMock(
+            side_effect=[
+                [b"done", str(cutoff.timestamp()).encode(), b"1"],
+                [b"queued", str(datetime.now(timezone.utc).timestamp()).encode(), b"1"],
+            ]
+        )
+
+        with patch(
+            "redis_sre_agent.core.task_purge_helpers.delete_task_core",
+            new_callable=AsyncMock,
+        ) as mock_delete:
+            result = await purge_tasks_helper(
+                status="done",
+                older_than="1d",
+                confirm=True,
+                redis_client=redis_client,
+            )
+
+        assert result == {
+            "status": "purged",
+            "scanned": 2,
+            "deleted": 1,
+            "matched": ["task-1"],
+            "dry_run": False,
+        }
+        mock_delete.assert_awaited_once_with(task_id="task-1", redis_client=redis_client)
+
+    @pytest.mark.asyncio
+    async def test_purge_tasks_helper_ignores_hmget_and_delete_errors(self):
+        redis_client = AsyncMock()
+        redis_client.scan = AsyncMock(side_effect=[(0, [b"sre_tasks:task-1"])])
+        redis_client.hmget = AsyncMock(side_effect=RuntimeError("boom"))
+
+        with patch(
+            "redis_sre_agent.core.task_purge_helpers.delete_task_core",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("delete failed"),
+        ) as mock_delete:
+            result = await purge_tasks_helper(
+                purge_all=True,
+                confirm=True,
+                redis_client=redis_client,
+            )
+
+        assert result == {
+            "status": "purged",
+            "scanned": 1,
+            "deleted": 0,
+            "matched": ["task-1"],
+            "dry_run": False,
+        }
+        mock_delete.assert_awaited_once_with(task_id="task-1", redis_client=redis_client)
+
+    @pytest.mark.asyncio
+    async def test_purge_tasks_helper_handles_empty_scan(self):
+        redis_client = AsyncMock()
+        redis_client.scan = AsyncMock(return_value=(0, []))
+
+        result = await purge_tasks_helper(
+            purge_all=True,
+            confirm=True,
+            redis_client=redis_client,
+        )
+
+        assert result == {
+            "status": "purged",
+            "scanned": 0,
+            "deleted": 0,
+            "matched": [],
+            "dry_run": False,
+        }

--- a/tests/unit/core/test_tasks.py
+++ b/tests/unit/core/test_tasks.py
@@ -15,6 +15,7 @@ from redis_sre_agent.core.docket_tasks import (
     process_chat_turn,
     process_knowledge_query,
     process_pipeline_operation,
+    process_runbook_operation,
     register_sre_tasks,
     run_agent_with_progress,
     scheduler_task,
@@ -30,7 +31,7 @@ class TestSRETaskCollection:
 
     def test_sre_task_collection_populated(self):
         """Test that SRE task collection contains expected tasks."""
-        assert len(SRE_TASK_COLLECTION) == 8
+        assert len(SRE_TASK_COLLECTION) == 9
 
         task_names = [task.__name__ for task in SRE_TASK_COLLECTION]
         expected_tasks = [
@@ -41,6 +42,7 @@ class TestSRETaskCollection:
             "process_chat_turn",  # New: MCP chat task
             "process_knowledge_query",  # New: MCP knowledge query task
             "process_pipeline_operation",
+            "process_runbook_operation",
             "embed_qa_record",  # Q&A embedding task
         ]
 
@@ -773,6 +775,72 @@ class TestProcessPipelineOperation:
                 )
 
         mock_task_manager.set_task_error.assert_awaited_once_with("task-123", "pipeline failed")
+
+
+class TestProcessRunbookOperation:
+    """Test process_runbook_operation task."""
+
+    @pytest.mark.asyncio
+    async def test_process_runbook_operation_success(self):
+        """Runbook task should persist results and mark completion."""
+        mock_redis = AsyncMock()
+        mock_task_manager = AsyncMock()
+        mock_task_manager.update_task_status = AsyncMock()
+        mock_task_manager.set_task_result = AsyncMock()
+
+        with (
+            patch("redis_sre_agent.core.docket_tasks.get_redis_client", return_value=mock_redis),
+            patch("redis_sre_agent.core.docket_tasks.TaskManager", return_value=mock_task_manager),
+            patch("redis_sre_agent.core.docket_tasks.TaskEmitter"),
+            patch(
+                "redis_sre_agent.core.runbook_execution_helpers.run_runbook_operation_helper",
+                new_callable=AsyncMock,
+                return_value={"operation": "generate", "success": True},
+            ) as mock_helper,
+        ):
+            result = await process_runbook_operation(
+                operation="generate",
+                task_id="task-123",
+                thread_id="thread-456",
+                topic="Memory Pressure",
+                scenario_description="Redis memory saturation on primaries",
+            )
+
+        assert result == {"operation": "generate", "success": True}
+        mock_helper.assert_awaited_once()
+        mock_task_manager.update_task_status.assert_any_call("task-123", TaskStatus.IN_PROGRESS)
+        mock_task_manager.update_task_status.assert_any_call("task-123", TaskStatus.DONE)
+        mock_task_manager.set_task_result.assert_awaited_once_with(
+            "task-123",
+            {"operation": "generate", "success": True},
+        )
+
+    @pytest.mark.asyncio
+    async def test_process_runbook_operation_error(self):
+        """Runbook task should persist task errors and re-raise failures."""
+        mock_redis = AsyncMock()
+        mock_task_manager = AsyncMock()
+        mock_task_manager.update_task_status = AsyncMock()
+        mock_task_manager.set_task_error = AsyncMock()
+
+        with (
+            patch("redis_sre_agent.core.docket_tasks.get_redis_client", return_value=mock_redis),
+            patch("redis_sre_agent.core.docket_tasks.TaskManager", return_value=mock_task_manager),
+            patch("redis_sre_agent.core.docket_tasks.TaskEmitter"),
+            patch(
+                "redis_sre_agent.core.runbook_execution_helpers.run_runbook_operation_helper",
+                new_callable=AsyncMock,
+                side_effect=Exception("runbook failed"),
+            ),
+        ):
+            with pytest.raises(Exception, match="runbook failed"):
+                await process_runbook_operation(
+                    operation="evaluate",
+                    task_id="task-123",
+                    thread_id="thread-456",
+                )
+
+        mock_task_manager.set_task_error.assert_awaited_once_with("task-123", "runbook failed")
 
 
 class TestSchedulerTask:

--- a/tests/unit/core/test_tasks.py
+++ b/tests/unit/core/test_tasks.py
@@ -1133,6 +1133,78 @@ class TestProcessAgentTurn:
             otel_trace_id=None,
         )
 
+    @pytest.mark.asyncio
+    async def test_process_agent_turn_honors_requested_agent_type(self):
+        """Requested agent type should bypass router auto-selection."""
+        mock_redis = AsyncMock()
+
+        mock_thread = MagicMock()
+        mock_thread.id = "thread-123"
+        mock_thread.context = {}
+        mock_thread.metadata = MagicMock()
+        mock_thread.metadata.user_id = "user-1"
+        mock_thread.metadata.session_id = "session-1"
+        mock_thread.messages = []
+
+        mock_thread_manager = AsyncMock()
+        mock_thread_manager.get_thread = AsyncMock(return_value=mock_thread)
+        mock_thread_manager.update_thread_context = AsyncMock()
+        mock_thread_manager.append_messages = AsyncMock()
+
+        mock_task_manager = AsyncMock()
+        mock_task_manager.create_task = AsyncMock(return_value="new-task-123")
+        mock_task_manager.update_task_status = AsyncMock()
+        mock_task_manager.add_task_update = AsyncMock()
+        mock_task_manager.set_task_result = AsyncMock()
+        mock_task_manager.set_task_error = AsyncMock()
+
+        mock_chat_agent = AsyncMock()
+        mock_response = AgentResponse(
+            response="Chat response",
+            search_results=[],
+            tool_envelopes=[],
+        )
+        mock_chat_agent.process_query = AsyncMock(return_value=mock_response)
+
+        with (
+            patch("redis_sre_agent.core.docket_tasks.get_redis_client", return_value=mock_redis),
+            patch(
+                "redis_sre_agent.core.docket_tasks.ThreadManager", return_value=mock_thread_manager
+            ),
+            patch("redis_sre_agent.core.docket_tasks.TaskManager", return_value=mock_task_manager),
+            patch(
+                "redis_sre_agent.core.docket_tasks._extract_instance_details_from_message",
+                return_value=None,
+            ),
+            patch(
+                "redis_sre_agent.core.docket_tasks.get_chat_agent",
+                return_value=mock_chat_agent,
+            ),
+            patch(
+                "redis_sre_agent.core.docket_tasks.route_to_appropriate_agent",
+                new_callable=AsyncMock,
+            ) as mock_router,
+            patch(
+                "redis_sre_agent.core.docket_tasks.ULID", return_value="01HXTESTMESSAGEID1234567890"
+            ),
+            patch("opentelemetry.trace.get_tracer") as mock_tracer,
+        ):
+            mock_span = MagicMock()
+            mock_span.end = MagicMock()
+            mock_span.set_attribute = MagicMock()
+            mock_tracer.return_value.start_span.return_value = mock_span
+
+            result = await process_agent_turn(
+                thread_id="thread-123",
+                message="Use chat",
+                task_id="provided-task-123",
+                context={"requested_agent_type": "chat"},
+            )
+
+        mock_router.assert_not_called()
+        mock_chat_agent.process_query.assert_awaited_once()
+        assert result["message_id"] == "01HXTESTMESSAGEID1234567890"
+
 
 class TestRunAgentWithProgress:
     """Test run_agent_with_progress function."""

--- a/tests/unit/core/test_tasks.py
+++ b/tests/unit/core/test_tasks.py
@@ -14,6 +14,7 @@ from redis_sre_agent.core.docket_tasks import (
     process_agent_turn,
     process_chat_turn,
     process_knowledge_query,
+    process_pipeline_operation,
     register_sre_tasks,
     run_agent_with_progress,
     scheduler_task,
@@ -29,7 +30,7 @@ class TestSRETaskCollection:
 
     def test_sre_task_collection_populated(self):
         """Test that SRE task collection contains expected tasks."""
-        assert len(SRE_TASK_COLLECTION) == 7
+        assert len(SRE_TASK_COLLECTION) == 8
 
         task_names = [task.__name__ for task in SRE_TASK_COLLECTION]
         expected_tasks = [
@@ -39,6 +40,7 @@ class TestSRETaskCollection:
             "process_agent_turn",
             "process_chat_turn",  # New: MCP chat task
             "process_knowledge_query",  # New: MCP knowledge query task
+            "process_pipeline_operation",
             "embed_qa_record",  # Q&A embedding task
         ]
 
@@ -704,6 +706,73 @@ class TestProcessKnowledgeQuery:
         assert len(messages) == 1
         assert messages[0]["content"] == "Knowledge response text"
         assert isinstance(messages[0]["content"], str)
+
+
+class TestProcessPipelineOperation:
+    """Test process_pipeline_operation task."""
+
+    @pytest.mark.asyncio
+    async def test_process_pipeline_operation_success(self):
+        """Pipeline task should persist results and mark completion."""
+        mock_redis = AsyncMock()
+        mock_task_manager = AsyncMock()
+        mock_task_manager.update_task_status = AsyncMock()
+        mock_task_manager.set_task_result = AsyncMock()
+
+        with (
+            patch("redis_sre_agent.core.docket_tasks.get_redis_client", return_value=mock_redis),
+            patch("redis_sre_agent.core.docket_tasks.TaskManager", return_value=mock_task_manager),
+            patch("redis_sre_agent.core.docket_tasks.TaskEmitter"),
+            patch(
+                "redis_sre_agent.core.pipeline_execution_helpers.run_pipeline_operation_helper",
+                new_callable=AsyncMock,
+                return_value={"operation": "scrape", "success": True},
+            ) as mock_helper,
+        ):
+            result = await process_pipeline_operation(
+                operation="scrape",
+                task_id="task-123",
+                thread_id="thread-456",
+                artifacts_path="/tmp/artifacts",
+                scrapers=["redis_docs"],
+            )
+
+        assert result == {"operation": "scrape", "success": True}
+        mock_helper.assert_awaited_once()
+        mock_task_manager.update_task_status.assert_any_call("task-123", TaskStatus.IN_PROGRESS)
+        mock_task_manager.update_task_status.assert_any_call("task-123", TaskStatus.DONE)
+        mock_task_manager.set_task_result.assert_awaited_once_with(
+            "task-123",
+            {"operation": "scrape", "success": True},
+        )
+
+    @pytest.mark.asyncio
+    async def test_process_pipeline_operation_error(self):
+        """Pipeline task should persist task errors and re-raise failures."""
+        mock_redis = AsyncMock()
+        mock_task_manager = AsyncMock()
+        mock_task_manager.update_task_status = AsyncMock()
+        mock_task_manager.set_task_error = AsyncMock()
+
+        with (
+            patch("redis_sre_agent.core.docket_tasks.get_redis_client", return_value=mock_redis),
+            patch("redis_sre_agent.core.docket_tasks.TaskManager", return_value=mock_task_manager),
+            patch("redis_sre_agent.core.docket_tasks.TaskEmitter"),
+            patch(
+                "redis_sre_agent.core.pipeline_execution_helpers.run_pipeline_operation_helper",
+                new_callable=AsyncMock,
+                side_effect=Exception("pipeline failed"),
+            ),
+        ):
+            with pytest.raises(Exception, match="pipeline failed"):
+                await process_pipeline_operation(
+                    operation="ingest",
+                    task_id="task-123",
+                    thread_id="thread-456",
+                    batch_date="2026-03-25",
+                )
+
+        mock_task_manager.set_task_error.assert_awaited_once_with("task-123", "pipeline failed")
 
 
 class TestSchedulerTask:

--- a/tests/unit/core/test_thread_inspection_helpers.py
+++ b/tests/unit/core/test_thread_inspection_helpers.py
@@ -1,0 +1,275 @@
+"""Tests for thread inspection helpers."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from redis_sre_agent.core.thread_inspection_helpers import (
+    get_thread_sources_helper,
+    get_thread_trace_helper,
+)
+
+
+class TestGetThreadSourcesHelper:
+    """Test shared helpers for thread source inspection."""
+
+    @pytest.mark.asyncio
+    async def test_get_thread_sources_helper_collects_fragments(self):
+        """Knowledge-source updates should be flattened into fragment rows."""
+        mock_client = AsyncMock()
+        mock_client.zrange.return_value = [b"task-1", "task-2"]
+        task_state = SimpleNamespace(
+            updates=[
+                SimpleNamespace(
+                    update_type="knowledge_sources",
+                    timestamp="2026-03-25T12:00:00Z",
+                    metadata={
+                        "fragments": [
+                            {
+                                "id": "frag-1",
+                                "document_hash": "doc-1",
+                                "chunk_index": 3,
+                                "title": "KB Article",
+                                "source": "redis.io",
+                            }
+                        ]
+                    },
+                ),
+                SimpleNamespace(
+                    update_type="progress",
+                    timestamp="2026-03-25T12:01:00Z",
+                    metadata={},
+                ),
+            ]
+        )
+
+        with (
+            patch(
+                "redis_sre_agent.core.thread_inspection_helpers.get_redis_client",
+                return_value=mock_client,
+            ),
+            patch(
+                "redis_sre_agent.core.thread_inspection_helpers.ThreadManager.get_thread",
+                new_callable=AsyncMock,
+                return_value=object(),
+            ),
+            patch(
+                "redis_sre_agent.core.thread_inspection_helpers.TaskManager.get_task_state",
+                new_callable=AsyncMock,
+                side_effect=[task_state, None],
+            ) as mock_get_task,
+        ):
+            result = await get_thread_sources_helper("thread-123")
+
+        assert result == {
+            "thread_id": "thread-123",
+            "task_id": None,
+            "fragments": [
+                {
+                    "timestamp": "2026-03-25T12:00:00Z",
+                    "task_id": "task-1",
+                    "id": "frag-1",
+                    "document_hash": "doc-1",
+                    "chunk_index": 3,
+                    "title": "KB Article",
+                    "source": "redis.io",
+                }
+            ],
+            "count": 1,
+        }
+        mock_client.zrange.assert_awaited_once()
+        assert mock_get_task.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_get_thread_sources_helper_filters_task_and_ignores_bad_updates(self):
+        """Task filters should narrow results while malformed updates are ignored."""
+        mock_client = AsyncMock()
+        mock_client.zrange.return_value = ["task-1", "task-2"]
+        task_state = SimpleNamespace(
+            updates=[
+                SimpleNamespace(
+                    update_type="knowledge_sources",
+                    timestamp="2026-03-25T12:00:00Z",
+                    metadata={"fragments": [object()]},
+                ),
+                SimpleNamespace(
+                    update_type="knowledge_sources",
+                    timestamp="2026-03-25T12:01:00Z",
+                    metadata={"fragments": [{"id": "frag-2"}]},
+                ),
+            ]
+        )
+
+        with (
+            patch(
+                "redis_sre_agent.core.thread_inspection_helpers.get_redis_client",
+                return_value=mock_client,
+            ),
+            patch(
+                "redis_sre_agent.core.thread_inspection_helpers.ThreadManager.get_thread",
+                new_callable=AsyncMock,
+                return_value=object(),
+            ),
+            patch(
+                "redis_sre_agent.core.thread_inspection_helpers.TaskManager.get_task_state",
+                new_callable=AsyncMock,
+                return_value=task_state,
+            ) as mock_get_task,
+        ):
+            result = await get_thread_sources_helper("thread-123", task_id="task-2")
+
+        assert result["count"] == 1
+        assert result["fragments"][0]["task_id"] == "task-2"
+        assert result["fragments"][0]["id"] == "frag-2"
+        mock_get_task.assert_awaited_once_with("task-2")
+
+    @pytest.mark.asyncio
+    async def test_get_thread_sources_helper_returns_not_found_payload(self):
+        """Missing threads should return an empty error payload."""
+        with (
+            patch(
+                "redis_sre_agent.core.thread_inspection_helpers.get_redis_client",
+                return_value=AsyncMock(),
+            ),
+            patch(
+                "redis_sre_agent.core.thread_inspection_helpers.ThreadManager.get_thread",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+        ):
+            result = await get_thread_sources_helper("thread-missing")
+
+        assert result == {
+            "error": "Thread thread-missing not found",
+            "thread_id": "thread-missing",
+            "task_id": None,
+            "fragments": [],
+            "count": 0,
+        }
+
+
+class TestGetThreadTraceHelper:
+    """Test shared helpers for thread trace inspection."""
+
+    @pytest.mark.asyncio
+    async def test_get_thread_trace_helper_summarizes_trace(self):
+        """Trace helper should summarize tool calls and derive citations."""
+        trace = {
+            "message_id": "msg-123",
+            "otel_trace_id": "otel-123",
+            "created_at": "2026-03-25T12:00:00Z",
+            "tool_envelopes": [
+                {
+                    "tool_key": "knowledge.search",
+                    "name": "knowledge_search",
+                    "args": {"query": "memory"},
+                    "status": "success",
+                    "summary": "Found memory docs",
+                    "data": {
+                        "results": [
+                            {
+                                "id": "doc-1",
+                                "title": "Memory Tuning",
+                                "source": "redis.io",
+                                "score": 0.98,
+                            }
+                        ]
+                    },
+                },
+                {
+                    "tool_key": "redis.info",
+                    "name": "redis_info",
+                    "args": {},
+                    "status": "success",
+                    "data": {"used_memory": 123},
+                },
+            ],
+        }
+
+        with (
+            patch(
+                "redis_sre_agent.core.thread_inspection_helpers.get_redis_client",
+                return_value=AsyncMock(),
+            ),
+            patch(
+                "redis_sre_agent.core.thread_inspection_helpers.ThreadManager.get_message_trace",
+                new_callable=AsyncMock,
+                return_value=trace,
+            ),
+        ):
+            result = await get_thread_trace_helper("msg-123")
+
+        assert result["message_id"] == "msg-123"
+        assert result["tool_call_count"] == 2
+        assert result["tool_calls"][0]["name"] == "knowledge_search"
+        assert result["tool_calls"][0]["result_preview"] == "Found memory docs"
+        assert "data" not in result["tool_calls"][0]
+        assert result["citations"] == [
+            {
+                "title": "Memory Tuning",
+                "source": "redis.io",
+                "score": 0.98,
+                "document_id": "doc-1",
+            }
+        ]
+        assert result["citation_count"] == 1
+
+    @pytest.mark.asyncio
+    async def test_get_thread_trace_helper_includes_tool_data_when_requested(self):
+        """Full tool data should be included when explicitly requested."""
+        trace = {
+            "message_id": "msg-123",
+            "tool_envelopes": [
+                {
+                    "tool_key": "redis.info",
+                    "name": "redis_info",
+                    "args": {},
+                    "status": "failed",
+                    "data": {"error": "boom"},
+                }
+            ],
+        }
+
+        with (
+            patch(
+                "redis_sre_agent.core.thread_inspection_helpers.get_redis_client",
+                return_value=AsyncMock(),
+            ),
+            patch(
+                "redis_sre_agent.core.thread_inspection_helpers.ThreadManager.get_message_trace",
+                new_callable=AsyncMock,
+                return_value=trace,
+            ),
+        ):
+            result = await get_thread_trace_helper("msg-123", include_tool_data=True)
+
+        assert result["tool_call_count"] == 1
+        assert result["tool_calls"][0]["status"] == "failed"
+        assert result["tool_calls"][0]["data"] == {"error": "boom"}
+        assert result["citation_count"] == 0
+
+    @pytest.mark.asyncio
+    async def test_get_thread_trace_helper_returns_not_found_payload(self):
+        """Missing traces should return an empty error payload."""
+        with (
+            patch(
+                "redis_sre_agent.core.thread_inspection_helpers.get_redis_client",
+                return_value=AsyncMock(),
+            ),
+            patch(
+                "redis_sre_agent.core.thread_inspection_helpers.ThreadManager.get_message_trace",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+        ):
+            result = await get_thread_trace_helper("msg-missing")
+
+        assert result == {
+            "error": "No decision trace found for message msg-missing",
+            "message_id": "msg-missing",
+            "tool_calls": [],
+            "tool_call_count": 0,
+            "citations": [],
+            "citation_count": 0,
+        }

--- a/tests/unit/core/test_thread_maintenance_helpers.py
+++ b/tests/unit/core/test_thread_maintenance_helpers.py
@@ -1,0 +1,767 @@
+"""Tests for thread maintenance MCP helpers."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+def _thread_state(
+    *,
+    subject: str = "",
+    user_id: str | None = None,
+    tags: list[str] | None = None,
+    context: dict | None = None,
+    messages: list | None = None,
+):
+    return SimpleNamespace(
+        metadata=SimpleNamespace(subject=subject, user_id=user_id, tags=tags or []),
+        context=context or {},
+        messages=messages or [],
+    )
+
+
+class TestThreadMaintenanceUtilities:
+    def test_parse_duration_and_decode_helpers(self):
+        from redis_sre_agent.core.thread_maintenance_helpers import _decode, _parse_duration
+
+        assert _decode(b"abc") == "abc"
+        assert _decode("abc") == "abc"
+        assert _parse_duration("2h").total_seconds() == 7200
+        assert _parse_duration("15m").total_seconds() == 900
+        assert _parse_duration("30").total_seconds() == 30
+
+    def test_parse_duration_rejects_invalid_values(self):
+        from redis_sre_agent.core.thread_maintenance_helpers import _parse_duration
+
+        with pytest.raises(ValueError, match="Invalid duration"):
+            _parse_duration("oops")
+
+    def test_derive_subject_prefers_original_query_then_messages(self):
+        from redis_sre_agent.core.thread_maintenance_helpers import _derive_subject
+
+        assert (
+            _derive_subject(
+                _thread_state(context={"original_query": "Check memory usage\nASAP"}),
+            )
+            == "Check memory usage\nASAP"
+        )
+        assert (
+            _derive_subject(
+                _thread_state(
+                    context={},
+                    messages=[SimpleNamespace(role="user", content="Investigate slow queries")],
+                )
+            )
+            == "Investigate slow queries"
+        )
+        assert (
+            _derive_subject(
+                _thread_state(
+                    context={"messages": [{"role": "user", "content": "Legacy message"}]},
+                )
+            )
+            == "Legacy message"
+        )
+        assert _derive_subject(_thread_state()) is None
+
+
+class TestThreadReindexHelpers:
+    @pytest.mark.asyncio
+    async def test_reindex_threads_helper_drops_recreates_and_backfills(self):
+        from redis_sre_agent.core.thread_maintenance_helpers import reindex_threads_helper
+
+        client = AsyncMock()
+        client.zrevrange.side_effect = [[b"thread-1"], []]
+
+        thread_manager = AsyncMock()
+
+        index = AsyncMock()
+        index.exists.side_effect = [True, False]
+
+        with (
+            patch(
+                "redis_sre_agent.core.thread_maintenance_helpers.get_redis_client",
+                return_value=client,
+            ),
+            patch(
+                "redis_sre_agent.core.thread_maintenance_helpers.ThreadManager",
+                return_value=thread_manager,
+            ),
+            patch(
+                "redis_sre_agent.core.thread_maintenance_helpers.get_threads_index",
+                new_callable=AsyncMock,
+                return_value=index,
+            ),
+        ):
+            result = await reindex_threads_helper(drop=True, limit=0, start=0)
+
+        assert result == {
+            "status": "completed",
+            "processed": 1,
+            "dropped": True,
+            "index": "sre_threads",
+        }
+        index.drop.assert_awaited_once()
+        index.create.assert_awaited_once()
+        thread_manager._upsert_thread_search_doc.assert_awaited_once_with("thread-1")
+
+    @pytest.mark.asyncio
+    async def test_reindex_threads_helper_falls_back_to_ft_dropindex(self):
+        from redis_sre_agent.core.thread_maintenance_helpers import reindex_threads_helper
+
+        client = AsyncMock()
+        client.zrevrange.side_effect = [[]]
+
+        thread_manager = AsyncMock()
+
+        index = AsyncMock()
+        index.exists.side_effect = [True, True]
+        index.drop.side_effect = RuntimeError("no drop")
+
+        with (
+            patch(
+                "redis_sre_agent.core.thread_maintenance_helpers.get_redis_client",
+                return_value=client,
+            ),
+            patch(
+                "redis_sre_agent.core.thread_maintenance_helpers.ThreadManager",
+                return_value=thread_manager,
+            ),
+            patch(
+                "redis_sre_agent.core.thread_maintenance_helpers.get_threads_index",
+                new_callable=AsyncMock,
+                return_value=index,
+            ),
+        ):
+            result = await reindex_threads_helper(drop=True, limit=0, start=0)
+
+        assert result["processed"] == 0
+        client.execute_command.assert_awaited_once_with("FT.DROPINDEX", "sre_threads")
+
+    @pytest.mark.asyncio
+    async def test_reindex_threads_helper_tolerates_exists_and_drop_failures(self):
+        from redis_sre_agent.core.thread_maintenance_helpers import reindex_threads_helper
+
+        client = AsyncMock()
+        client.zrevrange.side_effect = [[]]
+
+        thread_manager = AsyncMock()
+
+        index = AsyncMock()
+        index.exists.side_effect = [RuntimeError("missing"), True]
+        index.drop.side_effect = RuntimeError("no drop")
+        client.execute_command.side_effect = RuntimeError("still no drop")
+
+        with (
+            patch(
+                "redis_sre_agent.core.thread_maintenance_helpers.get_redis_client",
+                return_value=client,
+            ),
+            patch(
+                "redis_sre_agent.core.thread_maintenance_helpers.ThreadManager",
+                return_value=thread_manager,
+            ),
+            patch(
+                "redis_sre_agent.core.thread_maintenance_helpers.get_threads_index",
+                new_callable=AsyncMock,
+                return_value=index,
+            ),
+        ):
+            result = await reindex_threads_helper(drop=True, limit=0, start=0)
+
+        assert result == {
+            "status": "completed",
+            "processed": 0,
+            "dropped": False,
+            "index": "sre_threads",
+        }
+        index.create.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_reindex_threads_helper_ignores_ft_dropindex_failures(self):
+        from redis_sre_agent.core.thread_maintenance_helpers import reindex_threads_helper
+
+        client = AsyncMock()
+        client.zrevrange.side_effect = [[]]
+        client.execute_command.side_effect = RuntimeError("still no drop")
+
+        thread_manager = AsyncMock()
+
+        index = AsyncMock()
+        index.exists.side_effect = [True, True]
+        index.drop.side_effect = RuntimeError("no drop")
+
+        with (
+            patch(
+                "redis_sre_agent.core.thread_maintenance_helpers.get_redis_client",
+                return_value=client,
+            ),
+            patch(
+                "redis_sre_agent.core.thread_maintenance_helpers.ThreadManager",
+                return_value=thread_manager,
+            ),
+            patch(
+                "redis_sre_agent.core.thread_maintenance_helpers.get_threads_index",
+                new_callable=AsyncMock,
+                return_value=index,
+            ),
+        ):
+            result = await reindex_threads_helper(drop=True, limit=0, start=0)
+
+        assert result == {
+            "status": "completed",
+            "processed": 0,
+            "dropped": False,
+            "index": "sre_threads",
+        }
+        index.create.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_backfill_threads_helper_applies_limit(self):
+        from redis_sre_agent.core.thread_maintenance_helpers import backfill_threads_helper
+
+        client = AsyncMock()
+        client.zrevrange.side_effect = [[b"thread-1", b"thread-2"], []]
+        thread_manager = AsyncMock()
+
+        with (
+            patch(
+                "redis_sre_agent.core.thread_maintenance_helpers.get_redis_client",
+                return_value=client,
+            ),
+            patch(
+                "redis_sre_agent.core.thread_maintenance_helpers.ThreadManager",
+                return_value=thread_manager,
+            ),
+        ):
+            result = await backfill_threads_helper(limit=1, start=0)
+
+        assert result == {"status": "completed", "processed": 1, "index": "sre_threads"}
+        thread_manager._upsert_thread_search_doc.assert_awaited_once_with("thread-1")
+
+
+class TestThreadSubjectBackfills:
+    @pytest.mark.asyncio
+    async def test_backfill_scheduled_subjects_updates_subjects_and_tags(self):
+        from redis_sre_agent.core.thread_maintenance_helpers import (
+            backfill_scheduled_thread_subjects_helper,
+        )
+
+        client = AsyncMock()
+        client.zrevrange.side_effect = [[b"thread-1"], []]
+        thread_manager = AsyncMock()
+        state = _thread_state(
+            subject="",
+            user_id="scheduler",
+            tags=[],
+            context={"schedule_name": "Nightly Check", "automated": True},
+        )
+        thread_manager.get_thread.return_value = state
+
+        with (
+            patch(
+                "redis_sre_agent.core.thread_maintenance_helpers.get_redis_client",
+                return_value=client,
+            ),
+            patch(
+                "redis_sre_agent.core.thread_maintenance_helpers.ThreadManager",
+                return_value=thread_manager,
+            ),
+        ):
+            result = await backfill_scheduled_thread_subjects_helper(
+                limit=0, start=0, dry_run=False
+            )
+
+        assert result == {
+            "status": "completed",
+            "scanned": 1,
+            "subjects_updated": 1,
+            "tags_updated": 1,
+            "dry_run": False,
+        }
+        thread_manager.set_thread_subject.assert_awaited_once_with("thread-1", "Nightly Check")
+        assert state.metadata.tags == ["scheduled"]
+        thread_manager._save_thread_state.assert_awaited_once_with(state)
+
+    @pytest.mark.asyncio
+    async def test_backfill_scheduled_subjects_supports_dry_run(self):
+        from redis_sre_agent.core.thread_maintenance_helpers import (
+            backfill_scheduled_thread_subjects_helper,
+        )
+
+        client = AsyncMock()
+        client.zrevrange.side_effect = [[b"thread-1"], []]
+        thread_manager = AsyncMock()
+        thread_manager.get_thread.return_value = _thread_state(
+            subject="Unknown",
+            user_id="scheduler",
+            tags=["scheduled"],
+            context={"schedule_name": "Nightly Check"},
+        )
+
+        with (
+            patch(
+                "redis_sre_agent.core.thread_maintenance_helpers.get_redis_client",
+                return_value=client,
+            ),
+            patch(
+                "redis_sre_agent.core.thread_maintenance_helpers.ThreadManager",
+                return_value=thread_manager,
+            ),
+        ):
+            result = await backfill_scheduled_thread_subjects_helper(limit=0, start=0, dry_run=True)
+
+        assert result["status"] == "dry_run"
+        thread_manager.set_thread_subject.assert_not_called()
+        thread_manager._save_thread_state.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_backfill_scheduled_subjects_skips_missing_state(self):
+        from redis_sre_agent.core.thread_maintenance_helpers import (
+            backfill_scheduled_thread_subjects_helper,
+        )
+
+        client = AsyncMock()
+        client.zrevrange.side_effect = [[b"thread-1"], []]
+        thread_manager = AsyncMock()
+        thread_manager.get_thread.return_value = None
+
+        with (
+            patch(
+                "redis_sre_agent.core.thread_maintenance_helpers.get_redis_client",
+                return_value=client,
+            ),
+            patch(
+                "redis_sre_agent.core.thread_maintenance_helpers.ThreadManager",
+                return_value=thread_manager,
+            ),
+        ):
+            result = await backfill_scheduled_thread_subjects_helper(
+                limit=0, start=0, dry_run=False
+            )
+
+        assert result == {
+            "status": "completed",
+            "scanned": 1,
+            "subjects_updated": 0,
+            "tags_updated": 0,
+            "dry_run": False,
+        }
+
+    @pytest.mark.asyncio
+    async def test_backfill_scheduled_subjects_honors_limit(self):
+        from redis_sre_agent.core.thread_maintenance_helpers import (
+            backfill_scheduled_thread_subjects_helper,
+        )
+
+        client = AsyncMock()
+        client.zrevrange.side_effect = [[b"thread-1", b"thread-2"], []]
+        thread_manager = AsyncMock()
+        thread_manager.get_thread.side_effect = [
+            _thread_state(
+                subject="",
+                user_id="scheduler",
+                tags=[],
+                context={"schedule_name": "Nightly Check"},
+            ),
+            _thread_state(
+                subject="",
+                user_id="scheduler",
+                tags=[],
+                context={"schedule_name": "Should Not Be Reached"},
+            ),
+        ]
+
+        with (
+            patch(
+                "redis_sre_agent.core.thread_maintenance_helpers.get_redis_client",
+                return_value=client,
+            ),
+            patch(
+                "redis_sre_agent.core.thread_maintenance_helpers.ThreadManager",
+                return_value=thread_manager,
+            ),
+        ):
+            result = await backfill_scheduled_thread_subjects_helper(
+                limit=1, start=0, dry_run=False
+            )
+
+        assert result == {
+            "status": "completed",
+            "scanned": 1,
+            "subjects_updated": 1,
+            "tags_updated": 1,
+            "dry_run": False,
+        }
+
+    @pytest.mark.asyncio
+    async def test_backfill_empty_subjects_updates_subject_and_truncates(self):
+        from redis_sre_agent.core.thread_maintenance_helpers import (
+            backfill_empty_thread_subjects_helper,
+        )
+
+        client = AsyncMock()
+        client.scan.side_effect = [(0, [b"sre_threads:thread-1"])]
+        thread_manager = AsyncMock()
+        thread_manager.get_thread.return_value = _thread_state(
+            subject="Untitled",
+            context={"original_query": "A" * 90},
+        )
+
+        with (
+            patch(
+                "redis_sre_agent.core.thread_maintenance_helpers.get_redis_client",
+                return_value=client,
+            ),
+            patch(
+                "redis_sre_agent.core.thread_maintenance_helpers.ThreadManager",
+                return_value=thread_manager,
+            ),
+        ):
+            result = await backfill_empty_thread_subjects_helper(limit=0, start=0, dry_run=False)
+
+        assert result == {
+            "status": "completed",
+            "scanned": 1,
+            "subjects_updated": 1,
+            "dry_run": False,
+        }
+        subject = thread_manager.set_thread_subject.await_args.args[1]
+        assert subject.endswith("...")
+        assert len(subject) == 80
+
+    @pytest.mark.asyncio
+    async def test_backfill_empty_subjects_supports_dry_run_and_skips_missing_state(self):
+        from redis_sre_agent.core.thread_maintenance_helpers import (
+            backfill_empty_thread_subjects_helper,
+        )
+
+        client = AsyncMock()
+        client.scan.side_effect = [(0, [b"sre_threads:thread-1", b"sre_threads:thread-2"])]
+        thread_manager = AsyncMock()
+        thread_manager.get_thread.side_effect = [
+            None,
+            _thread_state(
+                subject="", context={"messages": [{"role": "user", "content": "Legacy"}]}
+            ),
+        ]
+
+        with (
+            patch(
+                "redis_sre_agent.core.thread_maintenance_helpers.get_redis_client",
+                return_value=client,
+            ),
+            patch(
+                "redis_sre_agent.core.thread_maintenance_helpers.ThreadManager",
+                return_value=thread_manager,
+            ),
+        ):
+            result = await backfill_empty_thread_subjects_helper(limit=0, start=0, dry_run=True)
+
+        assert result == {
+            "status": "dry_run",
+            "scanned": 2,
+            "subjects_updated": 1,
+            "dry_run": True,
+        }
+        thread_manager.set_thread_subject.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_backfill_empty_subjects_handles_break_limit_and_skip_paths(self):
+        from redis_sre_agent.core.thread_maintenance_helpers import (
+            backfill_empty_thread_subjects_helper,
+        )
+
+        client = AsyncMock()
+        client.scan.side_effect = [
+            (0, []),
+            (0, [b"sre_threads:thread-1", b"sre_threads:thread-2"]),
+            (0, [b"sre_threads:thread-3", b"sre_threads:thread-4"]),
+        ]
+        thread_manager = AsyncMock()
+        thread_manager.get_thread.side_effect = [
+            _thread_state(subject="Healthy subject"),
+            _thread_state(subject="", context={}),
+            _thread_state(subject="", context={"original_query": "Recovered subject"}),
+            _thread_state(subject="", context={"original_query": "Ignored by limit"}),
+        ]
+
+        with (
+            patch(
+                "redis_sre_agent.core.thread_maintenance_helpers.get_redis_client",
+                return_value=client,
+            ),
+            patch(
+                "redis_sre_agent.core.thread_maintenance_helpers.ThreadManager",
+                return_value=thread_manager,
+            ),
+        ):
+            empty_result = await backfill_empty_thread_subjects_helper(
+                limit=0, start=0, dry_run=False
+            )
+            skip_result = await backfill_empty_thread_subjects_helper(
+                limit=0, start=0, dry_run=False
+            )
+            limited_result = await backfill_empty_thread_subjects_helper(
+                limit=1, start=0, dry_run=False
+            )
+
+        assert empty_result == {
+            "status": "completed",
+            "scanned": 0,
+            "subjects_updated": 0,
+            "dry_run": False,
+        }
+        assert skip_result == {
+            "status": "completed",
+            "scanned": 2,
+            "subjects_updated": 0,
+            "dry_run": False,
+        }
+        assert limited_result == {
+            "status": "completed",
+            "scanned": 1,
+            "subjects_updated": 1,
+            "dry_run": False,
+        }
+        thread_manager.set_thread_subject.assert_awaited_once_with("thread-3", "Recovered subject")
+
+
+class TestThreadPurgeHelper:
+    @pytest.mark.asyncio
+    async def test_purge_threads_helper_requires_scope(self):
+        from redis_sre_agent.core.thread_maintenance_helpers import purge_threads_helper
+
+        result = await purge_threads_helper(confirm=True)
+
+        assert result == {
+            "error": "Refusing to purge without a scope. Provide older_than or purge_all.",
+            "status": "failed",
+        }
+
+    @pytest.mark.asyncio
+    async def test_purge_threads_helper_requires_confirmation(self):
+        from redis_sre_agent.core.thread_maintenance_helpers import purge_threads_helper
+
+        result = await purge_threads_helper(older_than="7d", confirm=False)
+
+        assert result == {
+            "error": "Confirmation required",
+            "status": "cancelled",
+            "dry_run": False,
+        }
+
+    @pytest.mark.asyncio
+    async def test_purge_threads_helper_supports_dry_run(self):
+        from redis_sre_agent.core.thread_maintenance_helpers import purge_threads_helper
+
+        client = AsyncMock()
+        client.scan.side_effect = [(0, [b"sre_threads:thread-1"])]
+        client.hget.return_value = b"1"
+
+        with patch(
+            "redis_sre_agent.core.thread_maintenance_helpers.get_redis_client",
+            return_value=client,
+        ):
+            result = await purge_threads_helper(older_than="3650d", dry_run=True)
+
+        assert result == {
+            "status": "dry_run",
+            "scanned": 1,
+            "deleted": 0,
+            "deleted_tasks": 0,
+            "matched": ["thread-1"],
+            "dry_run": True,
+            "include_tasks": True,
+        }
+
+    @pytest.mark.asyncio
+    async def test_purge_threads_helper_deletes_threads_and_tasks(self):
+        from redis_sre_agent.core.thread_maintenance_helpers import purge_threads_helper
+
+        client = AsyncMock()
+        client.scan.side_effect = [
+            (0, [b"sre_threads:thread-1"]),
+            (0, [b"sre_tasks:task-doc-1"]),
+        ]
+        client.hget.side_effect = [b"1", b"thread-1"]
+        client.zrevrange.return_value = [b"task-1"]
+
+        thread_manager = AsyncMock()
+        thread_manager.delete_thread.return_value = True
+
+        with (
+            patch(
+                "redis_sre_agent.core.thread_maintenance_helpers.get_redis_client",
+                return_value=client,
+            ),
+            patch(
+                "redis_sre_agent.core.thread_maintenance_helpers.ThreadManager",
+                return_value=thread_manager,
+            ),
+            patch(
+                "redis_sre_agent.core.thread_maintenance_helpers.delete_task_core",
+                new_callable=AsyncMock,
+            ) as mock_delete_task,
+        ):
+            result = await purge_threads_helper(purge_all=True, confirm=True)
+
+        assert result == {
+            "status": "purged",
+            "scanned": 1,
+            "deleted": 1,
+            "deleted_tasks": 1,
+            "matched": ["thread-1"],
+            "dry_run": False,
+            "include_tasks": True,
+        }
+        mock_delete_task.assert_awaited_once_with(task_id="task-1", redis_client=client)
+        thread_manager.delete_thread.assert_awaited_once_with("thread-1")
+
+    @pytest.mark.asyncio
+    async def test_purge_threads_helper_ignores_task_and_delete_errors(self):
+        from redis_sre_agent.core.thread_maintenance_helpers import purge_threads_helper
+
+        client = AsyncMock()
+        client.scan.side_effect = [
+            (0, [b"sre_threads:thread-1"]),
+            (0, [b"sre_tasks:task-doc-1"]),
+        ]
+        client.hget.side_effect = [b"1", RuntimeError("ignore me")]
+        client.zrevrange.return_value = [b"task-1"]
+        client.delete.side_effect = RuntimeError("ignore me")
+
+        thread_manager = AsyncMock()
+        thread_manager.delete_thread.return_value = False
+
+        with (
+            patch(
+                "redis_sre_agent.core.thread_maintenance_helpers.get_redis_client",
+                return_value=client,
+            ),
+            patch(
+                "redis_sre_agent.core.thread_maintenance_helpers.ThreadManager",
+                return_value=thread_manager,
+            ),
+            patch(
+                "redis_sre_agent.core.thread_maintenance_helpers.delete_task_core",
+                new_callable=AsyncMock,
+                side_effect=RuntimeError("ignore me"),
+            ),
+        ):
+            result = await purge_threads_helper(purge_all=True, confirm=True)
+
+        assert result == {
+            "status": "purged",
+            "scanned": 1,
+            "deleted": 0,
+            "deleted_tasks": 0,
+            "matched": ["thread-1"],
+            "dry_run": False,
+            "include_tasks": True,
+        }
+
+    @pytest.mark.asyncio
+    async def test_purge_threads_helper_handles_empty_and_ineligible_threads(self):
+        from redis_sre_agent.core.thread_maintenance_helpers import purge_threads_helper
+
+        client = AsyncMock()
+        client.scan.side_effect = [
+            (0, []),
+            (0, [b"sre_threads:thread-1", b"sre_threads:thread-2"]),
+            (0, [b"sre_threads:thread-3"]),
+            (0, [b"sre_tasks:task-doc-1"]),
+        ]
+        client.hget.side_effect = [
+            b"9999999999",
+            RuntimeError("bad timestamp"),
+            b"1",
+            RuntimeError("bad task doc"),
+        ]
+
+        thread_manager = AsyncMock()
+        thread_manager.delete_thread.return_value = True
+        client.delete.side_effect = [RuntimeError("thread doc delete failed")]
+
+        with (
+            patch(
+                "redis_sre_agent.core.thread_maintenance_helpers.get_redis_client",
+                return_value=client,
+            ),
+            patch(
+                "redis_sre_agent.core.thread_maintenance_helpers.ThreadManager",
+                return_value=thread_manager,
+            ),
+        ):
+            empty_result = await purge_threads_helper(purge_all=True, confirm=True)
+            skipped_result = await purge_threads_helper(
+                older_than="3650d", include_tasks=False, confirm=True
+            )
+            deleted_result = await purge_threads_helper(purge_all=True, confirm=True)
+
+        assert empty_result == {
+            "status": "purged",
+            "scanned": 0,
+            "deleted": 0,
+            "deleted_tasks": 0,
+            "matched": [],
+            "dry_run": False,
+            "include_tasks": True,
+        }
+        assert skipped_result == {
+            "status": "purged",
+            "scanned": 2,
+            "deleted": 0,
+            "deleted_tasks": 0,
+            "matched": [],
+            "dry_run": False,
+            "include_tasks": False,
+        }
+        assert deleted_result == {
+            "status": "purged",
+            "scanned": 1,
+            "deleted": 1,
+            "deleted_tasks": 0,
+            "matched": ["thread-3"],
+            "dry_run": False,
+            "include_tasks": True,
+        }
+
+    @pytest.mark.asyncio
+    async def test_purge_threads_helper_ignores_stray_task_doc_delete_errors(self):
+        from redis_sre_agent.core.thread_maintenance_helpers import purge_threads_helper
+
+        client = AsyncMock()
+        client.scan.side_effect = [
+            (0, [b"sre_threads:thread-1"]),
+            (0, [b"sre_tasks:task-doc-1"]),
+        ]
+        client.hget.return_value = b"thread-1"
+        client.zrevrange.return_value = []
+        client.delete.side_effect = [RuntimeError("task doc delete failed"), None]
+
+        thread_manager = AsyncMock()
+        thread_manager.delete_thread.return_value = True
+
+        with (
+            patch(
+                "redis_sre_agent.core.thread_maintenance_helpers.get_redis_client",
+                return_value=client,
+            ),
+            patch(
+                "redis_sre_agent.core.thread_maintenance_helpers.ThreadManager",
+                return_value=thread_manager,
+            ),
+        ):
+            result = await purge_threads_helper(purge_all=True, confirm=True)
+
+        assert result == {
+            "status": "purged",
+            "scanned": 1,
+            "deleted": 1,
+            "deleted_tasks": 0,
+            "matched": ["thread-1"],
+            "dry_run": False,
+            "include_tasks": True,
+        }

--- a/tests/unit/mcp_server/test_mcp_server.py
+++ b/tests/unit/mcp_server/test_mcp_server.py
@@ -6,7 +6,10 @@ import pytest
 
 from redis_sre_agent.mcp_server.server import (
     mcp,
+    redis_sre_backfill_empty_thread_subjects,
     redis_sre_backfill_instance_links,
+    redis_sre_backfill_scheduled_thread_subjects,
+    redis_sre_backfill_threads,
     redis_sre_cache_clear,
     redis_sre_cache_stats,
     redis_sre_cleanup_pipeline_batches,
@@ -55,8 +58,10 @@ from redis_sre_agent.mcp_server.server import (
     redis_sre_list_threads,
     redis_sre_prepare_source_documents,
     redis_sre_purge_tasks,
+    redis_sre_purge_threads,
     redis_sre_query,
     redis_sre_recreate_indices,
+    redis_sre_reindex_threads,
     redis_sre_run_pipeline_full,
     redis_sre_run_pipeline_ingest,
     redis_sre_run_pipeline_scrape,
@@ -152,6 +157,11 @@ class TestMCPServerSetup:
         assert "redis_sre_delete_schedule" in tool_names
         assert "redis_sre_run_schedule_now" in tool_names
         assert "redis_sre_list_schedule_runs" in tool_names
+        assert "redis_sre_reindex_threads" in tool_names
+        assert "redis_sre_backfill_threads" in tool_names
+        assert "redis_sre_backfill_scheduled_thread_subjects" in tool_names
+        assert "redis_sre_backfill_empty_thread_subjects" in tool_names
+        assert "redis_sre_purge_threads" in tool_names
 
 
 class TestDeepTriageTool:
@@ -2152,6 +2162,102 @@ class TestScheduleTools:
                 interval_value=12,
                 instructions="Check memory usage",
             )
+
+        assert result == {"error": "boom", "status": "failed"}
+
+
+class TestThreadMaintenanceTools:
+    """Test MCP tools for thread maintenance workflows."""
+
+    @pytest.mark.asyncio
+    async def test_reindex_threads_delegates_to_helper(self):
+        with patch(
+            "redis_sre_agent.core.thread_maintenance_helpers.reindex_threads_helper",
+            new_callable=AsyncMock,
+            return_value={"status": "completed", "processed": 2},
+        ) as mock_helper:
+            result = await redis_sre_reindex_threads(drop=True, limit=5, start=10)
+
+        assert result["processed"] == 2
+        mock_helper.assert_awaited_once_with(drop=True, limit=5, start=10)
+
+    @pytest.mark.asyncio
+    async def test_backfill_threads_delegates_to_helper(self):
+        with patch(
+            "redis_sre_agent.core.thread_maintenance_helpers.backfill_threads_helper",
+            new_callable=AsyncMock,
+            return_value={"status": "completed", "processed": 2},
+        ) as mock_helper:
+            result = await redis_sre_backfill_threads(limit=5, start=10)
+
+        assert result["processed"] == 2
+        mock_helper.assert_awaited_once_with(limit=5, start=10)
+
+    @pytest.mark.asyncio
+    async def test_backfill_scheduled_thread_subjects_delegates_to_helper(self):
+        with patch(
+            "redis_sre_agent.core.thread_maintenance_helpers.backfill_scheduled_thread_subjects_helper",
+            new_callable=AsyncMock,
+            return_value={"status": "dry_run", "subjects_updated": 2},
+        ) as mock_helper:
+            result = await redis_sre_backfill_scheduled_thread_subjects(
+                limit=5,
+                start=10,
+                dry_run=True,
+            )
+
+        assert result["subjects_updated"] == 2
+        mock_helper.assert_awaited_once_with(limit=5, start=10, dry_run=True)
+
+    @pytest.mark.asyncio
+    async def test_backfill_empty_thread_subjects_delegates_to_helper(self):
+        with patch(
+            "redis_sre_agent.core.thread_maintenance_helpers.backfill_empty_thread_subjects_helper",
+            new_callable=AsyncMock,
+            return_value={"status": "dry_run", "subjects_updated": 2},
+        ) as mock_helper:
+            result = await redis_sre_backfill_empty_thread_subjects(
+                limit=5,
+                start=10,
+                dry_run=True,
+            )
+
+        assert result["subjects_updated"] == 2
+        mock_helper.assert_awaited_once_with(limit=5, start=10, dry_run=True)
+
+    @pytest.mark.asyncio
+    async def test_purge_threads_delegates_to_helper(self):
+        with patch(
+            "redis_sre_agent.core.thread_maintenance_helpers.purge_threads_helper",
+            new_callable=AsyncMock,
+            return_value={"status": "purged", "deleted": 2},
+        ) as mock_helper:
+            result = await redis_sre_purge_threads(
+                older_than="7d",
+                purge_all=False,
+                include_tasks=True,
+                dry_run=False,
+                confirm=True,
+            )
+
+        assert result["deleted"] == 2
+        mock_helper.assert_awaited_once_with(
+            older_than="7d",
+            purge_all=False,
+            include_tasks=True,
+            dry_run=False,
+            confirm=True,
+        )
+
+    @pytest.mark.asyncio
+    async def test_thread_maintenance_tool_error_payload(self):
+        with patch(
+            "redis_sre_agent.core.thread_maintenance_helpers.reindex_threads_helper",
+            new_callable=AsyncMock,
+        ) as mock_helper:
+            mock_helper.side_effect = RuntimeError("boom")
+
+            result = await redis_sre_reindex_threads()
 
         assert result == {"error": "boom", "status": "failed"}
 

--- a/tests/unit/mcp_server/test_mcp_server.py
+++ b/tests/unit/mcp_server/test_mcp_server.py
@@ -6,6 +6,8 @@ import pytest
 
 from redis_sre_agent.mcp_server.server import (
     mcp,
+    redis_sre_cache_clear,
+    redis_sre_cache_stats,
     redis_sre_cleanup_pipeline_batches,
     redis_sre_create_instance,
     redis_sre_database_chat,
@@ -46,6 +48,7 @@ from redis_sre_agent.mcp_server.server import (
     redis_sre_test_redis_url,
     redis_sre_update_instance,
     redis_sre_upload_support_package,
+    redis_sre_version,
 )
 
 
@@ -104,6 +107,9 @@ class TestMCPServerSetup:
         assert "redis_sre_delete_instance" in tool_names
         assert "redis_sre_test_instance" in tool_names
         assert "redis_sre_test_redis_url" in tool_names
+        assert "redis_sre_cache_stats" in tool_names
+        assert "redis_sre_cache_clear" in tool_names
+        assert "redis_sre_version" in tool_names
 
 
 class TestDeepTriageTool:
@@ -1581,6 +1587,80 @@ class TestInstanceMutationTools:
             result = await redis_sre_update_instance(instance_id="redis-prod-1")
 
         assert result == {"error": "boom", "id": "redis-prod-1", "status": "failed"}
+
+
+class TestCacheAndVersionTools:
+    """Test MCP tools for cache management and version reporting."""
+
+    @pytest.mark.asyncio
+    async def test_cache_stats_delegates_to_helper(self):
+        """Cache stats should delegate to the shared helper."""
+        mock_result = {"total_keys": 7, "instances": ["redis-prod-1"]}
+
+        with patch(
+            "redis_sre_agent.core.cache_helpers.cache_stats_helper",
+            new_callable=AsyncMock,
+        ) as mock_helper:
+            mock_helper.return_value = mock_result
+
+            result = await redis_sre_cache_stats(instance_id="redis-prod-1")
+
+        assert result == mock_result
+        mock_helper.assert_awaited_once_with(instance_id="redis-prod-1")
+
+    @pytest.mark.asyncio
+    async def test_cache_stats_error_payload(self):
+        """Cache stats failures should be structured."""
+        with patch(
+            "redis_sre_agent.core.cache_helpers.cache_stats_helper",
+            new_callable=AsyncMock,
+        ) as mock_helper:
+            mock_helper.side_effect = RuntimeError("boom")
+
+            result = await redis_sre_cache_stats(instance_id="redis-prod-1")
+
+        assert result == {"error": "boom", "status": "failed", "instance_id": "redis-prod-1"}
+
+    @pytest.mark.asyncio
+    async def test_cache_clear_delegates_to_helper(self):
+        """Cache clear should delegate to the shared helper."""
+        mock_result = {"status": "cleared", "scope": "all", "deleted": 11}
+
+        with patch(
+            "redis_sre_agent.core.cache_helpers.cache_clear_helper",
+            new_callable=AsyncMock,
+        ) as mock_helper:
+            mock_helper.return_value = mock_result
+
+            result = await redis_sre_cache_clear(clear_all=True, confirm=True)
+
+        assert result == mock_result
+        mock_helper.assert_awaited_once_with(instance_id=None, clear_all=True, confirm=True)
+
+    @pytest.mark.asyncio
+    async def test_cache_clear_error_payload(self):
+        """Cache clear failures should be structured."""
+        with patch(
+            "redis_sre_agent.core.cache_helpers.cache_clear_helper",
+            new_callable=AsyncMock,
+        ) as mock_helper:
+            mock_helper.side_effect = RuntimeError("boom")
+
+            result = await redis_sre_cache_clear(instance_id="redis-prod-1", confirm=True)
+
+        assert result == {"error": "boom", "status": "failed", "instance_id": "redis-prod-1"}
+
+    def test_version_delegates_to_helper(self):
+        """Version tool should delegate to the shared helper."""
+        mock_result = {"name": "redis-sre-agent", "version": "0.0-test"}
+
+        with patch("redis_sre_agent.core.cache_helpers.version_helper") as mock_helper:
+            mock_helper.return_value = mock_result
+
+            result = redis_sre_version()
+
+        assert result == mock_result
+        mock_helper.assert_called_once_with()
 
     @pytest.mark.asyncio
     async def test_delete_instance_delegates_to_helper(self):

--- a/tests/unit/mcp_server/test_mcp_server.py
+++ b/tests/unit/mcp_server/test_mcp_server.py
@@ -40,6 +40,7 @@ from redis_sre_agent.mcp_server.server import (
     redis_sre_list_tasks,
     redis_sre_list_threads,
     redis_sre_prepare_source_documents,
+    redis_sre_purge_tasks,
     redis_sre_run_pipeline_full,
     redis_sre_run_pipeline_ingest,
     redis_sre_run_pipeline_scrape,
@@ -100,6 +101,7 @@ class TestMCPServerSetup:
         assert "redis_sre_get_task_citations" in tool_names
         assert "redis_sre_get_task" in tool_names
         assert "redis_sre_list_tasks" in tool_names
+        assert "redis_sre_purge_tasks" in tool_names
         assert "redis_sre_delete_task" in tool_names
         assert "redis_sre_list_instances" in tool_names
         assert "redis_sre_create_instance" in tool_names
@@ -2442,3 +2444,46 @@ class TestDeleteTaskTool:
             assert result["status"] == "error"
             assert result["task_id"] == "task-err"
             assert "boom" in result["error"]
+
+
+class TestPurgeTasksTool:
+    """Test the redis_sre_purge_tasks MCP tool."""
+
+    @pytest.mark.asyncio
+    async def test_purge_tasks_delegates_to_helper(self):
+        mock_result = {"status": "purged", "deleted": 2}
+
+        with patch(
+            "redis_sre_agent.core.task_purge_helpers.purge_tasks_helper",
+            new_callable=AsyncMock,
+        ) as mock_helper:
+            mock_helper.return_value = mock_result
+
+            result = await redis_sre_purge_tasks(
+                status="done",
+                older_than="7d",
+                purge_all=False,
+                dry_run=False,
+                confirm=True,
+            )
+
+        assert result == mock_result
+        mock_helper.assert_awaited_once_with(
+            status="done",
+            older_than="7d",
+            purge_all=False,
+            dry_run=False,
+            confirm=True,
+        )
+
+    @pytest.mark.asyncio
+    async def test_purge_tasks_error_payload(self):
+        with patch(
+            "redis_sre_agent.core.task_purge_helpers.purge_tasks_helper",
+            new_callable=AsyncMock,
+        ) as mock_helper:
+            mock_helper.side_effect = RuntimeError("boom")
+
+            result = await redis_sre_purge_tasks(confirm=True, purge_all=True)
+
+        assert result == {"error": "boom", "status": "failed"}

--- a/tests/unit/mcp_server/test_mcp_server.py
+++ b/tests/unit/mcp_server/test_mcp_server.py
@@ -43,6 +43,7 @@ from redis_sre_agent.mcp_server.server import (
     redis_sre_list_threads,
     redis_sre_prepare_source_documents,
     redis_sre_purge_tasks,
+    redis_sre_query,
     redis_sre_recreate_indices,
     redis_sre_run_pipeline_full,
     redis_sre_run_pipeline_ingest,
@@ -116,6 +117,7 @@ class TestMCPServerSetup:
         assert "redis_sre_cache_stats" in tool_names
         assert "redis_sre_cache_clear" in tool_names
         assert "redis_sre_version" in tool_names
+        assert "redis_sre_query" in tool_names
         assert "redis_sre_list_indices" in tool_names
         assert "redis_sre_get_index_schema_status" in tool_names
         assert "redis_sre_recreate_indices" in tool_names
@@ -1831,6 +1833,56 @@ class TestIndexTools:
             "status": "failed",
             "error": "boom",
             "index_name": "knowledge",
+        }
+
+
+class TestQueryTool:
+    """Test the unified query MCP tool."""
+
+    @pytest.mark.asyncio
+    async def test_query_delegates_to_helper(self):
+        mock_result = {"thread_id": "thread-123", "task_id": "task-123", "status": "queued"}
+
+        with patch(
+            "redis_sre_agent.core.query_helpers.queue_query_task_helper",
+            new_callable=AsyncMock,
+        ) as mock_helper:
+            mock_helper.return_value = mock_result
+
+            result = await redis_sre_query(
+                query="Investigate memory usage",
+                instance_id="redis-prod-1",
+                support_package_id="pkg-1",
+                thread_id="thread-123",
+                agent="knowledge",
+                user_id="user-1",
+            )
+
+        assert result == mock_result
+        mock_helper.assert_awaited_once_with(
+            query="Investigate memory usage",
+            instance_id="redis-prod-1",
+            cluster_id=None,
+            support_package_id="pkg-1",
+            thread_id="thread-123",
+            agent="knowledge",
+            user_id="user-1",
+        )
+
+    @pytest.mark.asyncio
+    async def test_query_error_payload(self):
+        with patch(
+            "redis_sre_agent.core.query_helpers.queue_query_task_helper",
+            new_callable=AsyncMock,
+        ) as mock_helper:
+            mock_helper.side_effect = RuntimeError("boom")
+
+            result = await redis_sre_query(query="Investigate memory usage")
+
+        assert result == {
+            "error": "boom",
+            "status": "failed",
+            "message": "Failed to start query: boom",
         }
 
 

--- a/tests/unit/mcp_server/test_mcp_server.py
+++ b/tests/unit/mcp_server/test_mcp_server.py
@@ -12,9 +12,11 @@ from redis_sre_agent.mcp_server.server import (
     redis_sre_deep_triage,
     redis_sre_delete_support_package,
     redis_sre_delete_task,
+    redis_sre_evaluate_runbooks,
     redis_sre_extract_support_package,
     redis_sre_general_chat,
     redis_sre_generate_pipeline_runbooks,
+    redis_sre_generate_runbook,
     redis_sre_get_knowledge_fragments,
     redis_sre_get_pipeline_batch,
     redis_sre_get_pipeline_status,
@@ -67,6 +69,8 @@ class TestMCPServerSetup:
         assert "redis_sre_prepare_source_documents" in tool_names
         assert "redis_sre_generate_pipeline_runbooks" in tool_names
         assert "redis_sre_cleanup_pipeline_batches" in tool_names
+        assert "redis_sre_generate_runbook" in tool_names
+        assert "redis_sre_evaluate_runbooks" in tool_names
         assert "redis_sre_upload_support_package" in tool_names
         assert "redis_sre_list_support_packages" in tool_names
         assert "redis_sre_extract_support_package" in tool_names
@@ -771,6 +775,70 @@ class TestPipelineExecutionTools:
                 user_id=None,
                 keep_days=7,
                 artifacts_path="/tmp/artifacts",
+            )
+
+
+class TestRunbookExecutionTools:
+    """Test task-backed runbook execution MCP tools."""
+
+    @pytest.mark.asyncio
+    async def test_generate_runbook_queues_task(self):
+        """Generate tool should delegate queueing to the shared helper."""
+        with patch(
+            "redis_sre_agent.core.runbook_execution_helpers.queue_runbook_operation_task",
+            new_callable=AsyncMock,
+        ) as mock_queue:
+            mock_queue.return_value = {"task_id": "task-456", "status": "queued"}
+
+            result = await redis_sre_generate_runbook(
+                topic="Memory Pressure",
+                scenario_description="Redis memory saturation on primaries",
+                severity="critical",
+                category="operational_runbook",
+                output_file="/tmp/runbook.md",
+                requirements=["Include memory diagnostics"],
+                max_iterations=3,
+                auto_save=False,
+                ingest=True,
+                user_id="user-123",
+            )
+
+            assert result["task_id"] == "task-456"
+            mock_queue.assert_awaited_once_with(
+                operation="generate",
+                user_id="user-123",
+                topic="Memory Pressure",
+                scenario_description="Redis memory saturation on primaries",
+                severity="critical",
+                category="operational_runbook",
+                output_file="/tmp/runbook.md",
+                requirements=["Include memory diagnostics"],
+                max_iterations=3,
+                auto_save=False,
+                ingest=True,
+            )
+
+    @pytest.mark.asyncio
+    async def test_evaluate_runbooks_queues_task(self):
+        """Evaluate tool should delegate queueing to the shared helper."""
+        with patch(
+            "redis_sre_agent.core.runbook_execution_helpers.queue_runbook_operation_task",
+            new_callable=AsyncMock,
+        ) as mock_queue:
+            mock_queue.return_value = {"task_id": "task-456", "status": "queued"}
+
+            result = await redis_sre_evaluate_runbooks(
+                input_dir="/tmp/runbooks",
+                output_file="/tmp/evaluation.json",
+                user_id="user-123",
+            )
+
+            assert result["task_id"] == "task-456"
+            mock_queue.assert_awaited_once_with(
+                operation="evaluate",
+                user_id="user-123",
+                input_dir="/tmp/runbooks",
+                output_file="/tmp/evaluation.json",
             )
 
 

--- a/tests/unit/mcp_server/test_mcp_server.py
+++ b/tests/unit/mcp_server/test_mcp_server.py
@@ -23,6 +23,7 @@ from redis_sre_agent.mcp_server.server import (
     redis_sre_get_related_knowledge_fragments,
     redis_sre_get_support_package_info,
     redis_sre_get_support_ticket,
+    redis_sre_get_task,
     redis_sre_get_task_citations,
     redis_sre_get_task_status,
     redis_sre_get_thread,
@@ -30,6 +31,7 @@ from redis_sre_agent.mcp_server.server import (
     redis_sre_knowledge_search,
     redis_sre_list_instances,
     redis_sre_list_support_packages,
+    redis_sre_list_tasks,
     redis_sre_list_threads,
     redis_sre_prepare_source_documents,
     redis_sre_run_pipeline_full,
@@ -83,6 +85,8 @@ class TestMCPServerSetup:
         assert "redis_sre_list_threads" in tool_names
         assert "redis_sre_get_task_status" in tool_names
         assert "redis_sre_get_task_citations" in tool_names
+        assert "redis_sre_get_task" in tool_names
+        assert "redis_sre_list_tasks" in tool_names
         assert "redis_sre_delete_task" in tool_names
         assert "redis_sre_list_instances" in tool_names
         assert "redis_sre_create_instance" in tool_names
@@ -1895,6 +1899,76 @@ class TestGetTaskStatusTool:
 
             assert result["status"] == "not_found"
             assert "error" in result
+
+
+class TestTaskInspectionTools:
+    """Test direct task inspection MCP tools."""
+
+    @pytest.mark.asyncio
+    async def test_get_task_delegates_to_helper(self):
+        """Task detail tool should delegate to the shared helper."""
+        with patch(
+            "redis_sre_agent.core.task_inspection_helpers.get_task_helper",
+            new_callable=AsyncMock,
+        ) as mock_helper:
+            mock_helper.return_value = {"task_id": "task-123", "status": "done"}
+
+            result = await redis_sre_get_task(task_id="task-123")
+
+        assert result == {"task_id": "task-123", "status": "done"}
+        mock_helper.assert_awaited_once_with("task-123")
+
+    @pytest.mark.asyncio
+    async def test_get_task_not_found(self):
+        """Task detail tool should return a structured not-found payload."""
+        with patch(
+            "redis_sre_agent.core.task_inspection_helpers.get_task_helper",
+            new_callable=AsyncMock,
+        ) as mock_helper:
+            mock_helper.side_effect = ValueError("Task task-999 not found")
+
+            result = await redis_sre_get_task(task_id="task-999")
+
+        assert result["status"] == "not_found"
+        assert result["task_id"] == "task-999"
+
+    @pytest.mark.asyncio
+    async def test_list_tasks_delegates_to_helper(self):
+        """Task listing tool should delegate to the shared helper."""
+        with patch(
+            "redis_sre_agent.core.task_inspection_helpers.list_tasks_helper",
+            new_callable=AsyncMock,
+        ) as mock_helper:
+            mock_helper.return_value = {"tasks": [], "count": 0}
+
+            result = await redis_sre_list_tasks(
+                user_id="user-123",
+                status="done",
+                show_all=False,
+                limit=25,
+            )
+
+        assert result == {"tasks": [], "count": 0}
+        mock_helper.assert_awaited_once_with(
+            user_id="user-123",
+            status="done",
+            show_all=False,
+            limit=25,
+        )
+
+    @pytest.mark.asyncio
+    async def test_list_tasks_invalid_filter(self):
+        """Task listing tool should return structured validation failures."""
+        with patch(
+            "redis_sre_agent.core.task_inspection_helpers.list_tasks_helper",
+            new_callable=AsyncMock,
+        ) as mock_helper:
+            mock_helper.side_effect = ValueError("Invalid task status filter: bogus")
+
+            result = await redis_sre_list_tasks(status="bogus")
+
+        assert result["status"] == "failed"
+        assert "Invalid task status filter" in result["message"]
 
 
 class TestGetTaskCitationsTool:

--- a/tests/unit/mcp_server/test_mcp_server.py
+++ b/tests/unit/mcp_server/test_mcp_server.py
@@ -6,6 +6,7 @@ import pytest
 
 from redis_sre_agent.mcp_server.server import (
     mcp,
+    redis_sre_cleanup_pipeline_batches,
     redis_sre_create_instance,
     redis_sre_database_chat,
     redis_sre_deep_triage,
@@ -13,6 +14,7 @@ from redis_sre_agent.mcp_server.server import (
     redis_sre_delete_task,
     redis_sre_extract_support_package,
     redis_sre_general_chat,
+    redis_sre_generate_pipeline_runbooks,
     redis_sre_get_knowledge_fragments,
     redis_sre_get_pipeline_batch,
     redis_sre_get_pipeline_status,
@@ -27,6 +29,10 @@ from redis_sre_agent.mcp_server.server import (
     redis_sre_list_instances,
     redis_sre_list_support_packages,
     redis_sre_list_threads,
+    redis_sre_prepare_source_documents,
+    redis_sre_run_pipeline_full,
+    redis_sre_run_pipeline_ingest,
+    redis_sre_run_pipeline_scrape,
     redis_sre_search_support_tickets,
     redis_sre_upload_support_package,
 )
@@ -55,6 +61,12 @@ class TestMCPServerSetup:
         assert "redis_sre_get_related_knowledge_fragments" in tool_names
         assert "redis_sre_get_pipeline_status" in tool_names
         assert "redis_sre_get_pipeline_batch" in tool_names
+        assert "redis_sre_run_pipeline_scrape" in tool_names
+        assert "redis_sre_run_pipeline_ingest" in tool_names
+        assert "redis_sre_run_pipeline_full" in tool_names
+        assert "redis_sre_prepare_source_documents" in tool_names
+        assert "redis_sre_generate_pipeline_runbooks" in tool_names
+        assert "redis_sre_cleanup_pipeline_batches" in tool_names
         assert "redis_sre_upload_support_package" in tool_names
         assert "redis_sre_list_support_packages" in tool_names
         assert "redis_sre_extract_support_package" in tool_names
@@ -590,6 +602,176 @@ class TestPipelineInspectionTools:
             assert result["batch_date"] == "2026-03-25"
             assert result["artifacts_path"] == "/tmp/artifacts"
             assert "error" in result
+
+
+class TestPipelineExecutionTools:
+    """Test task-backed pipeline execution MCP tools."""
+
+    @pytest.mark.asyncio
+    async def test_run_pipeline_scrape_queues_task(self):
+        """Scrape tool should delegate queueing to the shared helper."""
+        with patch(
+            "redis_sre_agent.core.pipeline_execution_helpers.queue_pipeline_operation_task",
+            new_callable=AsyncMock,
+        ) as mock_queue:
+            mock_queue.return_value = {
+                "thread_id": "thread-123",
+                "task_id": "task-456",
+                "status": "queued",
+                "operation": "scrape",
+            }
+
+            result = await redis_sre_run_pipeline_scrape(
+                artifacts_path="/tmp/artifacts",
+                scrapers=["redis_docs"],
+                latest_only=True,
+                docs_path="/tmp/docs",
+                user_id="user-123",
+            )
+
+            assert result["task_id"] == "task-456"
+            mock_queue.assert_awaited_once_with(
+                operation="scrape",
+                user_id="user-123",
+                artifacts_path="/tmp/artifacts",
+                scrapers=["redis_docs"],
+                latest_only=True,
+                docs_path="/tmp/docs",
+            )
+
+    @pytest.mark.asyncio
+    async def test_run_pipeline_ingest_queues_task(self):
+        """Ingest tool should delegate queueing to the shared helper."""
+        with patch(
+            "redis_sre_agent.core.pipeline_execution_helpers.queue_pipeline_operation_task",
+            new_callable=AsyncMock,
+        ) as mock_queue:
+            mock_queue.return_value = {"task_id": "task-456", "status": "queued"}
+
+            result = await redis_sre_run_pipeline_ingest(
+                batch_date="2026-03-25",
+                artifacts_path="/tmp/artifacts",
+                latest_only=True,
+            )
+
+            assert result["task_id"] == "task-456"
+            mock_queue.assert_awaited_once_with(
+                operation="ingest",
+                user_id=None,
+                batch_date="2026-03-25",
+                artifacts_path="/tmp/artifacts",
+                latest_only=True,
+            )
+
+    @pytest.mark.asyncio
+    async def test_run_pipeline_full_queues_task(self):
+        """Full tool should delegate queueing to the shared helper."""
+        with patch(
+            "redis_sre_agent.core.pipeline_execution_helpers.queue_pipeline_operation_task",
+            new_callable=AsyncMock,
+        ) as mock_queue:
+            mock_queue.return_value = {"task_id": "task-456", "status": "queued"}
+
+            result = await redis_sre_run_pipeline_full(
+                artifacts_path="/tmp/artifacts",
+                scrapers=["redis_docs_local"],
+                latest_only=True,
+                docs_path="/tmp/docs",
+            )
+
+            assert result["task_id"] == "task-456"
+            mock_queue.assert_awaited_once_with(
+                operation="full",
+                user_id=None,
+                artifacts_path="/tmp/artifacts",
+                scrapers=["redis_docs_local"],
+                latest_only=True,
+                docs_path="/tmp/docs",
+            )
+
+    @pytest.mark.asyncio
+    async def test_prepare_source_documents_queues_task(self):
+        """Prepare-sources tool should delegate queueing to the shared helper."""
+        with patch(
+            "redis_sre_agent.core.pipeline_execution_helpers.queue_pipeline_operation_task",
+            new_callable=AsyncMock,
+        ) as mock_queue:
+            mock_queue.return_value = {"task_id": "task-456", "status": "queued"}
+
+            result = await redis_sre_prepare_source_documents(
+                source_dir="/tmp/source_documents",
+                batch_date="2026-03-25",
+                prepare_only=True,
+                artifacts_path="/tmp/artifacts",
+            )
+
+            assert result["task_id"] == "task-456"
+            mock_queue.assert_awaited_once_with(
+                operation="prepare_sources",
+                user_id=None,
+                source_dir="/tmp/source_documents",
+                batch_date="2026-03-25",
+                prepare_only=True,
+                artifacts_path="/tmp/artifacts",
+            )
+
+    @pytest.mark.asyncio
+    async def test_generate_pipeline_runbooks_queues_task(self):
+        """Runbooks tool should delegate queueing to the shared helper."""
+        with patch(
+            "redis_sre_agent.core.pipeline_execution_helpers.queue_pipeline_operation_task",
+            new_callable=AsyncMock,
+        ) as mock_queue:
+            mock_queue.return_value = {"task_id": "task-456", "status": "queued"}
+
+            result = await redis_sre_generate_pipeline_runbooks(
+                url="https://example.com/runbook",
+                artifacts_path="/tmp/artifacts",
+            )
+
+            assert result["task_id"] == "task-456"
+            mock_queue.assert_awaited_once_with(
+                operation="runbooks",
+                user_id=None,
+                url="https://example.com/runbook",
+                test_url=None,
+                list_urls=False,
+                artifacts_path="/tmp/artifacts",
+            )
+
+    @pytest.mark.asyncio
+    async def test_cleanup_pipeline_batches_requires_confirm(self):
+        """Cleanup tool should reject destructive execution without confirmation."""
+        result = await redis_sre_cleanup_pipeline_batches(
+            keep_days=7,
+            artifacts_path="/tmp/artifacts",
+        )
+
+        assert result["status"] == "failed"
+        assert "confirm=True" in result["message"]
+
+    @pytest.mark.asyncio
+    async def test_cleanup_pipeline_batches_queues_task(self):
+        """Cleanup tool should queue once confirmation is provided."""
+        with patch(
+            "redis_sre_agent.core.pipeline_execution_helpers.queue_pipeline_operation_task",
+            new_callable=AsyncMock,
+        ) as mock_queue:
+            mock_queue.return_value = {"task_id": "task-456", "status": "queued"}
+
+            result = await redis_sre_cleanup_pipeline_batches(
+                keep_days=7,
+                artifacts_path="/tmp/artifacts",
+                confirm=True,
+            )
+
+            assert result["task_id"] == "task-456"
+            mock_queue.assert_awaited_once_with(
+                operation="cleanup",
+                user_id=None,
+                keep_days=7,
+                artifacts_path="/tmp/artifacts",
+            )
 
 
 class TestSupportPackageManagementTools:

--- a/tests/unit/mcp_server/test_mcp_server.py
+++ b/tests/unit/mcp_server/test_mcp_server.py
@@ -12,12 +12,16 @@ from redis_sre_agent.mcp_server.server import (
     redis_sre_cleanup_pipeline_batches,
     redis_sre_create_cluster,
     redis_sre_create_instance,
+    redis_sre_create_schedule,
     redis_sre_database_chat,
     redis_sre_deep_triage,
     redis_sre_delete_cluster,
     redis_sre_delete_instance,
+    redis_sre_delete_schedule,
     redis_sre_delete_support_package,
     redis_sre_delete_task,
+    redis_sre_disable_schedule,
+    redis_sre_enable_schedule,
     redis_sre_evaluate_runbooks,
     redis_sre_extract_support_package,
     redis_sre_general_chat,
@@ -30,6 +34,7 @@ from redis_sre_agent.mcp_server.server import (
     redis_sre_get_pipeline_batch,
     redis_sre_get_pipeline_status,
     redis_sre_get_related_knowledge_fragments,
+    redis_sre_get_schedule,
     redis_sre_get_support_package_info,
     redis_sre_get_support_ticket,
     redis_sre_get_task,
@@ -43,6 +48,8 @@ from redis_sre_agent.mcp_server.server import (
     redis_sre_list_clusters,
     redis_sre_list_indices,
     redis_sre_list_instances,
+    redis_sre_list_schedule_runs,
+    redis_sre_list_schedules,
     redis_sre_list_support_packages,
     redis_sre_list_tasks,
     redis_sre_list_threads,
@@ -53,12 +60,14 @@ from redis_sre_agent.mcp_server.server import (
     redis_sre_run_pipeline_full,
     redis_sre_run_pipeline_ingest,
     redis_sre_run_pipeline_scrape,
+    redis_sre_run_schedule_now,
     redis_sre_search_support_tickets,
     redis_sre_sync_index_schemas,
     redis_sre_test_instance,
     redis_sre_test_redis_url,
     redis_sre_update_cluster,
     redis_sre_update_instance,
+    redis_sre_update_schedule,
     redis_sre_upload_support_package,
     redis_sre_version,
 )
@@ -134,6 +143,15 @@ class TestMCPServerSetup:
         assert "redis_sre_get_index_schema_status" in tool_names
         assert "redis_sre_recreate_indices" in tool_names
         assert "redis_sre_sync_index_schemas" in tool_names
+        assert "redis_sre_list_schedules" in tool_names
+        assert "redis_sre_get_schedule" in tool_names
+        assert "redis_sre_create_schedule" in tool_names
+        assert "redis_sre_update_schedule" in tool_names
+        assert "redis_sre_enable_schedule" in tool_names
+        assert "redis_sre_disable_schedule" in tool_names
+        assert "redis_sre_delete_schedule" in tool_names
+        assert "redis_sre_run_schedule_now" in tool_names
+        assert "redis_sre_list_schedule_runs" in tool_names
 
 
 class TestDeepTriageTool:
@@ -1984,6 +2002,158 @@ class TestClusterTools:
 
         assert result == {"clusters_created": 1}
         mock_helper.assert_awaited_once_with(dry_run=True, force=False)
+
+
+class TestScheduleTools:
+    """Test MCP tools for schedule inspection and mutation."""
+
+    @pytest.mark.asyncio
+    async def test_list_schedules_delegates_to_helper(self):
+        with patch(
+            "redis_sre_agent.core.schedule_helpers.list_schedules_helper",
+            new_callable=AsyncMock,
+            return_value={"schedules": []},
+        ) as mock_helper:
+            result = await redis_sre_list_schedules(limit=25)
+
+        assert result == {"schedules": []}
+        mock_helper.assert_awaited_once_with(limit=25)
+
+    @pytest.mark.asyncio
+    async def test_get_schedule_delegates_to_helper(self):
+        with patch(
+            "redis_sre_agent.core.schedule_helpers.get_schedule_helper",
+            new_callable=AsyncMock,
+            return_value={"id": "schedule-1"},
+        ) as mock_helper:
+            result = await redis_sre_get_schedule("schedule-1")
+
+        assert result == {"id": "schedule-1"}
+        mock_helper.assert_awaited_once_with("schedule-1")
+
+    @pytest.mark.asyncio
+    async def test_create_schedule_delegates_to_helper(self):
+        with patch(
+            "redis_sre_agent.core.schedule_helpers.create_schedule_helper",
+            new_callable=AsyncMock,
+            return_value={"id": "schedule-1", "status": "created"},
+        ) as mock_helper:
+            result = await redis_sre_create_schedule(
+                name="Nightly Check",
+                interval_type="hours",
+                interval_value=12,
+                instructions="Check memory usage",
+            )
+
+        assert result["status"] == "created"
+        mock_helper.assert_awaited_once_with(
+            name="Nightly Check",
+            interval_type="hours",
+            interval_value=12,
+            instructions="Check memory usage",
+            redis_instance_id=None,
+            description=None,
+            enabled=True,
+        )
+
+    @pytest.mark.asyncio
+    async def test_update_schedule_delegates_to_helper(self):
+        with patch(
+            "redis_sre_agent.core.schedule_helpers.update_schedule_helper",
+            new_callable=AsyncMock,
+            return_value={"id": "schedule-1", "status": "updated"},
+        ) as mock_helper:
+            result = await redis_sre_update_schedule("schedule-1", enabled=False)
+
+        assert result["status"] == "updated"
+        mock_helper.assert_awaited_once_with(
+            "schedule-1",
+            name=None,
+            description=None,
+            instructions=None,
+            redis_instance_id=None,
+            interval_type=None,
+            interval_value=None,
+            enabled=False,
+            recalc_next_run=True,
+        )
+
+    @pytest.mark.asyncio
+    async def test_enable_schedule_delegates_to_helper(self):
+        with patch(
+            "redis_sre_agent.core.schedule_helpers.enable_schedule_helper",
+            new_callable=AsyncMock,
+            return_value={"id": "schedule-1", "status": "enabled"},
+        ) as mock_helper:
+            result = await redis_sre_enable_schedule("schedule-1")
+
+        assert result["status"] == "enabled"
+        mock_helper.assert_awaited_once_with("schedule-1")
+
+    @pytest.mark.asyncio
+    async def test_disable_schedule_delegates_to_helper(self):
+        with patch(
+            "redis_sre_agent.core.schedule_helpers.disable_schedule_helper",
+            new_callable=AsyncMock,
+            return_value={"id": "schedule-1", "status": "disabled"},
+        ) as mock_helper:
+            result = await redis_sre_disable_schedule("schedule-1")
+
+        assert result["status"] == "disabled"
+        mock_helper.assert_awaited_once_with("schedule-1")
+
+    @pytest.mark.asyncio
+    async def test_delete_schedule_delegates_to_helper(self):
+        with patch(
+            "redis_sre_agent.core.schedule_helpers.delete_schedule_helper",
+            new_callable=AsyncMock,
+            return_value={"id": "schedule-1", "status": "deleted"},
+        ) as mock_helper:
+            result = await redis_sre_delete_schedule("schedule-1", confirm=True)
+
+        assert result["status"] == "deleted"
+        mock_helper.assert_awaited_once_with("schedule-1", confirm=True)
+
+    @pytest.mark.asyncio
+    async def test_run_schedule_now_delegates_to_helper(self):
+        with patch(
+            "redis_sre_agent.core.schedule_helpers.run_schedule_now_helper",
+            new_callable=AsyncMock,
+            return_value={"schedule_id": "schedule-1", "status": "pending"},
+        ) as mock_helper:
+            result = await redis_sre_run_schedule_now("schedule-1")
+
+        assert result["status"] == "pending"
+        mock_helper.assert_awaited_once_with("schedule-1")
+
+    @pytest.mark.asyncio
+    async def test_list_schedule_runs_delegates_to_helper(self):
+        with patch(
+            "redis_sre_agent.core.schedule_helpers.list_schedule_runs_helper",
+            new_callable=AsyncMock,
+            return_value={"schedule_id": "schedule-1", "runs": []},
+        ) as mock_helper:
+            result = await redis_sre_list_schedule_runs("schedule-1", limit=10)
+
+        assert result == {"schedule_id": "schedule-1", "runs": []}
+        mock_helper.assert_awaited_once_with("schedule-1", limit=10)
+
+    @pytest.mark.asyncio
+    async def test_schedule_tool_error_payload(self):
+        with patch(
+            "redis_sre_agent.core.schedule_helpers.create_schedule_helper",
+            new_callable=AsyncMock,
+        ) as mock_helper:
+            mock_helper.side_effect = RuntimeError("boom")
+
+            result = await redis_sre_create_schedule(
+                name="Nightly Check",
+                interval_type="hours",
+                interval_value=12,
+                instructions="Check memory usage",
+            )
+
+        assert result == {"error": "boom", "status": "failed"}
 
 
 class TestGetThreadTool:

--- a/tests/unit/mcp_server/test_mcp_server.py
+++ b/tests/unit/mcp_server/test_mcp_server.py
@@ -17,6 +17,7 @@ from redis_sre_agent.mcp_server.server import (
     redis_sre_general_chat,
     redis_sre_generate_pipeline_runbooks,
     redis_sre_generate_runbook,
+    redis_sre_get_instance,
     redis_sre_get_knowledge_fragments,
     redis_sre_get_pipeline_batch,
     redis_sre_get_pipeline_status,
@@ -40,6 +41,8 @@ from redis_sre_agent.mcp_server.server import (
     redis_sre_run_pipeline_ingest,
     redis_sre_run_pipeline_scrape,
     redis_sre_search_support_tickets,
+    redis_sre_test_instance,
+    redis_sre_test_redis_url,
     redis_sre_upload_support_package,
 )
 
@@ -83,6 +86,7 @@ class TestMCPServerSetup:
         assert "redis_sre_search_support_tickets" in tool_names
         assert "redis_sre_get_support_ticket" in tool_names
         assert "redis_sre_knowledge_query" in tool_names
+        assert "redis_sre_get_instance" in tool_names
         assert "redis_sre_get_thread" in tool_names
         assert "redis_sre_get_thread_sources" in tool_names
         assert "redis_sre_get_thread_trace" in tool_names
@@ -94,6 +98,8 @@ class TestMCPServerSetup:
         assert "redis_sre_delete_task" in tool_names
         assert "redis_sre_list_instances" in tool_names
         assert "redis_sre_create_instance" in tool_names
+        assert "redis_sre_test_instance" in tool_names
+        assert "redis_sre_test_redis_url" in tool_names
 
 
 class TestDeepTriageTool:
@@ -1410,6 +1416,102 @@ class TestCreateInstanceTool:
 
             assert result["status"] == "failed"
             assert "already exists" in result["error"]
+
+
+class TestInstanceInspectionTools:
+    """Test MCP tools for instance inspection and connectivity checks."""
+
+    @pytest.mark.asyncio
+    async def test_get_instance_delegates_to_helper(self):
+        """Get-instance should delegate to the shared helper."""
+        mock_result = {"id": "redis-prod-1", "name": "Production Redis"}
+
+        with patch(
+            "redis_sre_agent.core.instance_inspection_helpers.get_instance_helper",
+            new_callable=AsyncMock,
+        ) as mock_helper:
+            mock_helper.return_value = mock_result
+
+            result = await redis_sre_get_instance(instance_id="redis-prod-1")
+
+        assert result == mock_result
+        mock_helper.assert_awaited_once_with("redis-prod-1")
+
+    @pytest.mark.asyncio
+    async def test_get_instance_error_payload(self):
+        """Get-instance failures should return a structured error payload."""
+        with patch(
+            "redis_sre_agent.core.instance_inspection_helpers.get_instance_helper",
+            new_callable=AsyncMock,
+        ) as mock_helper:
+            mock_helper.side_effect = Exception("lookup failed")
+
+            result = await redis_sre_get_instance(instance_id="redis-prod-1")
+
+        assert result["id"] == "redis-prod-1"
+        assert "error" in result
+
+    @pytest.mark.asyncio
+    async def test_test_instance_delegates_to_helper(self):
+        """Configured instance connectivity tests should delegate to the helper."""
+        mock_result = {"success": True, "instance_id": "redis-prod-1"}
+
+        with patch(
+            "redis_sre_agent.core.instance_inspection_helpers.check_instance_helper",
+            new_callable=AsyncMock,
+        ) as mock_helper:
+            mock_helper.return_value = mock_result
+
+            result = await redis_sre_test_instance(instance_id="redis-prod-1")
+
+        assert result == mock_result
+        mock_helper.assert_awaited_once_with("redis-prod-1")
+
+    @pytest.mark.asyncio
+    async def test_test_instance_error_payload(self):
+        """Configured instance connectivity failures should be structured."""
+        with patch(
+            "redis_sre_agent.core.instance_inspection_helpers.check_instance_helper",
+            new_callable=AsyncMock,
+        ) as mock_helper:
+            mock_helper.side_effect = Exception("probe failed")
+
+            result = await redis_sre_test_instance(instance_id="redis-prod-1")
+
+        assert result["success"] is False
+        assert result["id"] == "redis-prod-1"
+        assert "error" in result
+
+    @pytest.mark.asyncio
+    async def test_test_redis_url_delegates_to_helper(self):
+        """Direct Redis URL checks should delegate to the helper."""
+        mock_result = {"success": True, "url": "redis://***:***@host:6379/0"}
+
+        with patch(
+            "redis_sre_agent.core.instance_inspection_helpers.check_redis_url_helper",
+            new_callable=AsyncMock,
+        ) as mock_helper:
+            mock_helper.return_value = mock_result
+
+            result = await redis_sre_test_redis_url(connection_url="redis://user:pass@host:6379/0")
+
+        assert result == mock_result
+        mock_helper.assert_awaited_once_with("redis://user:pass@host:6379/0")
+
+    @pytest.mark.asyncio
+    async def test_test_redis_url_error_payload(self):
+        """Direct Redis URL failures should return a structured payload."""
+        with patch(
+            "redis_sre_agent.core.instance_inspection_helpers.check_redis_url_helper",
+            new_callable=AsyncMock,
+        ) as mock_helper:
+            mock_helper.side_effect = Exception("probe failed")
+
+            result = await redis_sre_test_redis_url(connection_url="redis://user:pass@host:6379/0")
+
+        assert result["success"] is False
+        assert result["url"] == "redis://user:pass@host:6379/0"
+        assert "error" in result
 
 
 class TestGetThreadTool:

--- a/tests/unit/mcp_server/test_mcp_server.py
+++ b/tests/unit/mcp_server/test_mcp_server.py
@@ -27,6 +27,8 @@ from redis_sre_agent.mcp_server.server import (
     redis_sre_get_task_citations,
     redis_sre_get_task_status,
     redis_sre_get_thread,
+    redis_sre_get_thread_sources,
+    redis_sre_get_thread_trace,
     redis_sre_knowledge_query,
     redis_sre_knowledge_search,
     redis_sre_list_instances,
@@ -82,6 +84,8 @@ class TestMCPServerSetup:
         assert "redis_sre_get_support_ticket" in tool_names
         assert "redis_sre_knowledge_query" in tool_names
         assert "redis_sre_get_thread" in tool_names
+        assert "redis_sre_get_thread_sources" in tool_names
+        assert "redis_sre_get_thread_trace" in tool_names
         assert "redis_sre_list_threads" in tool_names
         assert "redis_sre_get_task_status" in tool_names
         assert "redis_sre_get_task_citations" in tool_names
@@ -1840,6 +1844,88 @@ class TestListThreadsTool:
             latest = result["threads"][0]["latest_message"]
             assert len(latest) == 103  # 100 chars + "..."
             assert latest.endswith("...")
+
+
+class TestThreadInspectionTools:
+    """Test MCP tools for thread sources and trace inspection."""
+
+    @pytest.mark.asyncio
+    async def test_get_thread_sources_delegates_to_helper(self):
+        """Thread sources should delegate to the shared helper."""
+        mock_result = {
+            "thread_id": "thread-123",
+            "task_id": None,
+            "fragments": [{"id": "frag-1"}],
+            "count": 1,
+        }
+
+        with patch(
+            "redis_sre_agent.core.thread_inspection_helpers.get_thread_sources_helper",
+            new_callable=AsyncMock,
+        ) as mock_helper:
+            mock_helper.return_value = mock_result
+
+            result = await redis_sre_get_thread_sources(thread_id="thread-123")
+
+        assert result == mock_result
+        mock_helper.assert_awaited_once_with(thread_id="thread-123", task_id=None)
+
+    @pytest.mark.asyncio
+    async def test_get_thread_sources_error_payload(self):
+        """Unexpected failures should return a structured error payload."""
+        with patch(
+            "redis_sre_agent.core.thread_inspection_helpers.get_thread_sources_helper",
+            new_callable=AsyncMock,
+        ) as mock_helper:
+            mock_helper.side_effect = Exception("lookup failed")
+
+            result = await redis_sre_get_thread_sources(thread_id="thread-123", task_id="task-1")
+
+        assert result["thread_id"] == "thread-123"
+        assert result["task_id"] == "task-1"
+        assert result["fragments"] == []
+        assert result["count"] == 0
+        assert "error" in result
+
+    @pytest.mark.asyncio
+    async def test_get_thread_trace_delegates_to_helper(self):
+        """Thread trace should delegate to the shared helper."""
+        mock_result = {
+            "message_id": "msg-123",
+            "tool_calls": [{"name": "redis_info"}],
+            "tool_call_count": 1,
+            "citations": [],
+            "citation_count": 0,
+        }
+
+        with patch(
+            "redis_sre_agent.core.thread_inspection_helpers.get_thread_trace_helper",
+            new_callable=AsyncMock,
+        ) as mock_helper:
+            mock_helper.return_value = mock_result
+
+            result = await redis_sre_get_thread_trace(message_id="msg-123", include_tool_data=True)
+
+        assert result == mock_result
+        mock_helper.assert_awaited_once_with(message_id="msg-123", include_tool_data=True)
+
+    @pytest.mark.asyncio
+    async def test_get_thread_trace_error_payload(self):
+        """Unexpected trace failures should return a structured error payload."""
+        with patch(
+            "redis_sre_agent.core.thread_inspection_helpers.get_thread_trace_helper",
+            new_callable=AsyncMock,
+        ) as mock_helper:
+            mock_helper.side_effect = Exception("trace failed")
+
+            result = await redis_sre_get_thread_trace(message_id="msg-123")
+
+        assert result["message_id"] == "msg-123"
+        assert result["tool_calls"] == []
+        assert result["tool_call_count"] == 0
+        assert result["citations"] == []
+        assert result["citation_count"] == 0
+        assert "error" in result
 
 
 class TestGetTaskStatusTool:

--- a/tests/unit/mcp_server/test_mcp_server.py
+++ b/tests/unit/mcp_server/test_mcp_server.py
@@ -13,8 +13,10 @@ from redis_sre_agent.mcp_server.server import (
     redis_sre_delete_task,
     redis_sre_extract_support_package,
     redis_sre_general_chat,
+    redis_sre_get_knowledge_fragments,
     redis_sre_get_pipeline_batch,
     redis_sre_get_pipeline_status,
+    redis_sre_get_related_knowledge_fragments,
     redis_sre_get_support_package_info,
     redis_sre_get_support_ticket,
     redis_sre_get_task_citations,
@@ -49,6 +51,8 @@ class TestMCPServerSetup:
         assert "redis_sre_general_chat" in tool_names
         assert "redis_sre_database_chat" in tool_names
         assert "redis_sre_knowledge_search" in tool_names
+        assert "redis_sre_get_knowledge_fragments" in tool_names
+        assert "redis_sre_get_related_knowledge_fragments" in tool_names
         assert "redis_sre_get_pipeline_status" in tool_names
         assert "redis_sre_get_pipeline_batch" in tool_names
         assert "redis_sre_upload_support_package" in tool_names
@@ -401,6 +405,105 @@ class TestKnowledgeSearchTool:
             assert "error" in result
             assert result["results"] == []
             assert result["total_results"] == 0
+
+
+class TestKnowledgeFragmentTools:
+    """Test document fragment MCP tools."""
+
+    @pytest.mark.asyncio
+    async def test_get_knowledge_fragments_success(self):
+        """Full fragment retrieval returns helper payload."""
+        mock_result = {
+            "document_hash": "doc-123",
+            "fragments_count": 2,
+            "fragments": [{"chunk_index": 0}, {"chunk_index": 1}],
+        }
+
+        with patch(
+            "redis_sre_agent.core.knowledge_helpers.get_all_document_fragments",
+            new_callable=AsyncMock,
+        ) as mock_helper:
+            mock_helper.return_value = mock_result
+
+            result = await redis_sre_get_knowledge_fragments(document_hash="doc-123")
+
+            assert result["document_hash"] == "doc-123"
+            assert result["fragments_count"] == 2
+            mock_helper.assert_awaited_once_with(
+                "doc-123",
+                include_metadata=True,
+                index_type="knowledge",
+                version=None,
+            )
+
+    @pytest.mark.asyncio
+    async def test_get_knowledge_fragments_error_payload_passthrough(self):
+        """Fragment retrieval preserves helper error payload."""
+        with patch(
+            "redis_sre_agent.core.knowledge_helpers.get_all_document_fragments",
+            new_callable=AsyncMock,
+        ) as mock_helper:
+            mock_helper.return_value = {
+                "document_hash": "doc-123",
+                "error": "No fragments found for this document",
+                "fragments": [],
+            }
+
+            result = await redis_sre_get_knowledge_fragments(document_hash="doc-123")
+
+            assert result["document_hash"] == "doc-123"
+            assert result["error"] == "No fragments found for this document"
+
+    @pytest.mark.asyncio
+    async def test_get_related_knowledge_fragments_success(self):
+        """Related fragment retrieval returns helper payload."""
+        mock_result = {
+            "document_hash": "doc-123",
+            "target_chunk_index": 4,
+            "related_fragments_count": 3,
+            "related_fragments": [{"chunk_index": 3}, {"chunk_index": 4}, {"chunk_index": 5}],
+        }
+
+        with patch(
+            "redis_sre_agent.core.knowledge_helpers.get_related_document_fragments",
+            new_callable=AsyncMock,
+        ) as mock_helper:
+            mock_helper.return_value = mock_result
+
+            result = await redis_sre_get_related_knowledge_fragments(
+                document_hash="doc-123",
+                chunk_index=4,
+                window=1,
+            )
+
+            assert result["target_chunk_index"] == 4
+            assert result["related_fragments_count"] == 3
+            mock_helper.assert_awaited_once_with(
+                "doc-123",
+                current_chunk_index=4,
+                context_window=1,
+            )
+
+    @pytest.mark.asyncio
+    async def test_get_related_knowledge_fragments_error_payload_passthrough(self):
+        """Related fragment retrieval preserves helper error payload."""
+        with patch(
+            "redis_sre_agent.core.knowledge_helpers.get_related_document_fragments",
+            new_callable=AsyncMock,
+        ) as mock_helper:
+            mock_helper.return_value = {
+                "document_hash": "doc-123",
+                "error": "lookup failed",
+                "related_fragments": [],
+            }
+
+            result = await redis_sre_get_related_knowledge_fragments(
+                document_hash="doc-123",
+                chunk_index=4,
+            )
+
+            assert result["document_hash"] == "doc-123"
+            assert result["error"] == "lookup failed"
 
 
 class TestPipelineInspectionTools:

--- a/tests/unit/mcp_server/test_mcp_server.py
+++ b/tests/unit/mcp_server/test_mcp_server.py
@@ -9,8 +9,13 @@ from redis_sre_agent.mcp_server.server import (
     redis_sre_create_instance,
     redis_sre_database_chat,
     redis_sre_deep_triage,
+    redis_sre_delete_support_package,
     redis_sre_delete_task,
+    redis_sre_extract_support_package,
     redis_sre_general_chat,
+    redis_sre_get_pipeline_batch,
+    redis_sre_get_pipeline_status,
+    redis_sre_get_support_package_info,
     redis_sre_get_support_ticket,
     redis_sre_get_task_citations,
     redis_sre_get_task_status,
@@ -18,8 +23,10 @@ from redis_sre_agent.mcp_server.server import (
     redis_sre_knowledge_query,
     redis_sre_knowledge_search,
     redis_sre_list_instances,
+    redis_sre_list_support_packages,
     redis_sre_list_threads,
     redis_sre_search_support_tickets,
+    redis_sre_upload_support_package,
 )
 
 
@@ -42,6 +49,13 @@ class TestMCPServerSetup:
         assert "redis_sre_general_chat" in tool_names
         assert "redis_sre_database_chat" in tool_names
         assert "redis_sre_knowledge_search" in tool_names
+        assert "redis_sre_get_pipeline_status" in tool_names
+        assert "redis_sre_get_pipeline_batch" in tool_names
+        assert "redis_sre_upload_support_package" in tool_names
+        assert "redis_sre_list_support_packages" in tool_names
+        assert "redis_sre_extract_support_package" in tool_names
+        assert "redis_sre_delete_support_package" in tool_names
+        assert "redis_sre_get_support_package_info" in tool_names
         assert "redis_sre_search_support_tickets" in tool_names
         assert "redis_sre_get_support_ticket" in tool_names
         assert "redis_sre_knowledge_query" in tool_names
@@ -387,6 +401,240 @@ class TestKnowledgeSearchTool:
             assert "error" in result
             assert result["results"] == []
             assert result["total_results"] == 0
+
+
+class TestPipelineInspectionTools:
+    """Test pipeline inspection MCP tools."""
+
+    @pytest.mark.asyncio
+    async def test_get_pipeline_status_success(self):
+        """Pipeline status returns helper payload."""
+        mock_result = {
+            "artifacts_path": "/tmp/artifacts",
+            "current_batch_date": "2026-03-25",
+            "available_batches": ["2026-03-24", "2026-03-25"],
+            "scrapers": {"redis_docs": {"source": "redis.io"}},
+            "ingestion": {"batches_ingested": 1},
+        }
+
+        with patch(
+            "redis_sre_agent.core.pipeline_helpers.get_pipeline_status_helper",
+            new_callable=AsyncMock,
+        ) as mock_helper:
+            mock_helper.return_value = mock_result
+
+            result = await redis_sre_get_pipeline_status()
+
+            assert result["current_batch_date"] == "2026-03-25"
+            assert result["available_batches"] == ["2026-03-24", "2026-03-25"]
+            mock_helper.assert_called_once_with(artifacts_path="./artifacts")
+
+    @pytest.mark.asyncio
+    async def test_get_pipeline_status_error_handling(self):
+        """Pipeline status returns structured error payload on failure."""
+        with patch(
+            "redis_sre_agent.core.pipeline_helpers.get_pipeline_status_helper",
+            new_callable=AsyncMock,
+        ) as mock_helper:
+            mock_helper.side_effect = Exception("status failed")
+
+            result = await redis_sre_get_pipeline_status(artifacts_path="/tmp/artifacts")
+
+            assert result["artifacts_path"] == "/tmp/artifacts"
+            assert result["available_batches"] == []
+            assert "error" in result
+
+    @pytest.mark.asyncio
+    async def test_get_pipeline_batch_success(self):
+        """Pipeline batch returns helper payload."""
+        mock_result = {
+            "batch_date": "2026-03-25",
+            "artifacts_path": "/tmp/artifacts",
+            "total_documents": 12,
+            "categories": {"oss": 10},
+            "document_types": {"documentation": 8},
+            "ingestion": {"available": True, "status": "success", "chunks_indexed": 42},
+        }
+
+        with patch(
+            "redis_sre_agent.core.pipeline_helpers.get_pipeline_batch_helper",
+            new_callable=AsyncMock,
+        ) as mock_helper:
+            mock_helper.return_value = mock_result
+
+            result = await redis_sre_get_pipeline_batch(batch_date="2026-03-25")
+
+            assert result["batch_date"] == "2026-03-25"
+            assert result["ingestion"]["status"] == "success"
+            mock_helper.assert_called_once_with(
+                batch_date="2026-03-25", artifacts_path="./artifacts"
+            )
+
+    @pytest.mark.asyncio
+    async def test_get_pipeline_batch_error_handling(self):
+        """Pipeline batch returns structured error payload on failure."""
+        with patch(
+            "redis_sre_agent.core.pipeline_helpers.get_pipeline_batch_helper",
+            new_callable=AsyncMock,
+        ) as mock_helper:
+            mock_helper.side_effect = Exception("batch failed")
+
+            result = await redis_sre_get_pipeline_batch(
+                batch_date="2026-03-25",
+                artifacts_path="/tmp/artifacts",
+            )
+
+            assert result["batch_date"] == "2026-03-25"
+            assert result["artifacts_path"] == "/tmp/artifacts"
+            assert "error" in result
+
+
+class TestSupportPackageManagementTools:
+    """Test support-package management MCP tools."""
+
+    @pytest.mark.asyncio
+    async def test_upload_support_package_success(self, tmp_path):
+        """Upload returns package id and status."""
+        archive = tmp_path / "support-package.tar.gz"
+        archive.write_bytes(b"dummy")
+
+        mock_manager = AsyncMock()
+        mock_manager.upload.return_value = "pkg-123"
+
+        with patch(
+            "redis_sre_agent.core.support_package_helpers.get_support_package_manager",
+            return_value=mock_manager,
+        ):
+            result = await redis_sre_upload_support_package(file_path=str(archive))
+
+            assert result == {
+                "package_id": "pkg-123",
+                "filename": "support-package.tar.gz",
+                "status": "uploaded",
+            }
+            mock_manager.upload.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_upload_support_package_missing_file(self):
+        """Upload validates file existence."""
+        result = await redis_sre_upload_support_package(file_path="/tmp/does-not-exist.tar.gz")
+
+        assert result["status"] == "failed"
+        assert "error" in result
+
+    @pytest.mark.asyncio
+    async def test_list_support_packages_success(self):
+        """List support packages returns serialized metadata."""
+        from datetime import datetime, timezone
+
+        from redis_sre_agent.tools.support_package.storage.protocols import PackageMetadata
+
+        mock_manager = AsyncMock()
+        mock_manager.list_packages.return_value = [
+            PackageMetadata(
+                package_id="pkg-123",
+                filename="support-package.tar.gz",
+                size_bytes=1024,
+                uploaded_at=datetime(2026, 3, 25, tzinfo=timezone.utc),
+                storage_path="/tmp/pkg-123",
+                checksum="abc123",
+            )
+        ]
+
+        with patch(
+            "redis_sre_agent.core.support_package_helpers.get_support_package_manager",
+            return_value=mock_manager,
+        ):
+            result = await redis_sre_list_support_packages()
+
+            assert result["total"] == 1
+            assert result["packages"][0]["package_id"] == "pkg-123"
+            assert result["packages"][0]["size_bytes"] == 1024
+
+    @pytest.mark.asyncio
+    async def test_extract_support_package_success(self):
+        """Extract returns output path."""
+        from pathlib import Path
+
+        mock_manager = AsyncMock()
+        mock_manager.extract.return_value = Path("/tmp/extracted/pkg-123")
+
+        with patch(
+            "redis_sre_agent.core.support_package_helpers.get_support_package_manager",
+            return_value=mock_manager,
+        ):
+            result = await redis_sre_extract_support_package(package_id="pkg-123")
+
+            assert result == {
+                "package_id": "pkg-123",
+                "path": "/tmp/extracted/pkg-123",
+                "status": "extracted",
+            }
+
+    @pytest.mark.asyncio
+    async def test_delete_support_package_requires_confirm(self):
+        """Delete is gated by explicit confirmation."""
+        result = await redis_sre_delete_support_package(package_id="pkg-123")
+
+        assert result["status"] == "failed"
+        assert "confirm" in result["error"].lower()
+
+    @pytest.mark.asyncio
+    async def test_delete_support_package_success(self):
+        """Delete returns deleted status."""
+        mock_manager = AsyncMock()
+
+        with patch(
+            "redis_sre_agent.core.support_package_helpers.get_support_package_manager",
+            return_value=mock_manager,
+        ):
+            result = await redis_sre_delete_support_package(package_id="pkg-123", confirm=True)
+
+            assert result == {"package_id": "pkg-123", "status": "deleted"}
+            mock_manager.delete.assert_awaited_once_with("pkg-123")
+
+    @pytest.mark.asyncio
+    async def test_get_support_package_info_success(self):
+        """Info returns metadata plus extraction state."""
+        from datetime import datetime, timezone
+
+        from redis_sre_agent.tools.support_package.storage.protocols import PackageMetadata
+
+        mock_manager = AsyncMock()
+        mock_manager.get_metadata.return_value = PackageMetadata(
+            package_id="pkg-123",
+            filename="support-package.tar.gz",
+            size_bytes=2048,
+            uploaded_at=datetime(2026, 3, 25, tzinfo=timezone.utc),
+            storage_path="/tmp/pkg-123",
+            checksum="abc123",
+        )
+        mock_manager.is_extracted.return_value = True
+
+        with patch(
+            "redis_sre_agent.core.support_package_helpers.get_support_package_manager",
+            return_value=mock_manager,
+        ):
+            result = await redis_sre_get_support_package_info(package_id="pkg-123")
+
+            assert result["package_id"] == "pkg-123"
+            assert result["is_extracted"] is True
+            assert result["checksum"] == "abc123"
+
+    @pytest.mark.asyncio
+    async def test_get_support_package_info_not_found(self):
+        """Info returns not_found payload when metadata is missing."""
+        mock_manager = AsyncMock()
+        mock_manager.get_metadata.return_value = None
+
+        with patch(
+            "redis_sre_agent.core.support_package_helpers.get_support_package_manager",
+            return_value=mock_manager,
+        ):
+            result = await redis_sre_get_support_package_info(package_id="pkg-123")
+
+            assert result["status"] == "not_found"
+            assert result["package_id"] == "pkg-123"
 
 
 class TestKnowledgeQueryTool:

--- a/tests/unit/mcp_server/test_mcp_server.py
+++ b/tests/unit/mcp_server/test_mcp_server.py
@@ -6,6 +6,7 @@ import pytest
 
 from redis_sre_agent.mcp_server.server import (
     mcp,
+    redis_sre_audit_cli_mcp_parity,
     redis_sre_backfill_empty_thread_subjects,
     redis_sre_backfill_instance_links,
     redis_sre_backfill_scheduled_thread_subjects,
@@ -136,6 +137,7 @@ class TestMCPServerSetup:
         assert "redis_sre_test_redis_url" in tool_names
         assert "redis_sre_cache_stats" in tool_names
         assert "redis_sre_cache_clear" in tool_names
+        assert "redis_sre_audit_cli_mcp_parity" in tool_names
         assert "redis_sre_version" in tool_names
         assert "redis_sre_query" in tool_names
         assert "redis_sre_list_clusters" in tool_names
@@ -162,6 +164,31 @@ class TestMCPServerSetup:
         assert "redis_sre_backfill_scheduled_thread_subjects" in tool_names
         assert "redis_sre_backfill_empty_thread_subjects" in tool_names
         assert "redis_sre_purge_threads" in tool_names
+
+
+class TestCliMcpParityAuditTool:
+    """Test the redis_sre_audit_cli_mcp_parity MCP tool."""
+
+    def test_audit_cli_mcp_parity_success(self):
+        expected = {"status": "ok", "missing_cli_mappings": [], "missing_mcp_tools": {}}
+
+        with patch(
+            "redis_sre_agent.core.cli_mcp_parity.audit_cli_mcp_parity",
+            return_value=expected,
+        ) as mock_audit:
+            result = redis_sre_audit_cli_mcp_parity()
+
+        assert result == expected
+        mock_audit.assert_called_once_with()
+
+    def test_audit_cli_mcp_parity_failure(self):
+        with patch(
+            "redis_sre_agent.core.cli_mcp_parity.audit_cli_mcp_parity",
+            side_effect=RuntimeError("boom"),
+        ):
+            result = redis_sre_audit_cli_mcp_parity()
+
+        assert result == {"error": "boom", "status": "failed"}
 
 
 class TestDeepTriageTool:

--- a/tests/unit/mcp_server/test_mcp_server.py
+++ b/tests/unit/mcp_server/test_mcp_server.py
@@ -10,6 +10,7 @@ from redis_sre_agent.mcp_server.server import (
     redis_sre_create_instance,
     redis_sre_database_chat,
     redis_sre_deep_triage,
+    redis_sre_delete_instance,
     redis_sre_delete_support_package,
     redis_sre_delete_task,
     redis_sre_evaluate_runbooks,
@@ -43,6 +44,7 @@ from redis_sre_agent.mcp_server.server import (
     redis_sre_search_support_tickets,
     redis_sre_test_instance,
     redis_sre_test_redis_url,
+    redis_sre_update_instance,
     redis_sre_upload_support_package,
 )
 
@@ -98,6 +100,8 @@ class TestMCPServerSetup:
         assert "redis_sre_delete_task" in tool_names
         assert "redis_sre_list_instances" in tool_names
         assert "redis_sre_create_instance" in tool_names
+        assert "redis_sre_update_instance" in tool_names
+        assert "redis_sre_delete_instance" in tool_names
         assert "redis_sre_test_instance" in tool_names
         assert "redis_sre_test_redis_url" in tool_names
 
@@ -1512,6 +1516,100 @@ class TestInstanceInspectionTools:
         assert result["success"] is False
         assert result["url"] == "redis://user:pass@host:6379/0"
         assert "error" in result
+
+
+class TestInstanceMutationTools:
+    """Test MCP tools for instance update and delete operations."""
+
+    @pytest.mark.asyncio
+    async def test_update_instance_delegates_to_helper(self):
+        """Update-instance should delegate to the shared helper."""
+        mock_result = {"id": "redis-prod-1", "status": "updated"}
+
+        with patch(
+            "redis_sre_agent.core.instance_mutation_helpers.update_instance_helper",
+            new_callable=AsyncMock,
+        ) as mock_helper:
+            mock_helper.return_value = mock_result
+
+            result = await redis_sre_update_instance(
+                instance_id="redis-prod-1",
+                description="Updated description",
+                set_extensions={"region": "us-west-2"},
+                unset_extensions=["old-key"],
+            )
+
+        assert result == mock_result
+        mock_helper.assert_awaited_once_with(
+            "redis-prod-1",
+            name=None,
+            connection_url=None,
+            environment=None,
+            usage=None,
+            description="Updated description",
+            repo_url=None,
+            notes=None,
+            monitoring_identifier=None,
+            logging_identifier=None,
+            instance_type=None,
+            admin_url=None,
+            admin_username=None,
+            admin_password=None,
+            cluster_id=None,
+            redis_cloud_subscription_id=None,
+            redis_cloud_database_id=None,
+            redis_cloud_subscription_type=None,
+            redis_cloud_database_name=None,
+            status=None,
+            version=None,
+            memory=None,
+            connections=None,
+            user_id=None,
+            set_extensions={"region": "us-west-2"},
+            unset_extensions=["old-key"],
+        )
+
+    @pytest.mark.asyncio
+    async def test_update_instance_error_payload(self):
+        """Update-instance failures should be structured."""
+        with patch(
+            "redis_sre_agent.core.instance_mutation_helpers.update_instance_helper",
+            new_callable=AsyncMock,
+        ) as mock_helper:
+            mock_helper.side_effect = RuntimeError("boom")
+
+            result = await redis_sre_update_instance(instance_id="redis-prod-1")
+
+        assert result == {"error": "boom", "id": "redis-prod-1", "status": "failed"}
+
+    @pytest.mark.asyncio
+    async def test_delete_instance_delegates_to_helper(self):
+        """Delete-instance should delegate to the shared helper."""
+        mock_result = {"id": "redis-prod-1", "status": "deleted"}
+
+        with patch(
+            "redis_sre_agent.core.instance_mutation_helpers.delete_instance_helper",
+            new_callable=AsyncMock,
+        ) as mock_helper:
+            mock_helper.return_value = mock_result
+
+            result = await redis_sre_delete_instance(instance_id="redis-prod-1", confirm=True)
+
+        assert result == mock_result
+        mock_helper.assert_awaited_once_with("redis-prod-1", confirm=True)
+
+    @pytest.mark.asyncio
+    async def test_delete_instance_error_payload(self):
+        """Delete-instance failures should be structured."""
+        with patch(
+            "redis_sre_agent.core.instance_mutation_helpers.delete_instance_helper",
+            new_callable=AsyncMock,
+        ) as mock_helper:
+            mock_helper.side_effect = RuntimeError("boom")
+
+            result = await redis_sre_delete_instance(instance_id="redis-prod-1", confirm=True)
+
+        assert result == {"error": "boom", "id": "redis-prod-1", "status": "failed"}
 
 
 class TestGetThreadTool:

--- a/tests/unit/mcp_server/test_mcp_server.py
+++ b/tests/unit/mcp_server/test_mcp_server.py
@@ -6,12 +6,15 @@ import pytest
 
 from redis_sre_agent.mcp_server.server import (
     mcp,
+    redis_sre_backfill_instance_links,
     redis_sre_cache_clear,
     redis_sre_cache_stats,
     redis_sre_cleanup_pipeline_batches,
+    redis_sre_create_cluster,
     redis_sre_create_instance,
     redis_sre_database_chat,
     redis_sre_deep_triage,
+    redis_sre_delete_cluster,
     redis_sre_delete_instance,
     redis_sre_delete_support_package,
     redis_sre_delete_task,
@@ -20,6 +23,7 @@ from redis_sre_agent.mcp_server.server import (
     redis_sre_general_chat,
     redis_sre_generate_pipeline_runbooks,
     redis_sre_generate_runbook,
+    redis_sre_get_cluster,
     redis_sre_get_index_schema_status,
     redis_sre_get_instance,
     redis_sre_get_knowledge_fragments,
@@ -36,6 +40,7 @@ from redis_sre_agent.mcp_server.server import (
     redis_sre_get_thread_trace,
     redis_sre_knowledge_query,
     redis_sre_knowledge_search,
+    redis_sre_list_clusters,
     redis_sre_list_indices,
     redis_sre_list_instances,
     redis_sre_list_support_packages,
@@ -52,6 +57,7 @@ from redis_sre_agent.mcp_server.server import (
     redis_sre_sync_index_schemas,
     redis_sre_test_instance,
     redis_sre_test_redis_url,
+    redis_sre_update_cluster,
     redis_sre_update_instance,
     redis_sre_upload_support_package,
     redis_sre_version,
@@ -118,6 +124,12 @@ class TestMCPServerSetup:
         assert "redis_sre_cache_clear" in tool_names
         assert "redis_sre_version" in tool_names
         assert "redis_sre_query" in tool_names
+        assert "redis_sre_list_clusters" in tool_names
+        assert "redis_sre_get_cluster" in tool_names
+        assert "redis_sre_create_cluster" in tool_names
+        assert "redis_sre_update_cluster" in tool_names
+        assert "redis_sre_delete_cluster" in tool_names
+        assert "redis_sre_backfill_instance_links" in tool_names
         assert "redis_sre_list_indices" in tool_names
         assert "redis_sre_get_index_schema_status" in tool_names
         assert "redis_sre_recreate_indices" in tool_names
@@ -1884,6 +1896,94 @@ class TestQueryTool:
             "status": "failed",
             "message": "Failed to start query: boom",
         }
+
+
+class TestClusterTools:
+    """Test MCP tools for cluster inspection and mutation."""
+
+    @pytest.mark.asyncio
+    async def test_list_clusters_delegates_to_helper(self):
+        with patch(
+            "redis_sre_agent.core.cluster_helpers.list_clusters_helper",
+            new_callable=AsyncMock,
+            return_value={"clusters": []},
+        ) as mock_helper:
+            result = await redis_sre_list_clusters(environment="production")
+
+        assert result == {"clusters": []}
+        mock_helper.assert_awaited_once_with(
+            environment="production",
+            status=None,
+            cluster_type=None,
+            user_id=None,
+            search=None,
+            limit=100,
+            offset=0,
+        )
+
+    @pytest.mark.asyncio
+    async def test_get_cluster_delegates_to_helper(self):
+        with patch(
+            "redis_sre_agent.core.cluster_helpers.get_cluster_helper",
+            new_callable=AsyncMock,
+            return_value={"id": "cluster-1"},
+        ) as mock_helper:
+            result = await redis_sre_get_cluster("cluster-1")
+
+        assert result == {"id": "cluster-1"}
+        mock_helper.assert_awaited_once_with("cluster-1")
+
+    @pytest.mark.asyncio
+    async def test_create_cluster_delegates_to_helper(self):
+        with patch(
+            "redis_sre_agent.core.cluster_helpers.create_cluster_helper",
+            new_callable=AsyncMock,
+            return_value={"id": "cluster-1", "status": "created"},
+        ) as mock_helper:
+            result = await redis_sre_create_cluster(
+                name="prod-cluster",
+                environment="production",
+                description="Primary cluster",
+            )
+
+        assert result["status"] == "created"
+        mock_helper.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_update_cluster_delegates_to_helper(self):
+        with patch(
+            "redis_sre_agent.core.cluster_helpers.update_cluster_helper",
+            new_callable=AsyncMock,
+            return_value={"id": "cluster-1", "status": "updated"},
+        ) as mock_helper:
+            result = await redis_sre_update_cluster("cluster-1", status="healthy")
+
+        assert result["status"] == "updated"
+        mock_helper.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_delete_cluster_delegates_to_helper(self):
+        with patch(
+            "redis_sre_agent.core.cluster_helpers.delete_cluster_helper",
+            new_callable=AsyncMock,
+            return_value={"id": "cluster-1", "status": "deleted"},
+        ) as mock_helper:
+            result = await redis_sre_delete_cluster("cluster-1", confirm=True)
+
+        assert result["status"] == "deleted"
+        mock_helper.assert_awaited_once_with("cluster-1", confirm=True)
+
+    @pytest.mark.asyncio
+    async def test_backfill_cluster_links_delegates_to_helper(self):
+        with patch(
+            "redis_sre_agent.core.cluster_helpers.backfill_instance_links_helper",
+            new_callable=AsyncMock,
+            return_value={"clusters_created": 1},
+        ) as mock_helper:
+            result = await redis_sre_backfill_instance_links(dry_run=True, force=False)
+
+        assert result == {"clusters_created": 1}
+        mock_helper.assert_awaited_once_with(dry_run=True, force=False)
 
 
 class TestGetThreadTool:

--- a/tests/unit/mcp_server/test_mcp_server.py
+++ b/tests/unit/mcp_server/test_mcp_server.py
@@ -20,6 +20,7 @@ from redis_sre_agent.mcp_server.server import (
     redis_sre_general_chat,
     redis_sre_generate_pipeline_runbooks,
     redis_sre_generate_runbook,
+    redis_sre_get_index_schema_status,
     redis_sre_get_instance,
     redis_sre_get_knowledge_fragments,
     redis_sre_get_pipeline_batch,
@@ -35,16 +36,19 @@ from redis_sre_agent.mcp_server.server import (
     redis_sre_get_thread_trace,
     redis_sre_knowledge_query,
     redis_sre_knowledge_search,
+    redis_sre_list_indices,
     redis_sre_list_instances,
     redis_sre_list_support_packages,
     redis_sre_list_tasks,
     redis_sre_list_threads,
     redis_sre_prepare_source_documents,
     redis_sre_purge_tasks,
+    redis_sre_recreate_indices,
     redis_sre_run_pipeline_full,
     redis_sre_run_pipeline_ingest,
     redis_sre_run_pipeline_scrape,
     redis_sre_search_support_tickets,
+    redis_sre_sync_index_schemas,
     redis_sre_test_instance,
     redis_sre_test_redis_url,
     redis_sre_update_instance,
@@ -112,6 +116,10 @@ class TestMCPServerSetup:
         assert "redis_sre_cache_stats" in tool_names
         assert "redis_sre_cache_clear" in tool_names
         assert "redis_sre_version" in tool_names
+        assert "redis_sre_list_indices" in tool_names
+        assert "redis_sre_get_index_schema_status" in tool_names
+        assert "redis_sre_recreate_indices" in tool_names
+        assert "redis_sre_sync_index_schemas" in tool_names
 
 
 class TestDeepTriageTool:
@@ -1692,6 +1700,138 @@ class TestCacheAndVersionTools:
             result = await redis_sre_delete_instance(instance_id="redis-prod-1", confirm=True)
 
         assert result == {"error": "boom", "id": "redis-prod-1", "status": "failed"}
+
+
+class TestIndexTools:
+    """Test MCP tools for index inspection and maintenance."""
+
+    @pytest.mark.asyncio
+    async def test_list_indices_delegates_to_helper(self):
+        mock_result = {"success": True, "indices": []}
+
+        with patch(
+            "redis_sre_agent.core.index_helpers.list_indices_helper",
+            new_callable=AsyncMock,
+        ) as mock_helper:
+            mock_helper.return_value = mock_result
+
+            result = await redis_sre_list_indices(index_name="knowledge")
+
+        assert result == mock_result
+        mock_helper.assert_awaited_once_with(index_name="knowledge")
+
+    @pytest.mark.asyncio
+    async def test_list_indices_error_payload(self):
+        with patch(
+            "redis_sre_agent.core.index_helpers.list_indices_helper",
+            new_callable=AsyncMock,
+        ) as mock_helper:
+            mock_helper.side_effect = RuntimeError("boom")
+
+            result = await redis_sre_list_indices(index_name="knowledge")
+
+        assert result == {
+            "success": False,
+            "status": "failed",
+            "error": "boom",
+            "index_name": "knowledge",
+        }
+
+    @pytest.mark.asyncio
+    async def test_get_index_schema_status_delegates_to_helper(self):
+        mock_result = {"success": True, "indices": {}}
+
+        with patch(
+            "redis_sre_agent.core.index_helpers.get_index_schema_status_helper",
+            new_callable=AsyncMock,
+        ) as mock_helper:
+            mock_helper.return_value = mock_result
+
+            result = await redis_sre_get_index_schema_status(index_name="knowledge")
+
+        assert result == mock_result
+        mock_helper.assert_awaited_once_with(index_name="knowledge")
+
+    @pytest.mark.asyncio
+    async def test_get_index_schema_status_error_payload(self):
+        with patch(
+            "redis_sre_agent.core.index_helpers.get_index_schema_status_helper",
+            new_callable=AsyncMock,
+        ) as mock_helper:
+            mock_helper.side_effect = RuntimeError("boom")
+
+            result = await redis_sre_get_index_schema_status(index_name="knowledge")
+
+        assert result == {
+            "success": False,
+            "status": "failed",
+            "error": "boom",
+            "index_name": "knowledge",
+        }
+
+    @pytest.mark.asyncio
+    async def test_recreate_indices_delegates_to_helper(self):
+        mock_result = {"success": True, "indices": {"knowledge": "recreated"}}
+
+        with patch(
+            "redis_sre_agent.core.index_helpers.recreate_indices_helper",
+            new_callable=AsyncMock,
+        ) as mock_helper:
+            mock_helper.return_value = mock_result
+
+            result = await redis_sre_recreate_indices(index_name="knowledge", confirm=True)
+
+        assert result == mock_result
+        mock_helper.assert_awaited_once_with(index_name="knowledge", confirm=True)
+
+    @pytest.mark.asyncio
+    async def test_recreate_indices_error_payload(self):
+        with patch(
+            "redis_sre_agent.core.index_helpers.recreate_indices_helper",
+            new_callable=AsyncMock,
+        ) as mock_helper:
+            mock_helper.side_effect = RuntimeError("boom")
+
+            result = await redis_sre_recreate_indices(index_name="knowledge", confirm=True)
+
+        assert result == {
+            "success": False,
+            "status": "failed",
+            "error": "boom",
+            "index_name": "knowledge",
+        }
+
+    @pytest.mark.asyncio
+    async def test_sync_index_schemas_delegates_to_helper(self):
+        mock_result = {"success": True, "indices": {"knowledge": {"action": "created"}}}
+
+        with patch(
+            "redis_sre_agent.core.index_helpers.sync_index_schemas_helper",
+            new_callable=AsyncMock,
+        ) as mock_helper:
+            mock_helper.return_value = mock_result
+
+            result = await redis_sre_sync_index_schemas(index_name="knowledge", confirm=True)
+
+        assert result == mock_result
+        mock_helper.assert_awaited_once_with(index_name="knowledge", confirm=True)
+
+    @pytest.mark.asyncio
+    async def test_sync_index_schemas_error_payload(self):
+        with patch(
+            "redis_sre_agent.core.index_helpers.sync_index_schemas_helper",
+            new_callable=AsyncMock,
+        ) as mock_helper:
+            mock_helper.side_effect = RuntimeError("boom")
+
+            result = await redis_sre_sync_index_schemas(index_name="knowledge", confirm=True)
+
+        assert result == {
+            "success": False,
+            "status": "failed",
+            "error": "boom",
+            "index_name": "knowledge",
+        }
 
 
 class TestGetThreadTool:


### PR DESCRIPTION
## Summary
- move the natural-language target discovery spec into `specs/`
- update `AGENTS.md` to direct written specs into `specs/`

## Testing
- pre-commit hooks
- `pytest tests/unit/ -v`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Adds many new MCP-exposed tools that can mutate/purge Redis-backed state (indices, tasks, threads, caches, instances/clusters) and trigger background work via Docket; mistakes or auth/validation gaps could cause data loss or operational disruption.
> 
> **Overview**
> Expands the MCP server surface significantly by adding a **unified `redis_sre_query` entrypoint** (thread continuation, optional instance/cluster/support-package targeting, and explicit agent selection) plus many new **immediate admin/inspection tools**.
> 
> Adds task-backed workflows for **pipeline operations** (scrape/ingest/full/prepare sources/runbook URL ops/cleanup) and **runbook operations** (generate/evaluate), including new Docket task processors and progress emission.
> 
> Introduces new helper modules to support MCP tools: **cluster CRUD** with masked credentials and instance-link backfill, **instance get/test/update/delete** (with cluster compatibility validation and extension-data patching), **index listing/schema drift/recreate/sync** (with confirmation gates), **schedule CRUD/run-now/run history**, **support package upload/list/info/extract/delete**, **cache stats/clear** (confirmation required) and **version**.
> 
> Adds maintenance/observability tooling for **thread traces/sources**, **thread reindex/backfill/subject backfill**, and **bulk purge** for threads/tasks with `dry_run` + explicit confirmation safeguards. Documentation is updated to list the expanded MCP tools, and a new design spec is added under `specs/`, with accompanying unit tests for new helpers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c57ba7a07d456d2ff9f5f281acbc145f17320623. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->