### PR TITLE
Add natural-language Redis target discovery

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,7 +52,12 @@ make local-services-logs # Tail logs
 - CLI: `redis_sre_agent/cli/`
 - Configuration: `redis_sre_agent/core/config.py`
 - Docker config: `docker-compose.yml`
+- Written specs: `specs/`
 - Source documents: `source_documents/`
+
+## Specs
+- Put newly written design specs and implementation specs in `specs/`.
+- Prefer `specs/` over `docs/` for work-in-progress or review-oriented specification documents.
 
 ## Environment Variables
 See `.env.example` for full configuration. Key variables:

--- a/redis_sre_agent/agent/chat_agent.py
+++ b/redis_sre_agent/agent/chat_agent.py
@@ -746,7 +746,7 @@ User Query: {query}"""
                 "max_iterations": max_iterations,
                 "startup_system_prompt": system_prompt,
                 "startup_prompt_initialized": True,
-                "toolset_generation": 0,
+                "toolset_generation": 1,
                 "signals_envelopes": [],  # Track tool outputs - citations derived via extract_citations()
             }
 

--- a/redis_sre_agent/agent/chat_agent.py
+++ b/redis_sre_agent/agent/chat_agent.py
@@ -737,6 +737,7 @@ User Query: {query}"""
 
             initial_messages.append(HumanMessage(content=enhanced_query))
 
+            initial_generation = tool_mgr.get_toolset_generation()
             initial_state: ChatAgentState = {
                 "messages": initial_messages,
                 "session_id": session_id,
@@ -746,7 +747,7 @@ User Query: {query}"""
                 "max_iterations": max_iterations,
                 "startup_system_prompt": system_prompt,
                 "startup_prompt_initialized": True,
-                "toolset_generation": 1,
+                "toolset_generation": initial_generation,
                 "signals_envelopes": [],  # Track tool outputs - citations derived via extract_citations()
             }
 

--- a/redis_sre_agent/agent/chat_agent.py
+++ b/redis_sre_agent/agent/chat_agent.py
@@ -112,6 +112,7 @@ class ChatAgentState(TypedDict):
     max_iterations: int
     startup_system_prompt: Optional[str]
     startup_prompt_initialized: NotRequired[bool]
+    toolset_generation: NotRequired[int]
     # Accumulated tool result envelopes for context management and citation derivation
     signals_envelopes: List[Dict[str, Any]]
 
@@ -412,18 +413,27 @@ class ChatAgent:
         # Mutable container for envelopes - expand_evidence references this
         # so it can access envelopes as they're added by tool calls
         envelopes_container: Dict[str, List[Dict[str, Any]]] = {"envelopes": []}
-        runtime_tools: Dict[str, Any] = {
-            "generation": None,
-            "tooldefs_by_name": {},
-            "all_adapters": [],
-            "llm_with_expand": None,
-            "tool_node": None,
-        }
+        runtime_tools_by_generation: Dict[int, Dict[str, Any]] = {}
 
-        async def ensure_runtime_tools() -> Dict[str, Any]:
-            generation = tool_mgr.get_toolset_generation()
-            if runtime_tools["generation"] == generation:
-                return runtime_tools
+        async def ensure_runtime_tools(
+            requested_generation: Optional[int] = None,
+        ) -> Dict[str, Any]:
+            current_generation = tool_mgr.get_toolset_generation()
+            generation = requested_generation or current_generation
+            cached = runtime_tools_by_generation.get(generation)
+            if cached is not None:
+                return cached
+
+            if requested_generation is not None and requested_generation != current_generation:
+                logger.warning(
+                    "Requested chat tool generation %s is unavailable; using current generation %s",
+                    requested_generation,
+                    current_generation,
+                )
+                generation = current_generation
+                cached = runtime_tools_by_generation.get(generation)
+                if cached is not None:
+                    return cached
 
             from .helpers import build_adapters_for_tooldefs as _build_adapters
 
@@ -436,12 +446,15 @@ class ChatAgent:
                 description=expand_spec["description"],
             )
             all_adapters = list(adapters) + [expand_tool]
-            runtime_tools["generation"] = generation
-            runtime_tools["tooldefs_by_name"] = {t.name: t for t in tooldefs}
-            runtime_tools["all_adapters"] = all_adapters
-            runtime_tools["llm_with_expand"] = self.llm.bind_tools(all_adapters)
-            runtime_tools["tool_node"] = LGToolNode(all_adapters)
-            return runtime_tools
+            runtime = {
+                "generation": generation,
+                "tooldefs_by_name": {t.name: t for t in tooldefs},
+                "all_adapters": all_adapters,
+                "llm_with_expand": self.llm.bind_tools(all_adapters),
+                "tool_node": LGToolNode(all_adapters),
+            }
+            runtime_tools_by_generation[generation] = runtime
+            return runtime
 
         async def agent_node(state: ChatAgentState) -> Dict[str, Any]:
             """Main agent node - invokes LLM with tools."""
@@ -495,6 +508,7 @@ class ChatAgent:
                 "iteration_count": iteration_count + 1,
                 "startup_system_prompt": startup_system_prompt,
                 "startup_prompt_initialized": startup_prompt_initialized,
+                "toolset_generation": runtime["generation"],
                 "current_tool_calls": response.tool_calls
                 if hasattr(response, "tool_calls")
                 else [],
@@ -502,7 +516,7 @@ class ChatAgent:
 
         async def tool_node(state: ChatAgentState) -> Dict[str, Any]:
             """Execute tool calls from the agent."""
-            runtime = await ensure_runtime_tools()
+            runtime = await ensure_runtime_tools(state.get("toolset_generation"))
             tooldefs_by_name = runtime["tooldefs_by_name"]
             messages = state["messages"]
             envelopes = list(state.get("signals_envelopes") or [])
@@ -585,6 +599,7 @@ class ChatAgent:
             return {
                 "messages": list(messages) + messages_for_llm,
                 "current_tool_calls": [],
+                "toolset_generation": runtime["generation"],
                 "signals_envelopes": envelopes,
             }
 
@@ -729,6 +744,7 @@ User Query: {query}"""
                 "max_iterations": max_iterations,
                 "startup_system_prompt": system_prompt,
                 "startup_prompt_initialized": True,
+                "toolset_generation": 0,
                 "signals_envelopes": [],  # Track tool outputs - citations derived via extract_citations()
             }
 

--- a/redis_sre_agent/agent/chat_agent.py
+++ b/redis_sre_agent/agent/chat_agent.py
@@ -419,7 +419,9 @@ class ChatAgent:
             requested_generation: Optional[int] = None,
         ) -> Dict[str, Any]:
             current_generation = tool_mgr.get_toolset_generation()
-            generation = requested_generation or current_generation
+            generation = (
+                requested_generation if requested_generation is not None else current_generation
+            )
             cached = runtime_tools_by_generation.get(generation)
             if cached is not None:
                 return cached

--- a/redis_sre_agent/agent/chat_agent.py
+++ b/redis_sre_agent/agent/chat_agent.py
@@ -14,7 +14,6 @@ from typing import TYPE_CHECKING, Any, Dict, List, NotRequired, Optional, TypedD
 
 from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, SystemMessage, ToolMessage
 from langchain_core.tools import StructuredTool
-from langchain_openai import ChatOpenAI
 from langgraph.checkpoint.memory import MemorySaver
 from langgraph.graph import END, StateGraph
 from langgraph.prebuilt import ToolNode as LGToolNode
@@ -402,36 +401,52 @@ class ChatAgent:
     def _build_workflow(
         self,
         tool_mgr: ToolManager,
-        llm_with_tools: ChatOpenAI,
-        adapters: List[Any],
         emitter: Optional[ProgressEmitter] = None,
     ) -> StateGraph:
         """Build the LangGraph workflow for chat interactions.
 
         Args:
             tool_mgr: ToolManager instance for resolving tool calls
-            llm_with_tools: LLM instance with tools bound
-            adapters: List of tool adapters for the ToolNode
             emitter: Optional progress emitter for status updates
         """
-        tooldefs_by_name = {t.name: t for t in tool_mgr.get_tools()}
-
         # Mutable container for envelopes - expand_evidence references this
         # so it can access envelopes as they're added by tool calls
         envelopes_container: Dict[str, List[Dict[str, Any]]] = {"envelopes": []}
+        runtime_tools: Dict[str, Any] = {
+            "generation": None,
+            "tooldefs_by_name": {},
+            "all_adapters": [],
+            "llm_with_expand": None,
+            "tool_node": None,
+        }
 
-        # Build expand_evidence tool upfront so LLM knows it exists
-        expand_spec = self._build_expand_evidence_tool(envelopes_container)
-        expand_tool = StructuredTool.from_function(
-            func=expand_spec["func"],
-            name=expand_spec["name"],
-            description=expand_spec["description"],
-        )
-        all_adapters = list(adapters) + [expand_tool]
-        llm_with_expand = self.llm.bind_tools(all_adapters)
+        async def ensure_runtime_tools() -> Dict[str, Any]:
+            generation = tool_mgr.get_toolset_generation()
+            if runtime_tools["generation"] == generation:
+                return runtime_tools
+
+            from .helpers import build_adapters_for_tooldefs as _build_adapters
+
+            tooldefs = tool_mgr.get_tools()
+            adapters = await _build_adapters(tool_mgr, tooldefs)
+            expand_spec = self._build_expand_evidence_tool(envelopes_container)
+            expand_tool = StructuredTool.from_function(
+                func=expand_spec["func"],
+                name=expand_spec["name"],
+                description=expand_spec["description"],
+            )
+            all_adapters = list(adapters) + [expand_tool]
+            runtime_tools["generation"] = generation
+            runtime_tools["tooldefs_by_name"] = {t.name: t for t in tooldefs}
+            runtime_tools["all_adapters"] = all_adapters
+            runtime_tools["llm_with_expand"] = self.llm.bind_tools(all_adapters)
+            runtime_tools["tool_node"] = LGToolNode(all_adapters)
+            return runtime_tools
 
         async def agent_node(state: ChatAgentState) -> Dict[str, Any]:
             """Main agent node - invokes LLM with tools."""
+            runtime = await ensure_runtime_tools()
+            tooldefs_by_name = runtime["tooldefs_by_name"]
             messages = state["messages"]
             iteration_count = state.get("iteration_count", 0)
             startup_system_prompt = state.get("startup_system_prompt")
@@ -470,7 +485,7 @@ class ChatAgent:
                 messages = [SystemMessage(content=startup_system_prompt)] + messages
 
             with tracer.start_as_current_span("chat_agent_node"):
-                response = await llm_with_expand.ainvoke(messages)
+                response = await runtime["llm_with_expand"].ainvoke(messages)
 
             # Persist only the original workflow state messages plus response.
             # If we injected a SystemMessage just for this invocation, keep it ephemeral.
@@ -487,6 +502,8 @@ class ChatAgent:
 
         async def tool_node(state: ChatAgentState) -> Dict[str, Any]:
             """Execute tool calls from the agent."""
+            runtime = await ensure_runtime_tools()
+            tooldefs_by_name = runtime["tooldefs_by_name"]
             messages = state["messages"]
             envelopes = list(state.get("signals_envelopes") or [])
 
@@ -512,8 +529,7 @@ class ChatAgent:
                         await emitter.emit(status_msg, "tool_call")
 
             with tracer.start_as_current_span("chat_tool_node"):
-                lg_tool_node = LGToolNode(all_adapters)
-                out = await lg_tool_node.ainvoke({"messages": messages})
+                out = await runtime["tool_node"].ainvoke({"messages": messages})
                 out_messages = out.get("messages", [])
                 new_tool_messages = [m for m in out_messages if isinstance(m, ToolMessage)]
 
@@ -642,16 +658,13 @@ class ChatAgent:
             support_package_path=self.support_package_path,
             cache_client=cache_client,
             cache_ttl_overrides=settings.tool_cache_ttl_overrides or None,
+            thread_id=session_id,
+            task_id=(context or {}).get("task_id"),
+            user_id=user_id,
         ) as tool_mgr:
             tools = tool_mgr.get_tools()
             logger.info(f"Chat agent loaded {len(tools)} tools")
-
-            from .helpers import build_adapters_for_tooldefs as _build_adapters
-
-            adapters = await _build_adapters(tool_mgr, tools)
-            llm_with_tools = self.llm.bind_tools(adapters)
-
-            workflow = self._build_workflow(tool_mgr, llm_with_tools, adapters, emitter)
+            workflow = self._build_workflow(tool_mgr, emitter)
 
             checkpointer = MemorySaver()
             app = workflow.compile(checkpointer=checkpointer)

--- a/redis_sre_agent/agent/langgraph_agent.py
+++ b/redis_sre_agent/agent/langgraph_agent.py
@@ -28,7 +28,7 @@ from langgraph.prebuilt import ToolNode as LGToolNode
 from opentelemetry import trace
 from pydantic import BaseModel, Field
 
-from ..agent.router import AgentType, format_conversation_context, route_to_appropriate_agent
+from ..agent.router import format_conversation_context, query_needs_live_redis_scope
 from ..core.config import settings
 from ..core.instances import (
     create_instance,
@@ -2023,11 +2023,9 @@ To get targeted analysis, please rephrase your query to specify which instance, 
                         # No instances configured - try to gather info or route to knowledge agent
                         logger.warning("No Redis instances configured")
 
-                        # Check if this query seems to be about a specific Redis instance
-                        # or if it's more general knowledge-seeking
-                        suggested_agent = await route_to_appropriate_agent(query, context)
-
-                        if suggested_agent == AgentType.KNOWLEDGE_ONLY:
+                        # Check if this query appears to need live Redis access,
+                        # even when no instance is currently configured.
+                        if not await query_needs_live_redis_scope(query):
                             # Route to knowledge agent for general queries
                             logger.info(
                                 "No instances configured and query is general - suggesting knowledge agent"
@@ -2230,6 +2228,9 @@ For now, I can still perform basic Redis diagnostics using the database connecti
             support_package_path=support_package_path,
             cache_client=cache_client,
             cache_ttl_overrides=settings.tool_cache_ttl_overrides or None,
+            thread_id=session_id,
+            task_id=(context or {}).get("task_id") if isinstance(context, dict) else None,
+            user_id=user_id,
         ) as tool_mgr:
             # Get tools and bind to LLM via StructuredTool adapters
             tools = tool_mgr.get_tools()

--- a/redis_sre_agent/agent/router.py
+++ b/redis_sre_agent/agent/router.py
@@ -23,7 +23,7 @@ class AgentType(Enum):
 
     REDIS_TRIAGE = "redis_triage"  # Full triage/health check agent
     REDIS_CHAT = "redis_chat"  # Lightweight chat agent for quick Q&A
-    KNOWLEDGE_ONLY = "knowledge_only"  # No instance, general knowledge
+    KNOWLEDGE_ONLY = "knowledge_only"  # Deprecated compatibility mode
 
     # Keep old value for backward compatibility
     REDIS_FOCUSED = "redis_triage"  # Alias for REDIS_TRIAGE
@@ -61,9 +61,9 @@ async def route_to_appropriate_agent(
     Route a query to the appropriate agent using a fast LLM categorization.
 
     Routing logic:
-    - No Redis diagnostic scope (instance/cluster): KNOWLEDGE_ONLY (general knowledge questions)
-    - Has Redis diagnostic scope + asks for deep/comprehensive triage: REDIS_TRIAGE
-    - Has Redis diagnostic scope + quick/standard question: REDIS_CHAT (fast diagnostic loop)
+    - Requests with support-package scope always use REDIS_TRIAGE
+    - Explicit deep/comprehensive triage requests use REDIS_TRIAGE
+    - All other requests use REDIS_CHAT, including zero-scope knowledge questions
 
     Args:
         query: The user's query text
@@ -86,47 +86,13 @@ async def route_to_appropriate_agent(
         logger.info("Support package provided - routing to REDIS_TRIAGE for diagnostic tools")
         return AgentType.REDIS_TRIAGE
 
-    # 2. No diagnostic scope (instance/cluster) - route to knowledge agent
+    # 2. No diagnostic scope (instance/cluster) - default to chat.
+    # Chat now serves as the zero-scope knowledge/default agent.
     if not has_diagnostic_scope:
-        # Use LLM to decide if query needs instance access or is knowledge-only
-        try:
-            llm = create_nano_llm(timeout=10.0)
-
-            # Include conversation context if available
-            context_str = format_conversation_context(conversation_history)
-
-            system_prompt = """You are a query categorization system for a Redis SRE agent.
-
-Categorize if this query requires access to a live Redis instance or is just seeking general knowledge.
-Consider the conversation context if provided - a follow-up like "yes" or "check that" refers to the previous discussion.
-
-1. NEEDS_INSTANCE: Queries that require access to a specific Redis instance for diagnostics, monitoring, or troubleshooting.
-   Examples: "Check my Redis memory", "Why is Redis slow?", "Show me the slowlog"
-
-2. KNOWLEDGE_ONLY: Queries seeking general knowledge, best practices, or guidance.
-   Examples: "What are Redis best practices?", "How does Redis replication work?"
-
-Respond with ONLY one word: either "NEEDS_INSTANCE" or "KNOWLEDGE_ONLY"."""
-
-            query_with_context = f"Categorize this query: {query}{context_str}"
-            messages = [
-                SystemMessage(content=system_prompt),
-                HumanMessage(content=query_with_context),
-            ]
-
-            response = await llm.ainvoke(messages)
-            category = response.content.strip().upper()
-
-            if "NEEDS_INSTANCE" in category:
-                logger.info("Query needs instance but none provided - routing to KNOWLEDGE_ONLY")
-            else:
-                logger.info("LLM categorized query as KNOWLEDGE_ONLY")
-
-            return AgentType.KNOWLEDGE_ONLY
-
-        except Exception as e:
-            logger.error(f"Error during LLM routing: {e}, defaulting to KNOWLEDGE_ONLY")
-            return AgentType.KNOWLEDGE_ONLY
+        logger.info(
+            "No diagnostic scope - routing to REDIS_CHAT as the default general-purpose agent"
+        )
+        return AgentType.REDIS_CHAT
 
     # 3. Has instance or cluster scope - decide between triage (full) and chat (quick)
     # Check user preferences first
@@ -220,3 +186,39 @@ Respond with ONLY one word: either "DEEP_TRIAGE" or "CHAT"."""
             return AgentType.REDIS_TRIAGE
         logger.error(f"Error during LLM routing: {e}, defaulting to REDIS_CHAT")
         return AgentType.REDIS_CHAT
+
+
+async def query_needs_live_redis_scope(
+    query: str,
+    conversation_history: Optional[List[BaseMessage]] = None,
+) -> bool:
+    """Best-effort classifier for whether a zero-scope query needs live Redis access."""
+    try:
+        llm = create_nano_llm(timeout=10.0)
+        context_str = format_conversation_context(conversation_history)
+        system_prompt = """You are a query categorization system for a Redis SRE agent.
+
+Categorize if this query requires access to a live Redis instance or is just seeking general knowledge.
+Consider the conversation context if provided - a follow-up like "yes" or "check that" refers to the previous discussion.
+
+1. NEEDS_INSTANCE: Queries that require access to a specific Redis instance for diagnostics, monitoring, or troubleshooting.
+   Examples: "Check my Redis memory", "Why is Redis slow?", "Show me the slowlog"
+
+2. KNOWLEDGE_ONLY: Queries seeking general knowledge, best practices, or guidance.
+   Examples: "What are Redis best practices?", "How does Redis replication work?"
+
+Respond with ONLY one word: either "NEEDS_INSTANCE" or "KNOWLEDGE_ONLY"."""
+        response = await llm.ainvoke(
+            [
+                SystemMessage(content=system_prompt),
+                HumanMessage(content=f"Categorize this query: {query}{context_str}"),
+            ]
+        )
+        category = response.content.strip().upper()
+        return "NEEDS_INSTANCE" in category
+    except Exception as e:
+        logger.error(
+            "Error during live-scope classification for zero-scope query: %s; defaulting to False",
+            e,
+        )
+        return False

--- a/redis_sre_agent/cli/query.py
+++ b/redis_sre_agent/cli/query.py
@@ -12,7 +12,6 @@ from rich.console import Console
 from rich.markdown import Markdown
 
 from redis_sre_agent.agent.chat_agent import get_chat_agent
-from redis_sre_agent.agent.knowledge_agent import get_knowledge_agent
 from redis_sre_agent.agent.langgraph_agent import get_sre_agent
 from redis_sre_agent.agent.router import AgentType, route_to_appropriate_agent
 from redis_sre_agent.core.citation_message import (
@@ -26,6 +25,9 @@ from redis_sre_agent.core.redis import get_redis_client
 from redis_sre_agent.core.threads import ThreadManager
 
 logger = logging.getLogger(__name__)
+
+# Backward-compatible module attribute for legacy tests and patches.
+get_knowledge_agent = get_chat_agent
 
 
 @click.command()
@@ -56,7 +58,7 @@ def query(
 
     \b
     The agent is automatically selected based on the query, or use --agent:
-      - knowledge: Legacy knowledge-only mode
+      - knowledge: Backward-compatible alias for chat mode
       - chat: Default general-purpose agent, with or without explicit scope
       - triage: Full health checks and diagnostics
       - auto: Let the router decide (default)
@@ -179,13 +181,13 @@ def query(
         agent_choice_map = {
             "triage": AgentType.REDIS_TRIAGE,
             "chat": AgentType.REDIS_CHAT,
-            "knowledge": AgentType.KNOWLEDGE_ONLY,
+            "knowledge": AgentType.REDIS_CHAT,
         }
 
         # Determine which agent to use
         if agent != "auto":
             agent_type = agent_choice_map[agent.lower()]
-            agent_label = agent.capitalize()
+            agent_label = "Chat" if agent.lower() == "knowledge" else agent.capitalize()
             console.print(f"[dim]🔧 Agent: {agent_label} (selected)[/dim]")
         else:
             agent_type = await route_to_appropriate_agent(
@@ -196,20 +198,18 @@ def query(
             agent_label = {
                 AgentType.REDIS_TRIAGE: "Triage",
                 AgentType.REDIS_CHAT: "Chat",
-                AgentType.KNOWLEDGE_ONLY: "Knowledge",
+                AgentType.KNOWLEDGE_ONLY: "Chat",
             }.get(agent_type, agent_type.value)
             console.print(f"[dim]🔧 Agent: {agent_label}[/dim]")
 
         # Get the appropriate agent instance
         if agent_type == AgentType.REDIS_TRIAGE:
             selected_agent = get_sre_agent()
-        elif agent_type == AgentType.REDIS_CHAT:
+        else:
             selected_agent = get_chat_agent(
                 redis_instance=instance,
                 redis_cluster=cluster,
             )
-        else:
-            selected_agent = get_knowledge_agent()
 
         try:
             # Build context with instance and/or support package

--- a/redis_sre_agent/cli/query.py
+++ b/redis_sre_agent/cli/query.py
@@ -56,8 +56,8 @@ def query(
 
     \b
     The agent is automatically selected based on the query, or use --agent:
-      - knowledge: General Redis questions (no instance needed)
-      - chat: Quick questions with a Redis instance
+      - knowledge: Legacy knowledge-only mode
+      - chat: Default general-purpose agent, with or without explicit scope
       - triage: Full health checks and diagnostics
       - auto: Let the router decide (default)
     """

--- a/redis_sre_agent/core/clusters.py
+++ b/redis_sre_agent/core/clusters.py
@@ -399,6 +399,15 @@ async def save_clusters(clusters: List[RedisCluster]) -> bool:
                 await client.delete(f"{SRE_CLUSTERS_INDEX}:{stale_id}")
             except Exception:
                 pass
+
+        # Best-effort rebuild of the unified discovery catalog, keeping cluster
+        # CRUD and direct lookup semantics unchanged.
+        try:
+            from redis_sre_agent.core.targets import sync_target_catalog
+
+            await sync_target_catalog(clusters=clusters)
+        except Exception:
+            logger.debug("Best-effort target catalog sync failed after saving clusters")
         return True
     except Exception as e:
         logger.exception("Failed to save clusters to Redis: %s", e)

--- a/redis_sre_agent/core/docket_tasks.py
+++ b/redis_sre_agent/core/docket_tasks.py
@@ -45,6 +45,17 @@ def sre_task(func):
     return func
 
 
+def _thread_messages_to_conversation_history(thread_messages: List[Message]) -> List[Any]:
+    """Convert persisted thread messages into LangChain conversation history."""
+    history: List[Any] = []
+    for msg in thread_messages:
+        if msg.role == "user":
+            history.append(HumanMessage(content=msg.content))
+        elif msg.role == "assistant":
+            history.append(AIMessage(content=msg.content))
+    return history
+
+
 # NOTE: analyze_system_metrics was removed as it was never actually provided
 # as a tool to the LLM. Metrics/diagnostics will be implemented via the
 # ToolProvider system in a future PR.
@@ -382,6 +393,11 @@ async def process_knowledge_query(
         # Create task emitter for notifications
         emitter = TaskEmitter(task_manager=task_manager, task_id=task_id)
 
+        conversation_history = None
+        thread = await thread_manager.get_thread(thread_id)
+        if thread and thread.messages:
+            conversation_history = _thread_messages_to_conversation_history(thread.messages)
+
         # Run chat agent without explicit target scope. This preserves the
         # legacy entrypoint while keeping runtime behavior on the two-agent model.
         agent = get_chat_agent()
@@ -391,6 +407,7 @@ async def process_knowledge_query(
             user_id=user_id or "mcp-user",
             context={"task_id": task_id},
             progress_emitter=emitter,
+            conversation_history=conversation_history,
         )
 
         # Store result on task (convert AgentResponse to dict for JSON serialization)

--- a/redis_sre_agent/core/docket_tasks.py
+++ b/redis_sre_agent/core/docket_tasks.py
@@ -401,10 +401,12 @@ async def process_knowledge_query(
         # Run chat agent without explicit target scope. This preserves the
         # legacy entrypoint while keeping runtime behavior on the two-agent model.
         agent = get_chat_agent()
+        chat_max_iterations = min(int(settings.max_iterations or 15), 10)
         response = await agent.process_query(
             query=query,
             session_id=thread_id,
             user_id=user_id or "mcp-user",
+            max_iterations=chat_max_iterations,
             context={"task_id": task_id},
             progress_emitter=emitter,
             conversation_history=conversation_history,

--- a/redis_sre_agent/core/docket_tasks.py
+++ b/redis_sre_agent/core/docket_tasks.py
@@ -10,7 +10,6 @@ from ulid import ULID
 
 from redis_sre_agent.agent import get_sre_agent
 from redis_sre_agent.agent.chat_agent import get_chat_agent
-from redis_sre_agent.agent.knowledge_agent import get_knowledge_agent
 from redis_sre_agent.agent.langgraph_agent import (
     _extract_instance_details_from_message,
 )
@@ -283,6 +282,7 @@ async def process_chat_turn(
             query=query,
             session_id=thread_id,
             user_id=user_id or "mcp-user",
+            context={"task_id": task_id},
             progress_emitter=emitter,
         )
 
@@ -353,9 +353,9 @@ async def process_knowledge_query(
     retry: Retry = Retry(attempts=2, delay=timedelta(seconds=2)),
 ) -> Dict[str, Any]:
     """
-    Process a knowledge query using the KnowledgeOnlyAgent (background task).
+    Process a knowledge query using the chat agent compatibility path.
 
-    This runs the KnowledgeOnlyAgent for general SRE knowledge questions.
+    This routes onto the default chat agent with no explicit Redis scope.
     Notifications are emitted to the task, and the result is stored on both
     the task and the thread.
 
@@ -369,8 +369,6 @@ async def process_knowledge_query(
     Returns:
         Dictionary with the knowledge agent response
     """
-    from redis_sre_agent.agent.knowledge_agent import KnowledgeOnlyAgent
-
     logger.info(f"Processing knowledge query for task {task_id}")
 
     redis_client = get_redis_client()
@@ -384,12 +382,14 @@ async def process_knowledge_query(
         # Create task emitter for notifications
         emitter = TaskEmitter(task_manager=task_manager, task_id=task_id)
 
-        # Run knowledge agent
-        agent = KnowledgeOnlyAgent(progress_emitter=emitter)
+        # Run chat agent without explicit target scope. This preserves the
+        # legacy entrypoint while keeping runtime behavior on the two-agent model.
+        agent = get_chat_agent()
         response = await agent.process_query(
             query=query,
             session_id=thread_id,
             user_id=user_id or "mcp-user",
+            context={"task_id": task_id},
             progress_emitter=emitter,
         )
 
@@ -439,7 +439,7 @@ async def process_knowledge_query(
                     "metadata": {
                         "task_id": task_id,
                         "message_id": message_id,
-                        "agent": "knowledge",
+                        "agent": "chat",
                     },
                 }
             ],
@@ -700,7 +700,7 @@ async def process_agent_turn(
         # 2. Else if client provides cluster_id, use it and clear instance_id on thread
         # 3. Else fall back to existing thread instance_id/cluster_id
         # 4. If no target exists, attempt to create an instance from user message
-        # 5. If still no target, route to knowledge/general tools
+        # 5. If still no target, route to the default zero-scope chat flow
         # ============================================================================
 
         instance_id_from_client = context.get("instance_id") if context else None
@@ -820,6 +820,7 @@ async def process_agent_turn(
         routing_context = thread.context.copy()
         if context:
             routing_context.update(context)
+        routing_context["task_id"] = task_id
 
         # Ensure active_instance_id is in routing context
         if active_instance_id:
@@ -835,15 +836,60 @@ async def process_agent_turn(
             user_preferences=None,  # Could be extended to include user preferences
         )
 
+        if agent_type == AgentType.REDIS_TRIAGE and not (active_instance_id or active_cluster_id):
+            try:
+                from redis_sre_agent.core.targets import attach_target_matches, resolve_target_query
+
+                resolution = await resolve_target_query(
+                    query=message,
+                    user_id=thread.metadata.user_id,
+                    allow_multiple=True,
+                    max_results=5,
+                    preferred_capabilities=["diagnostics", "admin", "cloud"],
+                )
+                if resolution.selected_matches:
+                    attached_bindings, generation = await attach_target_matches(
+                        thread_id=thread_id,
+                        matches=resolution.selected_matches,
+                        task_id=task_id,
+                        replace_existing=False,
+                    )
+                    if attached_bindings:
+                        active_binding = attached_bindings[0]
+                        if active_binding.target_kind == "instance":
+                            active_instance_id = active_binding.resource_id
+                            routing_context["instance_id"] = active_instance_id
+                            routing_context.pop("cluster_id", None)
+                        elif active_binding.target_kind == "cluster":
+                            active_cluster_id = active_binding.resource_id
+                            routing_context["cluster_id"] = active_cluster_id
+                            routing_context.pop("instance_id", None)
+                        routing_context["attached_target_handles"] = [
+                            binding.target_handle for binding in attached_bindings
+                        ]
+                        routing_context["target_toolset_generation"] = generation
+                        await task_manager.add_task_update(
+                            task_id,
+                            "Resolved target scope from natural language before deep triage",
+                            "target_resolution",
+                            metadata={
+                                "attached_target_handles": routing_context[
+                                    "attached_target_handles"
+                                ],
+                                "match_count": len(attached_bindings),
+                            },
+                        )
+            except Exception:
+                logger.exception("Failed to pre-resolve target scope for deep triage")
+
         logger.info(f"Routing query to {agent_type.value} agent")
 
         # Import and initialize the appropriate agent based on routing decision
         # REDIS_TRIAGE = full triage agent (heavy, comprehensive)
-        # REDIS_CHAT = lightweight chat agent (fast, targeted)
-        # KNOWLEDGE_ONLY = knowledge agent (no instance needed)
+        # REDIS_CHAT / KNOWLEDGE_ONLY = lightweight/default chat agent
         if agent_type == AgentType.REDIS_TRIAGE:
             agent = get_sre_agent()
-        elif agent_type == AgentType.REDIS_CHAT:
+        else:
             # Get the target instance for the chat agent
             target_instance = (
                 await get_instance_by_id(active_instance_id) if active_instance_id else None
@@ -855,8 +901,6 @@ async def process_agent_turn(
                 redis_instance=target_instance,
                 redis_cluster=target_cluster,
             )
-        else:
-            agent = get_knowledge_agent()
 
         # Prepare the conversation state with thread messages
         # Convert Message objects to dicts for agent processing
@@ -912,43 +956,7 @@ async def process_agent_turn(
         )
 
         # Run the appropriate agent
-        if agent_type == AgentType.KNOWLEDGE_ONLY:
-            # Use knowledge-only agent with simpler interface
-            await task_manager.add_task_update(
-                task_id, "Processing query with knowledge-only agent", "agent_processing"
-            )
-
-            # Convert conversation history to LangChain messages for knowledge agent
-            lc_history = []
-            for msg in conversation_state["messages"][:-1]:  # Exclude the latest message
-                if msg["role"] == "user":
-                    lc_history.append(HumanMessage(content=msg["content"]))
-                elif msg["role"] == "assistant":
-                    lc_history.append(AIMessage(content=msg["content"]))
-
-            # Use a smaller iteration cap for the knowledge agent to avoid long loops
-            _k_max_iters = settings.knowledge_max_iterations
-            if not isinstance(_k_max_iters, int) or _k_max_iters <= 0:
-                _k_max_iters = min(int(settings.max_iterations or 10), 8)
-
-            knowledge_agent_response = await agent.process_query(
-                query=message,
-                user_id=thread.metadata.user_id or "unknown",
-                session_id=thread.metadata.session_id or thread_id,
-                max_iterations=_k_max_iters,
-                context=None,
-                progress_emitter=progress_emitter,
-                conversation_history=lc_history if lc_history else None,
-            )
-
-            # knowledge_agent_response is an AgentResponse with .response, .search_results, .tool_envelopes
-            agent_response = {
-                "response": knowledge_agent_response.response,
-                "search_results": knowledge_agent_response.search_results,
-                "tool_envelopes": knowledge_agent_response.tool_envelopes,
-                "metadata": {"agent_type": "knowledge_only"},
-            }
-        elif agent_type == AgentType.REDIS_CHAT:
+        if agent_type != AgentType.REDIS_TRIAGE:
             # Use lightweight chat agent with process_query interface
             await task_manager.add_task_update(
                 task_id, "Processing query with chat agent", "agent_processing"
@@ -970,7 +978,7 @@ async def process_agent_turn(
                 user_id=thread.metadata.user_id or "unknown",
                 session_id=thread.metadata.session_id or thread_id,
                 max_iterations=_chat_max_iters,
-                context=routing_context,
+                context={**routing_context, "task_id": task_id},
                 progress_emitter=progress_emitter,
                 conversation_history=lc_history if lc_history else None,
             )

--- a/redis_sre_agent/core/docket_tasks.py
+++ b/redis_sre_agent/core/docket_tasks.py
@@ -396,7 +396,14 @@ async def process_knowledge_query(
         conversation_history = None
         thread = await thread_manager.get_thread(thread_id)
         if thread and thread.messages:
-            conversation_history = _thread_messages_to_conversation_history(thread.messages)
+            history_messages = list(thread.messages)
+            if (
+                history_messages
+                and history_messages[-1].role == "user"
+                and history_messages[-1].content == query
+            ):
+                history_messages = history_messages[:-1]
+            conversation_history = _thread_messages_to_conversation_history(history_messages)
 
         # Run chat agent without explicit target scope. This preserves the
         # legacy entrypoint while keeping runtime behavior on the two-agent model.

--- a/redis_sre_agent/core/docket_tasks.py
+++ b/redis_sre_agent/core/docket_tasks.py
@@ -997,7 +997,7 @@ async def process_agent_turn(
                 user_id=thread.metadata.user_id or "unknown",
                 session_id=thread.metadata.session_id or thread_id,
                 max_iterations=_chat_max_iters,
-                context={**routing_context, "task_id": task_id},
+                context=routing_context,
                 progress_emitter=progress_emitter,
                 conversation_history=lc_history if lc_history else None,
             )

--- a/redis_sre_agent/core/instances.py
+++ b/redis_sre_agent/core/instances.py
@@ -683,6 +683,15 @@ async def save_instances(instances: List[RedisInstance]) -> bool:
                 await client.delete(f"{SRE_INSTANCES_INDEX}:{sid}")
             except Exception:
                 pass
+
+        # Keep the unified discovery catalog in sync without changing the
+        # authoritative instance index behavior.
+        try:
+            from redis_sre_agent.core.targets import sync_target_catalog
+
+            await sync_target_catalog(instances=instances)
+        except Exception:
+            logger.debug("Best-effort target catalog sync failed after saving instances")
         return True
     except Exception as e:
         logger.exception("Failed to save instances to Redis: %s", e)

--- a/redis_sre_agent/core/redis.py
+++ b/redis_sre_agent/core/redis.py
@@ -30,6 +30,8 @@ SRE_TASKS_INDEX = "sre_tasks"
 SRE_INSTANCES_INDEX = "sre_instances"
 # Clusters index
 SRE_CLUSTERS_INDEX = "sre_clusters"
+# Unified targets index
+SRE_TARGETS_INDEX = "sre_targets"
 # Q&A index
 SRE_QA_INDEX = "sre_qa"
 
@@ -265,6 +267,38 @@ SRE_CLUSTERS_SCHEMA = {
         {"name": "status", "type": "tag"},
         {"name": "created_at", "type": "numeric"},
         {"name": "updated_at", "type": "numeric"},
+    ],
+}
+
+SRE_TARGETS_SCHEMA = {
+    "index": {
+        "name": SRE_TARGETS_INDEX,
+        "prefix": f"{SRE_TARGETS_INDEX}:",
+        "storage_type": "hash",
+    },
+    "fields": [
+        {"name": "target_id", "type": "tag"},
+        {"name": "target_kind", "type": "tag"},
+        {"name": "resource_id", "type": "tag"},
+        {"name": "display_name", "type": "text"},
+        {"name": "name", "type": "tag"},
+        {"name": "environment", "type": "tag"},
+        {"name": "status", "type": "tag"},
+        {"name": "target_type", "type": "tag"},
+        {"name": "usage", "type": "tag"},
+        {"name": "cluster_id", "type": "tag"},
+        {"name": "repo_slug", "type": "tag"},
+        {"name": "monitoring_identifier", "type": "tag"},
+        {"name": "logging_identifier", "type": "tag"},
+        {"name": "redis_cloud_subscription_id", "type": "tag"},
+        {"name": "redis_cloud_database_id", "type": "tag"},
+        {"name": "redis_cloud_database_name", "type": "tag"},
+        {"name": "search_aliases", "type": "tag"},
+        {"name": "capabilities", "type": "tag"},
+        {"name": "updated_at", "type": "numeric"},
+        {"name": "created_at", "type": "numeric"},
+        {"name": "search_text", "type": "text"},
+        {"name": "user_id", "type": "tag"},
     ],
 }
 
@@ -610,6 +644,19 @@ async def get_clusters_index(config: Optional[Settings] = None) -> AsyncSearchIn
     return index
 
 
+async def get_targets_index(config: Optional[Settings] = None) -> AsyncSearchIndex:
+    """Get SRE unified targets index (async)."""
+    from redisvl.schema import IndexSchema
+
+    cfg = config or settings
+    redis_url = cfg.redis_url.get_secret_value()
+
+    redis_client = Redis.from_url(redis_url, decode_responses=False)
+    schema = IndexSchema.from_dict(SRE_TARGETS_SCHEMA)
+    index = AsyncSearchIndex(schema=schema, redis_client=redis_client)
+    return index
+
+
 async def get_threads_index(config: Optional[Settings] = None) -> AsyncSearchIndex:
     """Get SRE threads/tasks index (async).
 
@@ -736,6 +783,7 @@ def _iter_index_configs():
     yield ("tasks", SRE_TASKS_INDEX, get_tasks_index, SRE_TASKS_SCHEMA)
     yield ("instances", SRE_INSTANCES_INDEX, get_instances_index, SRE_INSTANCES_SCHEMA)
     yield ("clusters", SRE_CLUSTERS_INDEX, get_clusters_index, SRE_CLUSTERS_SCHEMA)
+    yield ("targets", SRE_TARGETS_INDEX, get_targets_index, SRE_TARGETS_SCHEMA)
 
 
 async def get_index_schema_status(

--- a/redis_sre_agent/core/targets.py
+++ b/redis_sre_agent/core/targets.py
@@ -752,7 +752,9 @@ async def attach_target_matches(
 ) -> tuple[List[TargetBinding], int]:
     """Persist safe target handles on a thread and return attached bindings."""
     thread_manager = ThreadManager(redis_client=get_redis_client())
+    current_thread = await thread_manager.get_thread(thread_id)
     current_state = await get_thread_target_state(thread_id)
+    current_context = current_thread.context if current_thread else {}
 
     existing_by_resource = {
         (binding.target_kind, binding.resource_id): binding
@@ -801,8 +803,12 @@ async def attach_target_matches(
         "active_target_handle": active_handle or "",
         "target_toolset_generation": generation,
         "target_bindings": [binding.model_dump(mode="json") for binding in bindings_to_store],
-        "instance_id": "",
-        "cluster_id": "",
+        "instance_id": (
+            str(current_context.get("instance_id") or "") if not replace_existing else ""
+        ),
+        "cluster_id": (
+            str(current_context.get("cluster_id") or "") if not replace_existing else ""
+        ),
     }
 
     if active_binding and len(attached_handles) == 1:

--- a/redis_sre_agent/core/targets.py
+++ b/redis_sre_agent/core/targets.py
@@ -1,0 +1,808 @@
+"""Unified Redis target catalog, resolver, and thread binding helpers."""
+
+from __future__ import annotations
+
+import logging
+import re
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, Iterable, List, Optional, Sequence
+from urllib.parse import urlparse
+
+from pydantic import BaseModel, Field
+from redisvl.query import CountQuery, FilterQuery
+from ulid import ULID
+
+from redis_sre_agent.core.clusters import RedisCluster, get_clusters
+from redis_sre_agent.core.instances import RedisInstance, get_instances
+from redis_sre_agent.core.redis import SRE_TARGETS_INDEX, get_redis_client, get_targets_index
+from redis_sre_agent.core.threads import ThreadManager
+
+logger = logging.getLogger(__name__)
+
+_TOKEN_RE = re.compile(r"[a-z0-9]+")
+_ENV_ALIASES = {
+    "prod": "production",
+    "production": "production",
+    "stage": "staging",
+    "staging": "staging",
+    "dev": "development",
+    "development": "development",
+    "test": "test",
+    "qa": "test",
+}
+_USAGE_TERMS = {"cache", "queue", "session", "analytics", "custom"}
+_INSTANCE_HINTS = {"instance", "database", "db"}
+_CLUSTER_HINTS = {"cluster", "subscription"}
+_TYPE_HINTS = {
+    "enterprise": "redis_enterprise",
+    "cloud": "redis_cloud",
+    "oss": "oss_single",
+    "clustered": "oss_cluster",
+}
+_HEALTHY_STATUSES = {"healthy", "ok", "active", "available", "connected"}
+
+
+class TargetCatalogDoc(BaseModel):
+    """Safe denormalized metadata used for natural-language discovery."""
+
+    target_id: str
+    target_kind: str
+    resource_id: str
+    display_name: str
+    name: str
+    environment: Optional[str] = None
+    status: Optional[str] = None
+    target_type: Optional[str] = None
+    usage: Optional[str] = None
+    description: Optional[str] = None
+    notes: Optional[str] = None
+    repo_url: Optional[str] = None
+    repo_slug: Optional[str] = None
+    monitoring_identifier: Optional[str] = None
+    logging_identifier: Optional[str] = None
+    cluster_id: Optional[str] = None
+    redis_cloud_subscription_id: Optional[str] = None
+    redis_cloud_database_id: Optional[str] = None
+    redis_cloud_database_name: Optional[str] = None
+    search_text: str = ""
+    search_aliases: List[str] = Field(default_factory=list)
+    capabilities: List[str] = Field(default_factory=list)
+    updated_at: str = Field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
+    created_at: str = Field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
+    user_id: Optional[str] = None
+
+
+class TargetBinding(BaseModel):
+    """Opaque handle persisted in thread context for attached targets."""
+
+    target_handle: str
+    target_kind: str
+    resource_id: str
+    display_name: str
+    capabilities: List[str] = Field(default_factory=list)
+    thread_id: Optional[str] = None
+    task_id: Optional[str] = None
+    created_at: str = Field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
+    expires_at: Optional[str] = Field(
+        default_factory=lambda: (datetime.now(timezone.utc) + timedelta(hours=24)).isoformat()
+    )
+
+
+class ResolvedTargetMatch(BaseModel):
+    """A ranked candidate returned by the deterministic resolver."""
+
+    target_kind: str
+    resource_id: str
+    display_name: str
+    environment: Optional[str] = None
+    target_type: Optional[str] = None
+    capabilities: List[str] = Field(default_factory=list)
+    confidence: float
+    match_reasons: List[str] = Field(default_factory=list)
+    score: float = Field(default=0.0, exclude=True)
+
+
+class TargetResolutionResult(BaseModel):
+    """Public result shape for target resolution."""
+
+    status: str
+    clarification_required: bool = False
+    matches: List[ResolvedTargetMatch] = Field(default_factory=list)
+    attached_target_handles: List[str] = Field(default_factory=list)
+    toolset_generation: int = 0
+    selected_matches: List[ResolvedTargetMatch] = Field(default_factory=list, exclude=True)
+
+
+class ThreadTargetState(BaseModel):
+    """Attached target handles plus binding metadata for a thread."""
+
+    attached_target_handles: List[str] = Field(default_factory=list)
+    active_target_handle: Optional[str] = None
+    target_toolset_generation: int = 0
+    target_bindings: List[TargetBinding] = Field(default_factory=list)
+
+
+def _to_epoch(ts: Optional[str]) -> float:
+    if not ts:
+        return 0.0
+    try:
+        if ts.endswith("Z"):
+            ts = ts.replace("Z", "+00:00")
+        return datetime.fromisoformat(ts).timestamp()
+    except Exception:
+        try:
+            return float(ts)
+        except Exception:
+            return 0.0
+
+
+def _normalize(value: Any) -> str:
+    return str(value or "").strip().lower()
+
+
+def _tokenize(value: Any) -> List[str]:
+    text = _normalize(value)
+    return _TOKEN_RE.findall(text.replace("-", " ").replace("_", " "))
+
+
+def _dedupe(values: Iterable[str]) -> List[str]:
+    seen: set[str] = set()
+    out: List[str] = []
+    for value in values:
+        normalized = _normalize(value)
+        if not normalized or normalized in seen:
+            continue
+        seen.add(normalized)
+        out.append(normalized)
+    return out
+
+
+def _safe_repo_tokens(repo_url: Optional[str]) -> tuple[Optional[str], List[str]]:
+    if not repo_url:
+        return None, []
+    try:
+        parsed = urlparse(repo_url)
+        path_parts = [part for part in (parsed.path or "").split("/") if part]
+        slug = (
+            "/".join(path_parts[-2:])
+            if len(path_parts) >= 2
+            else (path_parts[0] if path_parts else "")
+        )
+        tokens = [parsed.netloc or "", slug]
+        tokens.extend(path_parts[-2:])
+        return slug or None, _dedupe(tokens)
+    except Exception:
+        return None, []
+
+
+def _extract_safe_aliases(extension_data: Optional[Dict[str, Any]]) -> List[str]:
+    if not isinstance(extension_data, dict):
+        return []
+
+    aliases: List[str] = []
+    for key in ("aliases", "search_aliases", "target_aliases"):
+        value = extension_data.get(key)
+        if isinstance(value, str):
+            aliases.extend([part.strip() for part in value.split(",")])
+        elif isinstance(value, list):
+            aliases.extend(str(item).strip() for item in value)
+
+    target_discovery = extension_data.get("target_discovery")
+    if isinstance(target_discovery, dict):
+        nested_aliases = target_discovery.get("aliases")
+        if isinstance(nested_aliases, list):
+            aliases.extend(str(item).strip() for item in nested_aliases)
+        elif isinstance(nested_aliases, str):
+            aliases.extend([part.strip() for part in nested_aliases.split(",")])
+
+    return _dedupe(aliases)
+
+
+def _instance_capabilities(instance: RedisInstance) -> List[str]:
+    capabilities = ["redis", "diagnostics", "metrics", "logs"]
+    instance_type = _normalize(
+        instance.instance_type.value
+        if hasattr(instance.instance_type, "value")
+        else instance.instance_type
+    )
+    if instance_type == "redis_enterprise":
+        capabilities.append("admin")
+    if instance_type == "redis_cloud":
+        capabilities.append("cloud")
+    return _dedupe(capabilities)
+
+
+def _cluster_capabilities(cluster: RedisCluster) -> List[str]:
+    cluster_type = _normalize(
+        cluster.cluster_type.value
+        if hasattr(cluster.cluster_type, "value")
+        else cluster.cluster_type
+    )
+    capabilities = []
+    if cluster_type == "redis_enterprise":
+        capabilities.append("admin")
+    if cluster_type == "redis_cloud":
+        capabilities.append("cloud")
+    return _dedupe(capabilities)
+
+
+def build_target_doc_from_instance(instance: RedisInstance) -> TargetCatalogDoc:
+    """Build a safe unified target document from a Redis instance."""
+    repo_slug, repo_tokens = _safe_repo_tokens(instance.repo_url)
+    aliases = _extract_safe_aliases(instance.extension_data)
+    cloud_subscription_id = (
+        str(instance.redis_cloud_subscription_id)
+        if instance.redis_cloud_subscription_id is not None
+        else None
+    )
+    cloud_database_id = (
+        str(instance.redis_cloud_database_id)
+        if instance.redis_cloud_database_id is not None
+        else None
+    )
+    safe_bits = _dedupe(
+        [
+            instance.name,
+            instance.environment,
+            instance.usage,
+            instance.description,
+            instance.notes,
+            instance.monitoring_identifier,
+            instance.logging_identifier,
+            instance.redis_cloud_database_name,
+            repo_slug,
+            *repo_tokens,
+            *aliases,
+        ]
+    )
+    instance_type = (
+        instance.instance_type.value
+        if hasattr(instance.instance_type, "value")
+        else str(instance.instance_type)
+    )
+    return TargetCatalogDoc(
+        target_id=f"instance:{instance.id}",
+        target_kind="instance",
+        resource_id=instance.id,
+        display_name=instance.name,
+        name=instance.name,
+        environment=_normalize(instance.environment),
+        status=_normalize(instance.status),
+        target_type=_normalize(instance_type),
+        usage=_normalize(instance.usage),
+        description=instance.description,
+        notes=instance.notes,
+        repo_url=instance.repo_url,
+        repo_slug=repo_slug,
+        monitoring_identifier=instance.monitoring_identifier,
+        logging_identifier=instance.logging_identifier,
+        cluster_id=instance.cluster_id,
+        redis_cloud_subscription_id=cloud_subscription_id,
+        redis_cloud_database_id=cloud_database_id,
+        redis_cloud_database_name=instance.redis_cloud_database_name,
+        search_text=" ".join(safe_bits),
+        search_aliases=aliases,
+        capabilities=_instance_capabilities(instance),
+        updated_at=instance.updated_at,
+        created_at=instance.created_at,
+        user_id=instance.user_id,
+    )
+
+
+def build_target_doc_from_cluster(cluster: RedisCluster) -> TargetCatalogDoc:
+    """Build a safe unified target document from a Redis cluster."""
+    aliases = _extract_safe_aliases(cluster.extension_data)
+    cluster_type = (
+        cluster.cluster_type.value
+        if hasattr(cluster.cluster_type, "value")
+        else str(cluster.cluster_type)
+    )
+    safe_bits = _dedupe(
+        [
+            cluster.name,
+            cluster.environment,
+            cluster.description,
+            cluster.notes,
+            *aliases,
+        ]
+    )
+    return TargetCatalogDoc(
+        target_id=f"cluster:{cluster.id}",
+        target_kind="cluster",
+        resource_id=cluster.id,
+        display_name=cluster.name,
+        name=cluster.name,
+        environment=_normalize(cluster.environment),
+        status=_normalize(cluster.status),
+        target_type=_normalize(cluster_type),
+        description=cluster.description,
+        notes=cluster.notes,
+        search_text=" ".join(safe_bits),
+        search_aliases=aliases,
+        capabilities=_cluster_capabilities(cluster),
+        updated_at=cluster.updated_at,
+        created_at=cluster.created_at,
+        user_id=cluster.user_id,
+    )
+
+
+def build_target_catalog_docs(
+    instances: Sequence[RedisInstance],
+    clusters: Sequence[RedisCluster],
+) -> List[TargetCatalogDoc]:
+    """Build the complete unified target catalog from stored resources."""
+    docs: List[TargetCatalogDoc] = [
+        build_target_doc_from_instance(instance) for instance in instances
+    ]
+    docs.extend(build_target_doc_from_cluster(cluster) for cluster in clusters)
+    return docs
+
+
+async def _ensure_targets_index_exists() -> None:
+    try:
+        index = await get_targets_index()
+        if not await index.exists():
+            await index.create()
+    except Exception:
+        return
+
+
+async def sync_target_catalog(
+    *,
+    instances: Optional[Sequence[RedisInstance]] = None,
+    clusters: Optional[Sequence[RedisCluster]] = None,
+) -> bool:
+    """Rebuild the target catalog from authoritative instance and cluster records."""
+    try:
+        await _ensure_targets_index_exists()
+        client = get_redis_client()
+
+        actual_instances = list(instances) if instances is not None else await get_instances()
+        actual_clusters = list(clusters) if clusters is not None else await get_clusters()
+        docs = build_target_catalog_docs(actual_instances, actual_clusters)
+        keep_ids = {doc.target_id for doc in docs}
+
+        for doc in docs:
+            key = f"{SRE_TARGETS_INDEX}:{doc.target_id}"
+            await client.hset(
+                key,
+                mapping={
+                    "target_id": doc.target_id,
+                    "target_kind": doc.target_kind,
+                    "resource_id": doc.resource_id,
+                    "display_name": doc.display_name,
+                    "name": doc.name,
+                    "environment": doc.environment or "",
+                    "status": doc.status or "",
+                    "target_type": doc.target_type or "",
+                    "usage": doc.usage or "",
+                    "cluster_id": doc.cluster_id or "",
+                    "repo_slug": doc.repo_slug or "",
+                    "monitoring_identifier": doc.monitoring_identifier or "",
+                    "logging_identifier": doc.logging_identifier or "",
+                    "redis_cloud_subscription_id": doc.redis_cloud_subscription_id or "",
+                    "redis_cloud_database_id": doc.redis_cloud_database_id or "",
+                    "redis_cloud_database_name": doc.redis_cloud_database_name or "",
+                    "search_aliases": ",".join(doc.search_aliases),
+                    "capabilities": ",".join(doc.capabilities),
+                    "updated_at": _to_epoch(doc.updated_at),
+                    "created_at": _to_epoch(doc.created_at),
+                    "search_text": doc.search_text,
+                    "user_id": doc.user_id or "",
+                    "data": doc.model_dump_json(),
+                },
+            )
+
+        stale_ids: List[str] = []
+        try:
+            index = await get_targets_index()
+            try:
+                total = await index.query(CountQuery(filter_expression="*"))
+            except Exception:
+                total = 1000
+
+            if total:
+                q = FilterQuery(
+                    filter_expression="*",
+                    return_fields=["data"],
+                    num_results=int(total) if isinstance(total, int) else 1000,
+                )
+                results = await index.query(q)
+                for doc in results or []:
+                    raw = doc.get("data")
+                    if not raw:
+                        continue
+                    if isinstance(raw, bytes):
+                        raw = raw.decode("utf-8")
+                    try:
+                        target_doc = TargetCatalogDoc.model_validate_json(raw)
+                    except Exception:
+                        continue
+                    if target_doc.target_id not in keep_ids:
+                        stale_ids.append(target_doc.target_id)
+        except Exception:
+            prefix = f"{SRE_TARGETS_INDEX}:"
+            cursor = 0
+            while True:
+                cursor, batch = await client.scan(cursor=cursor, match=f"{prefix}*")
+                if batch:
+                    for key in batch:
+                        decoded = (
+                            key.decode("utf-8") if isinstance(key, (bytes, bytearray)) else str(key)
+                        )
+                        target_id = decoded.split(":", 1)[1]
+                        if target_id not in keep_ids:
+                            stale_ids.append(target_id)
+                if cursor == 0:
+                    break
+
+        for stale_id in stale_ids:
+            await client.delete(f"{SRE_TARGETS_INDEX}:{stale_id}")
+
+        return True
+    except Exception:
+        logger.exception("Failed to sync unified target catalog")
+        return False
+
+
+async def get_target_catalog(
+    *,
+    user_id: Optional[str] = None,
+) -> List[TargetCatalogDoc]:
+    """Return all safe target docs from the unified discovery index."""
+    try:
+        await _ensure_targets_index_exists()
+        index = await get_targets_index()
+        client = get_redis_client()
+        try:
+            total = await index.query(CountQuery(filter_expression="*"))
+        except Exception:
+            total = 1000
+
+        docs: List[TargetCatalogDoc] = []
+        if total:
+            q = FilterQuery(
+                filter_expression="*",
+                return_fields=["data"],
+                num_results=int(total) if isinstance(total, int) else 1000,
+            ).sort_by("updated_at", asc=False)
+            results = await index.query(q)
+            for doc in results or []:
+                raw = doc.get("data")
+                if not raw:
+                    continue
+                if isinstance(raw, bytes):
+                    raw = raw.decode("utf-8")
+                try:
+                    docs.append(TargetCatalogDoc.model_validate_json(raw))
+                except Exception:
+                    continue
+
+        if not docs:
+            cursor = 0
+            prefix = f"{SRE_TARGETS_INDEX}:"
+            while True:
+                cursor, batch = await client.scan(cursor=cursor, match=f"{prefix}*")
+                for key in batch or []:
+                    raw = await client.hget(key, "data")
+                    if not raw:
+                        continue
+                    if isinstance(raw, bytes):
+                        raw = raw.decode("utf-8")
+                    try:
+                        docs.append(TargetCatalogDoc.model_validate_json(raw))
+                    except Exception:
+                        continue
+                if cursor == 0:
+                    break
+
+        filtered: List[TargetCatalogDoc] = []
+        for parsed in docs:
+            if user_id and parsed.user_id not in {None, "", user_id}:
+                continue
+            filtered.append(parsed)
+        filtered.sort(key=lambda doc: _to_epoch(doc.updated_at), reverse=True)
+        return filtered
+    except Exception:
+        logger.exception("Failed to load target catalog")
+        return []
+
+
+def _parse_query_hints(query: str) -> Dict[str, Any]:
+    normalized = _normalize(query)
+    tokens = set(_tokenize(normalized))
+    environments = {_ENV_ALIASES[token] for token in tokens if token in _ENV_ALIASES}
+    usages = {token for token in tokens if token in _USAGE_TERMS}
+    preferred_kinds = set()
+    if tokens & _INSTANCE_HINTS:
+        preferred_kinds.add("instance")
+    if tokens & _CLUSTER_HINTS:
+        preferred_kinds.add("cluster")
+    target_types = {_TYPE_HINTS[token] for token in tokens if token in _TYPE_HINTS}
+    return {
+        "normalized": normalized,
+        "tokens": tokens,
+        "environments": environments,
+        "usages": usages,
+        "preferred_kinds": preferred_kinds,
+        "target_types": target_types,
+    }
+
+
+def _score_target_doc(
+    query: str,
+    doc: TargetCatalogDoc,
+    *,
+    preferred_capabilities: Optional[Sequence[str]] = None,
+) -> tuple[float, List[str]]:
+    hints = _parse_query_hints(query)
+    normalized = hints["normalized"]
+    query_tokens = hints["tokens"]
+    reasons: List[str] = []
+    score = 0.0
+
+    name_tokens = set(_tokenize(doc.display_name)) | set(_tokenize(doc.name))
+    alias_tokens = set()
+    for alias in doc.search_aliases:
+        alias_tokens.update(_tokenize(alias))
+
+    if normalized and normalized in {_normalize(doc.display_name), _normalize(doc.name)}:
+        score += 8.0
+        reasons.append("matched exact target name")
+
+    exact_alias_matches = [alias for alias in doc.search_aliases if _normalize(alias) == normalized]
+    if exact_alias_matches:
+        score += 7.0
+        reasons.append(f"matched alias={exact_alias_matches[0]}")
+
+    partial_alias_matches = [
+        alias for alias in doc.search_aliases if _normalize(alias) in normalized
+    ]
+    if partial_alias_matches and not exact_alias_matches:
+        score += 3.0
+        reasons.append(f"matched alias={partial_alias_matches[0]}")
+
+    token_overlap = sorted(
+        query_tokens & (name_tokens | alias_tokens | set(_tokenize(doc.search_text)))
+    )
+    if token_overlap:
+        overlap_score = min(4.0, len(token_overlap) * 0.9)
+        score += overlap_score
+        reasons.append(f"matched tokens={','.join(token_overlap[:4])}")
+
+    for env in hints["environments"]:
+        if env == _normalize(doc.environment):
+            score += 3.0
+            reasons.append(f"matched environment={env}")
+
+    for usage in hints["usages"]:
+        if usage == _normalize(doc.usage):
+            score += 2.5
+            reasons.append(f"matched usage={usage}")
+
+    if hints["preferred_kinds"]:
+        if doc.target_kind in hints["preferred_kinds"]:
+            score += 2.0
+            reasons.append(f"matched kind={doc.target_kind}")
+        else:
+            score -= 0.5
+
+    if hints["target_types"] and _normalize(doc.target_type) in hints["target_types"]:
+        score += 2.0
+        reasons.append(f"matched type={doc.target_type}")
+
+    if preferred_capabilities:
+        preferred = {_normalize(capability) for capability in preferred_capabilities if capability}
+        supported = {_normalize(capability) for capability in doc.capabilities}
+        matched = sorted(preferred & supported)
+        if matched:
+            score += min(2.0, len(matched) * 0.75)
+            reasons.append(f"matched capabilities={','.join(matched[:3])}")
+
+    if _normalize(doc.status) in _HEALTHY_STATUSES:
+        score += 0.2
+
+    return score, reasons
+
+
+def _confidence_from_score(score: float) -> float:
+    if score <= 0:
+        return 0.0
+    if score >= 10:
+        return 0.99
+    return round(min(0.99, 0.45 + (score / 20.0)), 2)
+
+
+async def resolve_target_query(
+    *,
+    query: str,
+    user_id: Optional[str] = None,
+    allow_multiple: bool = False,
+    max_results: int = 5,
+    preferred_capabilities: Optional[Sequence[str]] = None,
+) -> TargetResolutionResult:
+    """Resolve natural-language query text against the safe target catalog."""
+    docs = await get_target_catalog(user_id=user_id)
+    if not docs:
+        return TargetResolutionResult(status="no_match")
+
+    ranked: List[ResolvedTargetMatch] = []
+    for doc in docs:
+        score, reasons = _score_target_doc(
+            query,
+            doc,
+            preferred_capabilities=preferred_capabilities,
+        )
+        if score < 2.5:
+            continue
+        ranked.append(
+            ResolvedTargetMatch(
+                target_kind=doc.target_kind,
+                resource_id=doc.resource_id,
+                display_name=doc.display_name,
+                environment=doc.environment,
+                target_type=doc.target_type,
+                capabilities=doc.capabilities,
+                confidence=_confidence_from_score(score),
+                match_reasons=reasons,
+                score=score,
+            )
+        )
+
+    ranked.sort(key=lambda match: (match.score, match.confidence), reverse=True)
+    limited = ranked[: max(1, min(max_results, 10))]
+
+    if not limited:
+        return TargetResolutionResult(status="no_match")
+
+    top = limited[0]
+    selected: List[ResolvedTargetMatch] = []
+    clarification_required = False
+
+    if allow_multiple:
+        selected = [match for match in limited if match.score >= max(3.0, top.score - 1.5)]
+        selected = selected[: min(3, max_results)]
+    else:
+        if len(limited) > 1 and limited[1].score >= top.score - 0.75:
+            clarification_required = True
+        elif top.score >= 3.0:
+            selected = [top]
+
+    status = (
+        "resolved"
+        if selected
+        else ("clarification_required" if clarification_required else "no_match")
+    )
+    return TargetResolutionResult(
+        status=status,
+        clarification_required=clarification_required,
+        matches=limited,
+        selected_matches=selected,
+    )
+
+
+def build_ephemeral_target_bindings(
+    matches: Sequence[ResolvedTargetMatch],
+    *,
+    thread_id: Optional[str] = None,
+    task_id: Optional[str] = None,
+) -> List[TargetBinding]:
+    """Build opaque target handles without persisting them."""
+    return [
+        TargetBinding(
+            target_handle=f"tgt_{ULID()}",
+            target_kind=match.target_kind,
+            resource_id=match.resource_id,
+            display_name=match.display_name,
+            capabilities=match.capabilities,
+            thread_id=thread_id,
+            task_id=task_id,
+        )
+        for match in matches
+    ]
+
+
+async def get_thread_target_state(thread_id: str) -> ThreadTargetState:
+    """Read target bindings from thread context."""
+    manager = ThreadManager(redis_client=get_redis_client())
+    thread = await manager.get_thread(thread_id)
+    if not thread:
+        return ThreadTargetState()
+
+    bindings: List[TargetBinding] = []
+    raw_bindings = thread.context.get("target_bindings") or []
+    if isinstance(raw_bindings, list):
+        for raw_binding in raw_bindings:
+            try:
+                bindings.append(TargetBinding.model_validate(raw_binding))
+            except Exception:
+                continue
+
+    raw_handles = thread.context.get("attached_target_handles") or []
+    attached_handles = (
+        [str(handle) for handle in raw_handles] if isinstance(raw_handles, list) else []
+    )
+    active_handle = thread.context.get("active_target_handle")
+    try:
+        generation = int(thread.context.get("target_toolset_generation") or 0)
+    except Exception:
+        generation = 0
+
+    return ThreadTargetState(
+        attached_target_handles=attached_handles,
+        active_target_handle=str(active_handle) if active_handle else None,
+        target_toolset_generation=generation,
+        target_bindings=bindings,
+    )
+
+
+async def attach_target_matches(
+    *,
+    thread_id: str,
+    matches: Sequence[ResolvedTargetMatch],
+    task_id: Optional[str] = None,
+    replace_existing: bool = False,
+) -> tuple[List[TargetBinding], int]:
+    """Persist safe target handles on a thread and return attached bindings."""
+    thread_manager = ThreadManager(redis_client=get_redis_client())
+    current_state = await get_thread_target_state(thread_id)
+
+    existing_by_resource = {
+        (binding.target_kind, binding.resource_id): binding
+        for binding in current_state.target_bindings
+    }
+    attached_bindings = [] if replace_existing else list(current_state.target_bindings)
+    attached_by_handle = {binding.target_handle: binding for binding in attached_bindings}
+    selected_bindings: List[TargetBinding] = []
+
+    for match in matches:
+        binding = existing_by_resource.get((match.target_kind, match.resource_id))
+        if binding is None:
+            binding = TargetBinding(
+                target_handle=f"tgt_{ULID()}",
+                target_kind=match.target_kind,
+                resource_id=match.resource_id,
+                display_name=match.display_name,
+                capabilities=match.capabilities,
+                thread_id=thread_id,
+                task_id=task_id,
+            )
+        if binding.target_handle not in attached_by_handle:
+            attached_bindings.append(binding)
+            attached_by_handle[binding.target_handle] = binding
+        selected_bindings.append(binding)
+
+    attached_handles = [
+        binding.target_handle
+        for binding in (selected_bindings if replace_existing else attached_bindings)
+    ]
+    bindings_to_store = selected_bindings if replace_existing else attached_bindings
+    active_handle = (
+        selected_bindings[0].target_handle
+        if selected_bindings
+        else current_state.active_target_handle
+    )
+    generation = max(1, current_state.target_toolset_generation) + (1 if selected_bindings else 0)
+
+    active_binding = next(
+        (binding for binding in bindings_to_store if binding.target_handle == active_handle),
+        None,
+    )
+
+    context_updates: Dict[str, Any] = {
+        "attached_target_handles": attached_handles,
+        "active_target_handle": active_handle or "",
+        "target_toolset_generation": generation,
+        "target_bindings": [binding.model_dump(mode="json") for binding in bindings_to_store],
+        "instance_id": "",
+        "cluster_id": "",
+    }
+
+    if active_binding and len(attached_handles) == 1:
+        if active_binding.target_kind == "instance":
+            context_updates["instance_id"] = active_binding.resource_id
+        elif active_binding.target_kind == "cluster":
+            context_updates["cluster_id"] = active_binding.resource_id
+
+    await thread_manager.update_thread_context(thread_id, context_updates, merge=True)
+    return selected_bindings, generation

--- a/redis_sre_agent/core/targets.py
+++ b/redis_sre_agent/core/targets.py
@@ -430,7 +430,11 @@ async def sync_target_catalog(
                         decoded = (
                             key.decode("utf-8") if isinstance(key, (bytes, bytearray)) else str(key)
                         )
-                        target_id = decoded.split(":", 1)[1]
+                        if not decoded.startswith(prefix):
+                            continue
+                        target_id = decoded.removeprefix(prefix)
+                        if not target_id:
+                            continue
                         if target_id not in keep_ids:
                             stale_ids.append(target_id)
                 if cursor == 0:

--- a/redis_sre_agent/core/targets.py
+++ b/redis_sre_agent/core/targets.py
@@ -556,13 +556,13 @@ def _score_target_doc(
         score += 7.0
         reasons.append(f"matched alias={exact_alias_matches[0]}")
 
-    partial_alias_matches = [
-        alias
-        for alias in doc.search_aliases
-        if (alias_tokens := set(_tokenize(alias)))
-        and alias_tokens <= query_tokens
-        and _normalize(alias) != normalized
-    ]
+    partial_alias_matches: List[str] = []
+    for alias in doc.search_aliases:
+        alias_token_set = set(_tokenize(alias))
+        if not alias_token_set:
+            continue
+        if alias_token_set <= query_tokens and _normalize(alias) != normalized:
+            partial_alias_matches.append(alias)
     if partial_alias_matches and not exact_alias_matches:
         score += 3.0
         reasons.append(f"matched alias={partial_alias_matches[0]}")

--- a/redis_sre_agent/core/targets.py
+++ b/redis_sre_agent/core/targets.py
@@ -576,8 +576,15 @@ def _score_target_doc(
         score += 3.0
         reasons.append(f"matched alias={partial_alias_matches[0]}")
 
+    hint_tokens = (
+        set(hints["environments"])
+        | set(hints["usages"])
+        | set(hints["preferred_kinds"])
+        | {token for target_type in hints["target_types"] for token in _tokenize(target_type)}
+    )
     token_overlap = sorted(
-        query_tokens & (name_tokens | alias_tokens | set(_tokenize(doc.search_text)))
+        (query_tokens - hint_tokens)
+        & (name_tokens | alias_tokens | set(_tokenize(doc.search_text)))
     )
     if token_overlap:
         overlap_score = min(4.0, len(token_overlap) * 0.9)

--- a/redis_sre_agent/core/targets.py
+++ b/redis_sre_agent/core/targets.py
@@ -140,6 +140,11 @@ def _normalize(value: Any) -> str:
     return str(value or "").strip().lower()
 
 
+def _normalize_environment(value: Any) -> str:
+    normalized = _normalize(value)
+    return _ENV_ALIASES.get(normalized, normalized)
+
+
 def _tokenize(value: Any) -> List[str]:
     text = _normalize(value)
     return _TOKEN_RE.findall(text.replace("-", " ").replace("_", " "))
@@ -266,7 +271,7 @@ def build_target_doc_from_instance(instance: RedisInstance) -> TargetCatalogDoc:
         resource_id=instance.id,
         display_name=instance.name,
         name=instance.name,
-        environment=_normalize(instance.environment),
+        environment=_normalize_environment(instance.environment),
         status=_normalize(instance.status),
         target_type=_normalize(instance_type),
         usage=_normalize(instance.usage),
@@ -312,7 +317,7 @@ def build_target_doc_from_cluster(cluster: RedisCluster) -> TargetCatalogDoc:
         resource_id=cluster.id,
         display_name=cluster.name,
         name=cluster.name,
-        environment=_normalize(cluster.environment),
+        environment=_normalize_environment(cluster.environment),
         status=_normalize(cluster.status),
         target_type=_normalize(cluster_type),
         description=cluster.description,

--- a/redis_sre_agent/core/targets.py
+++ b/redis_sre_agent/core/targets.py
@@ -584,15 +584,15 @@ def _score_target_doc(
         score += overlap_score
         reasons.append(f"matched tokens={','.join(token_overlap[:4])}")
 
-    for env in hints["environments"]:
-        if env == _normalize(doc.environment):
-            score += 3.0
-            reasons.append(f"matched environment={env}")
+    normalized_environment = _normalize_environment(doc.environment)
+    if normalized_environment and normalized_environment in hints["environments"]:
+        score += 3.0
+        reasons.append(f"matched environment={normalized_environment}")
 
-    for usage in hints["usages"]:
-        if usage == _normalize(doc.usage):
-            score += 2.5
-            reasons.append(f"matched usage={usage}")
+    normalized_usage = _normalize(doc.usage)
+    if normalized_usage and normalized_usage in hints["usages"]:
+        score += 2.5
+        reasons.append(f"matched usage={normalized_usage}")
 
     if hints["preferred_kinds"]:
         if doc.target_kind in hints["preferred_kinds"]:

--- a/redis_sre_agent/core/targets.py
+++ b/redis_sre_agent/core/targets.py
@@ -223,7 +223,7 @@ def _cluster_capabilities(cluster: RedisCluster) -> List[str]:
         if hasattr(cluster.cluster_type, "value")
         else cluster.cluster_type
     )
-    capabilities = []
+    capabilities = ["redis", "diagnostics", "metrics", "logs"]
     if cluster_type == "redis_enterprise":
         capabilities.append("admin")
     if cluster_type == "redis_cloud":
@@ -681,13 +681,14 @@ async def resolve_target_query(
     else:
         if len(limited) > 1 and limited[1].score >= top.score - 0.75:
             clarification_required = True
+            selected = limited[: min(3, max_results)]
         else:
             selected = [top]
 
     status = (
-        "resolved"
-        if selected
-        else ("clarification_required" if clarification_required else "no_match")
+        "clarification_required"
+        if clarification_required
+        else ("resolved" if selected else "no_match")
     )
     return TargetResolutionResult(
         status=status,

--- a/redis_sre_agent/core/targets.py
+++ b/redis_sre_agent/core/targets.py
@@ -681,7 +681,7 @@ async def resolve_target_query(
     else:
         if len(limited) > 1 and limited[1].score >= top.score - 0.75:
             clarification_required = True
-        elif top.score >= 3.0:
+        else:
             selected = [top]
 
     status = (

--- a/redis_sre_agent/core/targets.py
+++ b/redis_sre_agent/core/targets.py
@@ -534,8 +534,9 @@ def _score_target_doc(
     doc: TargetCatalogDoc,
     *,
     preferred_capabilities: Optional[Sequence[str]] = None,
+    hints: Optional[Dict[str, Any]] = None,
 ) -> tuple[float, List[str]]:
-    hints = _parse_query_hints(query)
+    hints = hints or _parse_query_hints(query)
     normalized = hints["normalized"]
     query_tokens = hints["tokens"]
     reasons: List[str] = []
@@ -556,7 +557,11 @@ def _score_target_doc(
         reasons.append(f"matched alias={exact_alias_matches[0]}")
 
     partial_alias_matches = [
-        alias for alias in doc.search_aliases if _normalize(alias) in normalized
+        alias
+        for alias in doc.search_aliases
+        if (alias_tokens := set(_tokenize(alias)))
+        and alias_tokens <= query_tokens
+        and _normalize(alias) != normalized
     ]
     if partial_alias_matches and not exact_alias_matches:
         score += 3.0
@@ -626,12 +631,14 @@ async def resolve_target_query(
     if not docs:
         return TargetResolutionResult(status="no_match")
 
+    hints = _parse_query_hints(query)
     ranked: List[ResolvedTargetMatch] = []
     for doc in docs:
         score, reasons = _score_target_doc(
             query,
             doc,
             preferred_capabilities=preferred_capabilities,
+            hints=hints,
         )
         if score < 2.5:
             continue

--- a/redis_sre_agent/tools/manager.py
+++ b/redis_sre_agent/tools/manager.py
@@ -76,6 +76,7 @@ class ToolManager:
     _always_on_providers = [
         "redis_sre_agent.tools.knowledge.knowledge_base.KnowledgeBaseToolProvider",
         "redis_sre_agent.tools.utilities.provider.UtilitiesToolProvider",
+        "redis_sre_agent.tools.target_discovery.provider.TargetDiscoveryToolProvider",
     ]
 
     def __init__(
@@ -86,6 +87,9 @@ class ToolManager:
         support_package_path: Optional["Path"] = None,
         cache_client: Optional[Any] = None,
         cache_ttl_overrides: Optional[Dict[str, int]] = None,
+        thread_id: Optional[str] = None,
+        task_id: Optional[str] = None,
+        user_id: Optional[str] = None,
     ):
         """Initialize tool manager.
 
@@ -108,8 +112,12 @@ class ToolManager:
         self.redis_cluster = redis_cluster
         self.exclude_mcp_categories = exclude_mcp_categories
         self.support_package_path = support_package_path
-        # Track loaded provider class paths to avoid duplicates
-        self._loaded_provider_paths: set[str] = set()
+        self.thread_id = thread_id
+        self.task_id = task_id
+        self.user_id = user_id
+        # Track loaded provider keys to avoid duplicate loads while allowing
+        # the same provider class to be attached for multiple opaque targets.
+        self._loaded_provider_keys: set[str] = set()
 
         # Mapping from tool name -> provider instance
         self._routing_table: Dict[str, ToolProvider] = {}
@@ -122,6 +130,8 @@ class ToolManager:
         self._stack: Optional[AsyncExitStack] = None
         # Per-run cache of tool results: (tool_name, stable_args_json) -> result
         self._call_cache: Dict[str, Any] = {}
+        self._attached_target_bindings: Dict[str, Any] = {}
+        self._toolset_generation = 0
 
         # Shared Redis-backed cache (optional)
         self._shared_cache: Optional["ToolCache"] = None
@@ -214,104 +224,6 @@ class ToolManager:
         for provider_path in self._always_on_providers:
             await self._load_provider(provider_path, always_on=True)
 
-        # Load instance-specific providers only if redis_instance is provided
-        if self.redis_instance:
-            logger.info(f"Loading instance-specific providers for: {self.redis_instance.name}")
-
-            # Load additional providers based on instance type
-            itype = (
-                self.redis_instance.instance_type.value
-                if self.redis_instance.instance_type
-                else None
-            )
-            instance_type = itype or "unknown"
-            logger.info(f"Instance type: {instance_type}")
-
-            if instance_type == "redis_enterprise":
-                (
-                    self.redis_instance,
-                    enterprise_admin_source,
-                ) = await self.resolve_redis_enterprise_admin_instance(self.redis_instance)
-                if enterprise_admin_source == "cluster":
-                    logger.info(
-                        "Using RedisCluster admin credentials for instance '%s' (cluster_id=%s)",
-                        self.redis_instance.name,
-                        self.redis_instance.cluster_id,
-                    )
-                elif enterprise_admin_source == "instance":
-                    logger.warning(
-                        "Using deprecated instance admin_* fields for Redis Enterprise instance '%s'. "
-                        "Prefer cluster_id + RedisCluster admin credentials.",
-                        self.redis_instance.name,
-                    )
-
-            # Load configured providers (these require redis_instance)
-            from redis_sre_agent.core.config import settings
-
-            for provider_path in settings.tool_providers:
-                await self._load_provider(provider_path)
-
-            if instance_type == "redis_enterprise":
-                # Load Redis Enterprise admin API provider
-                # Check for non-empty admin_url (handle None, empty string, whitespace)
-                has_admin_url = (
-                    self.redis_instance.admin_url and self.redis_instance.admin_url.strip()
-                )
-
-                if has_admin_url:
-                    logger.info("Loading Redis Enterprise admin API provider")
-                    await self._load_provider(
-                        "redis_sre_agent.tools.admin.redis_enterprise.provider.RedisEnterpriseAdminToolProvider"
-                    )
-                else:
-                    logger.warning(
-                        f"Redis Enterprise instance '{self.redis_instance.name}' detected but no admin_url configured. "
-                        "Enterprise admin tools will not be available. Using standard Redis CLI tools only."
-                    )
-
-            elif instance_type == "oss_cluster":
-                # Future: Load Redis Cluster-specific tools
-                logger.info(
-                    "OSS Cluster instance detected (cluster-specific tools not yet implemented)"
-                )
-
-            elif instance_type == "oss_single":
-                logger.info("OSS Single instance detected (using standard Redis CLI tools)")
-
-            elif instance_type == "redis_cloud":
-                # Load Redis Cloud Management API provider if credentials are available
-                import os
-
-                has_cloud_credentials = os.getenv("TOOLS_REDIS_CLOUD_API_KEY") and os.getenv(
-                    "TOOLS_REDIS_CLOUD_API_SECRET_KEY"
-                )
-
-                if has_cloud_credentials:
-                    logger.info("Loading Redis Cloud Management API provider")
-                    await self._load_provider(
-                        "redis_sre_agent.tools.cloud.redis_cloud.provider.RedisCloudToolProvider"
-                    )
-                else:
-                    logger.warning(
-                        f"Redis Cloud instance '{self.redis_instance.name}' detected but no API credentials configured. "
-                        "Set TOOLS_REDIS_CLOUD_API_KEY and TOOLS_REDIS_CLOUD_API_SECRET_KEY environment variables "
-                        "to enable Redis Cloud Management API tools. Using standard Redis CLI tools only."
-                    )
-
-            else:
-                logger.info(
-                    f"Unknown or unspecified instance type '{instance_type}' for instance '{self.redis_instance.name}'. "
-                    "Using standard Redis tools."
-                )
-        elif self.redis_cluster:
-            logger.info(
-                "Loading cluster-specific providers for cluster: %s",
-                self.redis_cluster.name,
-            )
-            await self._load_cluster_scoped_providers()
-        else:
-            logger.info("No redis_instance provided - loading only instance-independent providers")
-
         # Load MCP servers (these are always-on and don't require redis_instance)
         # Pass excluded categories to filter which MCP tools are loaded
         await self._load_mcp_providers()
@@ -320,6 +232,21 @@ class ToolManager:
         if self.support_package_path:
             await self._load_support_package_provider()
 
+        # Load explicit scope or previously attached thread scope after base tools.
+        if self.redis_instance:
+            logger.info("Loading instance-specific providers for: %s", self.redis_instance.name)
+            await self._load_instance_scoped_providers(self.redis_instance)
+        elif self.redis_cluster:
+            logger.info(
+                "Loading cluster-specific providers for cluster: %s",
+                self.redis_cluster.name,
+            )
+            await self._load_cluster_scoped_providers(self.redis_cluster)
+        else:
+            await self._load_thread_attached_targets()
+
+        self._toolset_generation = max(1, self._toolset_generation)
+
         logger.info(
             f"ToolManager initialized with {len(self._tools)} tools "
             f"from {len(set(self._routing_table.values()))} providers"
@@ -327,12 +254,126 @@ class ToolManager:
 
         return self
 
-    async def _load_cluster_scoped_providers(self) -> None:
+    async def _load_thread_attached_targets(self) -> None:
+        """Load target-scoped providers for any handles already attached to this thread."""
+        if not self.thread_id:
+            logger.info("No redis_instance provided - loading only instance-independent providers")
+            return
+
+        try:
+            from redis_sre_agent.core.targets import get_thread_target_state
+
+            target_state = await get_thread_target_state(self.thread_id)
+        except Exception:
+            logger.exception("Failed to load target bindings for thread %s", self.thread_id)
+            return
+
+        if not target_state.target_bindings:
+            logger.info("No previously attached targets for thread %s", self.thread_id)
+            return
+
+        await self.attach_bound_targets(
+            target_state.target_bindings,
+            generation=target_state.target_toolset_generation,
+        )
+
+    async def _load_instance_scoped_providers(
+        self,
+        redis_instance: RedisInstance,
+        *,
+        load_key_prefix: Optional[str] = None,
+    ) -> RedisInstance:
+        """Load providers that operate with instance-scoped credentials."""
+        logger.info("Instance type: %s", redis_instance.instance_type)
+        effective_instance = redis_instance
+        instance_type = (
+            redis_instance.instance_type.value if redis_instance.instance_type else "unknown"
+        )
+
+        if instance_type == "redis_enterprise":
+            (
+                effective_instance,
+                enterprise_admin_source,
+            ) = await self.resolve_redis_enterprise_admin_instance(redis_instance)
+            if enterprise_admin_source == "cluster":
+                logger.info(
+                    "Using RedisCluster admin credentials for instance '%s' (cluster_id=%s)",
+                    effective_instance.name,
+                    effective_instance.cluster_id,
+                )
+            elif enterprise_admin_source == "instance":
+                logger.warning(
+                    "Using deprecated instance admin_* fields for Redis Enterprise instance '%s'. "
+                    "Prefer cluster_id + RedisCluster admin credentials.",
+                    effective_instance.name,
+                )
+        if load_key_prefix is None:
+            self.redis_instance = effective_instance
+
+        from redis_sre_agent.core.config import settings
+
+        for provider_path in settings.tool_providers:
+            await self._load_provider(
+                provider_path,
+                redis_instance_override=effective_instance,
+                load_key=f"{load_key_prefix or effective_instance.id}:{provider_path}",
+            )
+
+        if instance_type == "redis_enterprise":
+            has_admin_url = bool(
+                effective_instance.admin_url and effective_instance.admin_url.strip()
+            )
+            if has_admin_url:
+                await self._load_provider(
+                    "redis_sre_agent.tools.admin.redis_enterprise.provider.RedisEnterpriseAdminToolProvider",
+                    redis_instance_override=effective_instance,
+                    load_key=f"{load_key_prefix or effective_instance.id}:enterprise_admin",
+                )
+            else:
+                logger.warning(
+                    "Redis Enterprise instance '%s' detected but no admin_url configured. "
+                    "Enterprise admin tools will not be available.",
+                    effective_instance.name,
+                )
+        elif instance_type == "redis_cloud":
+            import os
+
+            has_cloud_credentials = os.getenv("TOOLS_REDIS_CLOUD_API_KEY") and os.getenv(
+                "TOOLS_REDIS_CLOUD_API_SECRET_KEY"
+            )
+            if has_cloud_credentials:
+                await self._load_provider(
+                    "redis_sre_agent.tools.cloud.redis_cloud.provider.RedisCloudToolProvider",
+                    redis_instance_override=effective_instance,
+                    load_key=f"{load_key_prefix or effective_instance.id}:redis_cloud",
+                )
+            else:
+                logger.warning(
+                    "Redis Cloud instance '%s' detected but no API credentials configured. "
+                    "Cloud tools will not be available.",
+                    effective_instance.name,
+                )
+        elif instance_type == "oss_cluster":
+            logger.info(
+                "OSS Cluster instance detected (cluster-specific tools not yet implemented)"
+            )
+        elif instance_type == "oss_single":
+            logger.info("OSS Single instance detected (using standard Redis CLI tools)")
+        else:
+            logger.info(
+                "Unknown or unspecified instance type '%s' for instance '%s'. Using standard Redis tools.",
+                instance_type,
+                effective_instance.name,
+            )
+
+        return effective_instance
+
+    async def _load_cluster_scoped_providers(self, redis_cluster: "RedisCluster") -> None:
         """Load providers that can operate with cluster-only context."""
         cluster_type = (
-            self.redis_cluster.cluster_type.value
-            if hasattr(self.redis_cluster.cluster_type, "value")
-            else str(self.redis_cluster.cluster_type or "").strip().lower()
+            redis_cluster.cluster_type.value
+            if hasattr(redis_cluster.cluster_type, "value")
+            else str(redis_cluster.cluster_type or "").strip().lower()
         )
 
         if cluster_type != "redis_enterprise":
@@ -342,27 +383,30 @@ class ToolManager:
             )
             return
 
-        admin_instance = self.build_redis_enterprise_admin_instance_from_cluster(self.redis_cluster)
+        admin_instance = self.build_redis_enterprise_admin_instance_from_cluster(redis_cluster)
         if admin_instance is None:
             logger.warning(
                 "Redis Enterprise cluster '%s' is missing admin credentials. "
                 "Cluster-only admin tools will not be available.",
-                self.redis_cluster.name,
+                redis_cluster.name,
             )
             return
 
         logger.info(
             "Loading Redis Enterprise admin API provider for cluster '%s'",
-            self.redis_cluster.name,
+            redis_cluster.name,
         )
         await self._load_provider(
             "redis_sre_agent.tools.admin.redis_enterprise.provider.RedisEnterpriseAdminToolProvider",
             redis_instance_override=admin_instance,
+            load_key=f"cluster:{redis_cluster.id}:enterprise_admin",
         )
 
     @staticmethod
     def build_redis_enterprise_admin_instance_from_cluster(
         redis_cluster: "RedisCluster",
+        *,
+        target_id_override: Optional[str] = None,
     ) -> Optional[RedisInstance]:
         """Build a synthetic RedisInstance for cluster-scoped admin providers."""
         if redis_cluster is None:
@@ -384,7 +428,7 @@ class ToolManager:
 
         connection_host = (redis_cluster.admin_url or "").strip()
         return RedisInstance(
-            id=f"cluster-admin::{redis_cluster.id}",
+            id=target_id_override or f"cluster-admin::{redis_cluster.id}",
             name=f"{redis_cluster.name} (cluster admin)",
             connection_url="redis://cluster-only.invalid:6379",
             environment=redis_cluster.environment,
@@ -407,6 +451,7 @@ class ToolManager:
         provider_path: str,
         always_on: bool = False,
         redis_instance_override: Optional[RedisInstance] = None,
+        load_key: Optional[str] = None,
     ) -> None:
         """Load and register a provider.
 
@@ -414,11 +459,12 @@ class ToolManager:
             provider_path: Fully qualified class path
             always_on: If True, initialize without redis_instance (for always-on providers)
             redis_instance_override: Optional instance to use for a single provider load
+            load_key: Optional unique key used to de-duplicate loads
         """
         try:
-            # Skip duplicate loads of the same provider class
-            if provider_path in self._loaded_provider_paths:
-                logger.debug(f"Provider already loaded, skipping duplicate: {provider_path}")
+            provider_key = load_key or provider_path
+            if provider_key in self._loaded_provider_keys:
+                logger.debug("Provider already loaded, skipping duplicate: %s", provider_key)
                 return
 
             provider_cls = self._get_provider_class(provider_path)
@@ -445,7 +491,7 @@ class ToolManager:
             self._providers.append(provider)
 
             # Mark this provider as loaded to avoid duplicates later
-            self._loaded_provider_paths.add(provider_path)
+            self._loaded_provider_keys.add(provider_key)
 
             logger.info(f"Loaded provider {provider.provider_name} with {len(tools)} tools")
 
@@ -489,7 +535,7 @@ class ToolManager:
 
                 # Skip if already loaded (use a synthetic path for tracking)
                 mcp_provider_path = f"mcp:{server_name}"
-                if mcp_provider_path in self._loaded_provider_paths:
+                if mcp_provider_path in self._loaded_provider_keys:
                     logger.debug(f"MCP provider already loaded, skipping: {server_name}")
                     continue
 
@@ -533,7 +579,7 @@ class ToolManager:
 
                 # Track provider
                 self._providers.append(provider)
-                self._loaded_provider_paths.add(mcp_provider_path)
+                self._loaded_provider_keys.add(mcp_provider_path)
 
                 if excluded_count > 0:
                     logger.info(
@@ -567,7 +613,7 @@ class ToolManager:
 
             # Use a synthetic path for tracking
             provider_path = f"support_package:{self.support_package_path}"
-            if provider_path in self._loaded_provider_paths:
+            if provider_path in self._loaded_provider_keys:
                 logger.debug(
                     f"Support package provider already loaded: {self.support_package_path}"
                 )
@@ -595,7 +641,7 @@ class ToolManager:
 
             # Track provider
             self._providers.append(provider)
-            self._loaded_provider_paths.add(provider_path)
+            self._loaded_provider_keys.add(provider_path)
 
             logger.info(
                 f"Loaded support package provider for '{self.support_package_path}' "
@@ -607,6 +653,104 @@ class ToolManager:
                 f"Failed to load support package provider for '{self.support_package_path}'"
             )
             # Don't fail entire manager if support package provider fails
+
+    @staticmethod
+    def _build_target_scoped_instance(
+        redis_instance: RedisInstance,
+        target_handle: str,
+    ) -> RedisInstance:
+        """Clone an instance with an opaque ID so tool names stay secret-safe."""
+        return redis_instance.model_copy(update={"id": target_handle})
+
+    def get_toolset_generation(self) -> int:
+        """Return the current toolset generation for dynamic rebinding."""
+        return self._toolset_generation
+
+    def get_attached_target_bindings(self) -> List[Any]:
+        """Return the currently attached target bindings in load order."""
+        return list(self._attached_target_bindings.values())
+
+    async def attach_bound_targets(
+        self,
+        bindings: List[Any],
+        *,
+        generation: Optional[int] = None,
+    ) -> List[Any]:
+        """Attach already-resolved opaque target bindings to this manager."""
+        from redis_sre_agent.core.instances import get_instance_by_id
+
+        new_attachment = False
+        attached: List[Any] = []
+
+        for binding in bindings or []:
+            target_handle = getattr(binding, "target_handle", None)
+            target_kind = getattr(binding, "target_kind", None)
+            resource_id = getattr(binding, "resource_id", None)
+            if not target_handle or not target_kind or not resource_id:
+                continue
+
+            existing = self._attached_target_bindings.get(target_handle)
+            if existing is not None:
+                attached.append(existing)
+                continue
+
+            if target_kind == "instance":
+                instance = await get_instance_by_id(resource_id)
+                if instance is None:
+                    logger.warning(
+                        "Unable to attach target handle %s: instance %s not found",
+                        target_handle,
+                        resource_id,
+                    )
+                    continue
+                scoped_instance = self._build_target_scoped_instance(instance, target_handle)
+                await self._load_instance_scoped_providers(
+                    scoped_instance,
+                    load_key_prefix=f"target:{target_handle}",
+                )
+            elif target_kind == "cluster":
+                cluster = await core_clusters.get_cluster_by_id(resource_id)
+                if cluster is None:
+                    logger.warning(
+                        "Unable to attach target handle %s: cluster %s not found",
+                        target_handle,
+                        resource_id,
+                    )
+                    continue
+                admin_instance = self.build_redis_enterprise_admin_instance_from_cluster(
+                    cluster,
+                    target_id_override=target_handle,
+                )
+                if admin_instance is None:
+                    logger.warning(
+                        "Unable to attach target handle %s: cluster %s has no supported cluster-only tooling",
+                        target_handle,
+                        resource_id,
+                    )
+                    continue
+                await self._load_provider(
+                    "redis_sre_agent.tools.admin.redis_enterprise.provider.RedisEnterpriseAdminToolProvider",
+                    redis_instance_override=admin_instance,
+                    load_key=f"target:{target_handle}:enterprise_admin",
+                )
+            else:
+                logger.warning(
+                    "Skipping unsupported target binding kind '%s' for %s",
+                    target_kind,
+                    target_handle,
+                )
+                continue
+
+            self._attached_target_bindings[target_handle] = binding
+            attached.append(binding)
+            new_attachment = True
+
+        if generation is not None:
+            self._toolset_generation = max(self._toolset_generation, generation)
+        elif new_attachment:
+            self._toolset_generation += 1
+
+        return attached
 
     @classmethod
     def _get_provider_class(cls, provider_path: str) -> type:
@@ -655,8 +799,9 @@ class ToolManager:
             self._tools.clear()
             self._tool_by_name.clear()
             self._providers.clear()
-            self._loaded_provider_paths.clear()
+            self._loaded_provider_keys.clear()
             self._call_cache.clear()
+            self._attached_target_bindings.clear()
 
     # ----- Tool lookup APIs used by LLM bindings -----
 

--- a/redis_sre_agent/tools/target_discovery/__init__.py
+++ b/redis_sre_agent/tools/target_discovery/__init__.py
@@ -1,0 +1,1 @@
+"""Target discovery tool provider package."""

--- a/redis_sre_agent/tools/target_discovery/provider.py
+++ b/redis_sre_agent/tools/target_discovery/provider.py
@@ -1,0 +1,121 @@
+"""Natural-language target discovery provider."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from redis_sre_agent.core.targets import (
+    attach_target_matches,
+    build_ephemeral_target_bindings,
+    resolve_target_query,
+)
+from redis_sre_agent.tools.models import ToolCapability, ToolDefinition
+from redis_sre_agent.tools.protocols import ToolProvider
+
+
+class TargetDiscoveryToolProvider(ToolProvider):
+    """Resolve safe Redis targets from natural-language metadata queries."""
+
+    @property
+    def provider_name(self) -> str:
+        return "target_discovery"
+
+    @property
+    def requires_redis_instance(self) -> bool:
+        return False
+
+    def create_tool_schemas(self) -> List[ToolDefinition]:
+        return [
+            ToolDefinition(
+                name=self._make_tool_name("resolve_redis_targets"),
+                description=(
+                    "Resolve natural-language target descriptions like 'prod checkout cache' "
+                    "or 'the us-east enterprise cluster' into safe Redis target matches. "
+                    "This tool only returns secret-safe metadata and opaque target handles. "
+                    "Use it before live diagnostics when the user has not provided an "
+                    "explicit instance_id or cluster_id."
+                ),
+                capability=ToolCapability.UTILITIES,
+                parameters={
+                    "type": "object",
+                    "properties": {
+                        "query": {
+                            "type": "string",
+                            "description": "Natural-language description of the Redis target to resolve.",
+                        },
+                        "allow_multiple": {
+                            "type": "boolean",
+                            "description": "Whether multiple matching targets may be selected and attached.",
+                            "default": False,
+                        },
+                        "max_results": {
+                            "type": "integer",
+                            "description": "Maximum number of candidate matches to return.",
+                            "default": 5,
+                            "minimum": 1,
+                            "maximum": 10,
+                        },
+                        "attach_tools": {
+                            "type": "boolean",
+                            "description": "Whether to attach the resolved targets to the current tool manager.",
+                            "default": True,
+                        },
+                        "preferred_capabilities": {
+                            "type": "array",
+                            "items": {"type": "string"},
+                            "description": "Optional capability hints such as diagnostics, admin, cloud, metrics, or logs.",
+                        },
+                    },
+                    "required": ["query"],
+                },
+            )
+        ]
+
+    async def resolve_redis_targets(
+        self,
+        query: str,
+        allow_multiple: bool = False,
+        max_results: int = 5,
+        attach_tools: bool = True,
+        preferred_capabilities: Optional[List[str]] = None,
+    ) -> Dict[str, Any]:
+        manager = getattr(self, "_manager", None)
+        thread_id = getattr(manager, "thread_id", None)
+        task_id = getattr(manager, "task_id", None)
+        user_id = getattr(manager, "user_id", None)
+
+        result = await resolve_target_query(
+            query=query,
+            user_id=user_id,
+            allow_multiple=allow_multiple,
+            max_results=max_results,
+            preferred_capabilities=preferred_capabilities,
+        )
+
+        attached_handles: List[str] = []
+        toolset_generation = manager.get_toolset_generation() if manager else 0
+
+        if attach_tools and manager and result.selected_matches:
+            replace_existing = not allow_multiple
+            if thread_id:
+                bindings, persisted_generation = await attach_target_matches(
+                    thread_id=thread_id,
+                    matches=result.selected_matches,
+                    task_id=task_id,
+                    replace_existing=replace_existing,
+                )
+                await manager.attach_bound_targets(bindings, generation=persisted_generation)
+            else:
+                bindings = build_ephemeral_target_bindings(
+                    result.selected_matches,
+                    thread_id=thread_id,
+                    task_id=task_id,
+                )
+                await manager.attach_bound_targets(bindings)
+            attached_handles = [binding.target_handle for binding in bindings]
+            toolset_generation = manager.get_toolset_generation()
+
+        payload = result.model_dump()
+        payload["attached_target_handles"] = attached_handles
+        payload["toolset_generation"] = toolset_generation
+        return payload

--- a/specs/natural-language-target-discovery-spec.md
+++ b/specs/natural-language-target-discovery-spec.md
@@ -1,0 +1,552 @@
+# Natural-Language Target Discovery and Authenticated Tool Loading
+
+Status: Proposed
+
+## Summary
+
+Design a single target-discovery mechanism that lets the agent start with zero explicit
+`instance_id` or `cluster_id`, interpret natural language like "check prod checkout cache" or
+"investigate the us-east enterprise cluster", discover one or more matching Redis targets from
+stored metadata, and dynamically attach authenticated tooling for those targets without exposing
+connection strings, credentials, or API keys to the LLM.
+
+At the same time, collapse the current three-agent split:
+
+- keep `chat`
+- keep `deep triage`
+- remove the separate `knowledge-only` agent
+
+The `chat` agent becomes the default general-purpose agent. It always has knowledge tools and
+target-discovery tools. When no target is resolved, it behaves like today's knowledge agent.
+When one or more targets are resolved, it dynamically gains target-scoped tools.
+
+## Problem
+
+Today the system has three different ways to get scope:
+
+1. The caller passes `instance_id`
+2. The caller passes `cluster_id`
+3. The system extracts a raw `redis://...` URL from the message and creates an instance
+
+That leaves several gaps:
+
+- There is no metadata-based natural-language search across instances and clusters.
+- The agent cannot start from "prod cache in us-east" and resolve scope on its own.
+- The knowledge agent and chat agent are split even though both should be able to begin without
+  target information.
+- Tool loading happens up front; the toolset cannot expand naturally after a target is discovered.
+- Current instance and cluster search only supports narrow filtering plus name wildcard matching.
+- The desired authenticated clients exist only after a target is chosen, but the current design
+  does not model "discover now, attach tools later" as a first-class flow.
+
+## Goals
+
+- Allow `chat` and `deep triage` to begin with no explicit target identifiers.
+- Resolve instances, clusters, or multiple targets from natural language plus stored metadata.
+- Keep authentication details out of LLM prompts, tool schemas, tool results, traces, and thread
+  metadata.
+- Support dynamic loading of authenticated tools after target discovery.
+- Support multiple simultaneous target bindings in one conversation or triage run.
+- Preserve the current distinction between instance-scoped tooling and cluster-scoped tooling.
+- Reuse stored `RedisInstance` and `RedisCluster` records as the source of truth for credentials
+  and other private connection data.
+
+## Non-goals
+
+- Replacing the current `RedisInstance` / `RedisCluster` storage models.
+- Designing a full semantic vector search experience for targets in v1.
+- Accepting raw credentials from natural language as the primary happy path.
+  If a user pastes secrets into chat, that remains a separate sanitization problem.
+- Redesigning provider internals beyond what is needed for dynamic target attachment.
+
+## Current-State Observations
+
+- `process_agent_turn()` currently prefers explicit `instance_id` / `cluster_id`, then thread
+  context, then `_extract_instance_details_from_message()` if the prompt contains a raw Redis URL.
+- `route_to_appropriate_agent()` still routes to `knowledge_only` when no target scope exists.
+- `ChatAgent` and `KnowledgeOnlyAgent` both use `ToolManager`, but only `ChatAgent` can load
+  instance-scoped or cluster-scoped providers.
+- `ToolManager` can load providers for a `RedisInstance` or `RedisCluster`, but only at agent
+  construction time.
+- `query_instances()` and `query_clusters()` only support tag filters plus wildcard matching on
+  `name`, which is too weak for natural-language resolution.
+
+## Proposed Design
+
+## 1. Two-agent model only
+
+Replace the current routing model with two agents:
+
+- `chat`
+- `deep triage`
+
+`chat` becomes the default entry point for:
+
+- general Redis knowledge questions
+- natural-language target discovery
+- quick diagnostics
+- follow-up investigation on one or more attached targets
+
+`deep triage` remains the heavier orchestration path for comprehensive analysis, but it uses the
+same target-discovery mechanism before it begins planning tool work.
+
+### Routing rule
+
+- If the request explicitly asks for deep or exhaustive analysis, route to `deep triage`.
+- Otherwise route to `chat`.
+- Do not route to a separate `knowledge-only` agent.
+
+If no target is resolved, `chat` simply uses knowledge tools and answers as a general Redis/SRE
+assistant.
+
+## 2. Introduce a unified target catalog
+
+Add a new denormalized search index for discovery:
+
+- `sre_targets`
+
+Each document represents either:
+
+- an instance-backed target
+- a cluster-backed target
+
+Suggested document shape:
+
+- `target_id`
+- `target_kind`: `instance | cluster`
+- `resource_id`: underlying `RedisInstance.id` or `RedisCluster.id`
+- `display_name`
+- `name`
+- `environment`
+- `status`
+- `instance_type` or `cluster_type`
+- `usage`
+- `description`
+- `notes`
+- `repo_url`
+- `monitoring_identifier`
+- `logging_identifier`
+- `cluster_id`
+- `redis_cloud_subscription_id`
+- `redis_cloud_database_id`
+- `redis_cloud_database_name`
+- `search_text`
+- `search_aliases`
+- `capabilities`
+- `updated_at`
+
+### Searchable content
+
+`search_text` should be built only from safe metadata, for example:
+
+- instance name
+- cluster name
+- environment
+- usage
+- description
+- notes
+- repo URL host/repo slug
+- monitoring identifier
+- logging identifier
+- Redis Cloud database name
+- known aliases stored in extension metadata
+
+No secrets belong in this index. Specifically exclude:
+
+- `connection_url`
+- `admin_url`
+- usernames
+- passwords
+- API keys
+- secret extension data
+
+### Why a new index instead of reusing `sre_instances` and `sre_clusters`
+
+The unified index simplifies:
+
+- cross-kind search in one query
+- consistent ranking
+- capability-aware filtering
+- future support for richer aliases and relevance tuning
+
+The existing instance and cluster indices remain authoritative for CRUD and direct lookups.
+
+## 3. Add an always-on target discovery tool
+
+Add a new always-on provider, loaded alongside knowledge and utilities:
+
+- `TargetDiscoveryToolProvider`
+
+### Primary v1 tool
+
+Expose one primary tool:
+
+- `resolve_redis_targets`
+
+Suggested contract:
+
+```json
+{
+  "query": "prod checkout cache in us-east",
+  "allow_multiple": true,
+  "max_results": 5,
+  "attach_tools": true,
+  "preferred_capabilities": ["diagnostics", "admin", "cloud"]
+}
+```
+
+Suggested result shape:
+
+```json
+{
+  "status": "resolved",
+  "clarification_required": false,
+  "matches": [
+    {
+      "target_handle": "tgt_01H...",
+      "target_kind": "instance",
+      "resource_id": "redis-prod-checkout-cache",
+      "display_name": "checkout-cache-prod",
+      "environment": "production",
+      "target_type": "oss_single",
+      "capabilities": ["redis", "metrics", "logs"],
+      "confidence": 0.94,
+      "match_reasons": [
+        "matched environment=production",
+        "matched usage=cache",
+        "matched alias=checkout"
+      ]
+    }
+  ],
+  "attached_target_handles": ["tgt_01H..."],
+  "toolset_generation": 4
+}
+```
+
+### Important behavior
+
+The tool does two things:
+
+1. searches and ranks candidate targets
+2. optionally attaches authenticated target handles to the current session
+
+The LLM sees only safe metadata and opaque handles. The actual credentials never appear in the
+tool output.
+
+### Ambiguity policy
+
+- If there is one high-confidence match, auto-attach it.
+- If there are several plausible matches and the user asked for multiple targets, attach the top
+  bounded set and explain what was attached.
+- If there are several plausible matches and the user appears to want one target, return
+  `clarification_required=true` and ask the agent to clarify before using live tools.
+
+## 4. Use opaque target handles, not secrets
+
+Resolved targets should be represented in agent state by opaque handles:
+
+- `tgt_<opaque_id>`
+
+Each handle maps server-side to safe binding metadata:
+
+- `target_handle`
+- `target_kind`
+- `resource_id`
+- `capabilities`
+- `thread_id`
+- `task_id`
+- `created_at`
+- `expires_at`
+
+This binding can live in Redis as ephemeral session state. It does not need to store secrets.
+Because the underlying `RedisInstance` and `RedisCluster` records already store encrypted secrets,
+the binding only needs to remember which resource was chosen.
+
+### Secret-safe resolution path
+
+1. `resolve_redis_targets` returns safe match metadata plus target handles.
+2. The agent records attached handles in thread/task context.
+3. `ToolManager` uses the handle to fetch the underlying instance or cluster by ID.
+4. Provider initialization decrypts secrets server-side only when constructing clients.
+5. Tool schemas and tool results reference handles and display names, not credentials.
+
+## 5. Add dynamic authenticated tool loading
+
+Extend `ToolManager` into a target-aware manager that can load tools in phases:
+
+- base tools
+  - knowledge
+  - utilities
+  - target discovery
+  - MCP tools that do not require target scope
+- target-scoped tools
+  - loaded after one or more target handles are attached
+
+### Required capability
+
+The manager must support:
+
+- initial load with no target
+- attaching one target
+- attaching multiple targets
+- rebuilding the bound tool list when the target set changes
+
+### Tool loading rules
+
+For an attached instance handle:
+
+- load Redis command diagnostics
+- load metrics/logs/host telemetry providers as appropriate
+- load Redis Cloud provider when the instance represents a Redis Cloud database and credentials
+  are available through a secret-safe auth source
+
+For an attached cluster handle:
+
+- load Redis Enterprise admin provider when cluster type is `redis_enterprise`
+- load Redis Cloud subscription-level provider when cluster type is `redis_cloud` and a cloud auth
+  source exists
+- optionally expose cluster-linked instance tools when the agent explicitly expands into database
+  diagnostics
+
+### Multi-target naming
+
+Tool names must be target-scoped and secret-safe. They should include the opaque handle or another
+stable safe suffix, never a host or credential-bearing URL.
+
+Example shape:
+
+- `redis_diag_tgt_a1b2_info`
+- `re_admin_tgt_c3d4_list_bdbs`
+- `redis_cloud_tgt_e5f6_get_database`
+
+The display label shown to the LLM can still mention the safe display name:
+
+- "Redis diagnostics for checkout-cache-prod"
+
+## 6. Search and ranking strategy
+
+The resolver should be deterministic and metadata-first, not LLM-only.
+
+### Proposed pipeline
+
+1. Parse lightweight intent from the query
+   - environment terms: `prod`, `staging`, `dev`
+   - kind hints: `cluster`, `instance`, `database`
+   - topology hints: `enterprise`, `cloud`, `oss`
+   - usage hints: `cache`, `queue`, `session`, `analytics`
+   - entity tokens: names, aliases, repo names, cloud database names
+2. Search `sre_targets` with:
+   - exact tag matches where possible
+   - wildcard / full-text search on safe text fields
+3. Score matches using weighted metadata evidence
+4. Return ranked candidates plus an attach decision
+
+### Ranking inputs
+
+- exact name or alias match
+- environment match
+- usage match
+- target kind match
+- instance or cluster type match
+- monitoring/logging identifier match
+- cloud database name match
+- recency / status as tie-breakers
+
+### Why not pure LLM selection
+
+The LLM should choose whether to call the resolver, not perform secret-bearing lookup logic. The
+resolver must remain deterministic, inspectable, testable, and independent from model variance.
+
+## 7. Session and thread state
+
+Thread context should evolve from a single active ID to a target set:
+
+- `attached_target_handles: List[str]`
+- `active_target_handle: Optional[str]`
+- `target_toolset_generation: int`
+
+Retain compatibility fields during migration:
+
+- `instance_id`
+- `cluster_id`
+
+### Session semantics
+
+- A new session starts with no attached targets.
+- `resolve_redis_targets(..., attach_tools=true)` adds or replaces attached handles depending on
+  agent intent.
+- Follow-up turns reuse attached handles unless the user changes scope.
+- `deep triage` persists the same safe handle set on the task/thread so later follow-ups can
+  continue without rediscovery.
+
+## 8. Agent behavior
+
+## Chat
+
+`chat` should follow this pattern:
+
+1. start with base tools only
+2. if the user intent needs live Redis scope, call `resolve_redis_targets`
+3. if targets are attached, refresh the toolset
+4. continue the same turn using the newly loaded target-scoped tools
+5. if no target is resolved, continue as a knowledge-oriented chat
+
+This replaces today's split between `ChatAgent` and `KnowledgeOnlyAgent`.
+
+## Deep triage
+
+`deep triage` should use the same resolver first, then decide the work plan:
+
+- single instance target: standard instance triage
+- single cluster target: cluster triage, with optional expansion into linked instances
+- multiple targets: bounded fan-out with per-target evidence and aggregated synthesis
+
+The deep triage planner should be able to request additional target expansion if it starts with a
+cluster and later determines that per-database diagnostics are required.
+
+## 9. Authentication model
+
+The design should support three authenticated client families:
+
+- Redis client
+- Redis Enterprise Admin API client
+- Redis Cloud API client
+
+### Credential sources
+
+The LLM never receives these values directly. The runtime resolves them from stored records and
+secret sources:
+
+- `RedisInstance.connection_url`
+- `RedisCluster.admin_url`, `admin_username`, `admin_password`
+- Redis Cloud credentials from a secret-safe auth source
+  - environment-backed in v1 is acceptable
+  - later this can expand to cluster or extension-backed secrets
+
+### Client factories
+
+Introduce a small internal abstraction:
+
+- `AuthenticatedTargetContext`
+
+It exposes safe runtime factories such as:
+
+- `get_redis_client()`
+- `get_enterprise_client()`
+- `get_cloud_client()`
+
+These factories live below the LLM boundary. Providers may use them directly, or the tool manager
+may continue constructing providers from `RedisInstance` / `RedisCluster` models as long as the
+credential resolution stays server-side.
+
+## 10. API and MCP surface
+
+Target state should be discoverable through the main task-based chat and triage flows, not just
+through low-level list/get tools.
+
+### Public direction
+
+Move the product surface toward:
+
+- `redis_sre_chat`
+- `redis_sre_deep_triage`
+
+Compatibility wrappers can remain for:
+
+- `redis_sre_general_chat`
+- `redis_sre_database_chat`
+- `redis_sre_knowledge_query`
+
+But internally they should map onto the new two-agent design.
+
+### Optional helper tools
+
+The primary v1 feature only requires `resolve_redis_targets`, but these may be useful:
+
+- `list_attached_redis_targets`
+- `detach_redis_targets`
+- `expand_cluster_targets_to_instances`
+
+Those helpers are optional follow-ons, not prerequisites.
+
+## 11. Implementation sketch
+
+## Phase 1: Search foundation
+
+- Add `sre_targets` index and builder.
+- Backfill target documents from existing instances and clusters.
+- Add alias support from safe extension metadata.
+- Implement deterministic resolver service with ranking and ambiguity thresholds.
+
+## Phase 2: Tool provider
+
+- Add `TargetDiscoveryToolProvider`.
+- Expose `resolve_redis_targets`.
+- Persist safe target bindings in thread/task/session state.
+
+## Phase 3: Dynamic tool manager
+
+- Extend `ToolManager` to attach multiple targets and rebuild tool definitions.
+- Add target-scoped tool naming.
+- Ensure result envelopes and traces remain secret-safe.
+
+## Phase 4: Agent unification
+
+- Merge knowledge-only behavior into `chat`.
+- Remove `knowledge_only` from router decisions.
+- Update `process_agent_turn()` to use target handles instead of only `instance_id` /
+  `cluster_id`.
+
+## Phase 5: Deep triage integration
+
+- Resolve targets before triage planning.
+- Support bounded multi-target fan-out.
+- Support cluster-to-instance expansion where needed.
+
+## 12. Testing requirements
+
+Add tests for:
+
+- target catalog indexing from instances and clusters
+- resolver ranking and ambiguity handling
+- secret-safe tool output
+- dynamic toolset refresh after resolution
+- chat with zero initial scope resolving a target mid-turn
+- chat with no live target staying in knowledge mode
+- deep triage resolving one target from natural language
+- deep triage resolving multiple targets from natural language
+- cluster resolution followed by instance expansion
+
+Add regression coverage that ensures:
+
+- secrets never appear in resolver tool results
+- secrets never appear in stored traces or thread metadata
+- current explicit `instance_id` / `cluster_id` paths still work during migration
+
+## 13. Risks and tradeoffs
+
+- Dynamic tool rebinding adds complexity to the LangGraph loop.
+- Multi-target tool naming can increase prompt/toolset size if not bounded carefully.
+- Redis Cloud auth is less mature than instance and enterprise cluster auth today, so the first
+  implementation may need to keep cloud attachment behind capability checks.
+- A unified target catalog introduces denormalization; it must be kept in sync whenever instances
+  or clusters change.
+
+## 14. Recommended v1 decisions
+
+- Build `sre_targets` as a new unified metadata index.
+- Add exactly one primary tool: `resolve_redis_targets`.
+- Keep handles opaque and secret-free.
+- Merge `knowledge-only` behavior into `chat`.
+- Make routing binary: `chat` vs `deep triage`.
+- Use deterministic metadata search and scoring in v1.
+- Bound auto-attached targets to a small maximum, for example 3.
+
+## Open Questions
+
+- Should cluster selection automatically attach linked instances, or should that remain an
+  explicit expansion step?
+- Should Redis Cloud credentials remain environment-scoped in v1, or should this work also define
+  cluster-backed cloud secrets?
+- Should attached target handles live only for a thread, or also be shareable across threads in a
+  user session?

--- a/tests/integration/test_target_discovery_flow.py
+++ b/tests/integration/test_target_discovery_flow.py
@@ -1,0 +1,294 @@
+"""Redis-backed integration coverage for natural-language target discovery."""
+
+from __future__ import annotations
+
+import base64
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from redisvl.index import AsyncSearchIndex
+from redisvl.schema import IndexSchema
+
+from redis_sre_agent.agent.router import AgentType
+from redis_sre_agent.core.docket_tasks import process_agent_turn
+from redis_sre_agent.core.instances import RedisInstance, save_instances
+from redis_sre_agent.core.redis import (
+    SRE_CLUSTERS_SCHEMA,
+    SRE_INSTANCES_SCHEMA,
+    SRE_TARGETS_SCHEMA,
+)
+from redis_sre_agent.core.tasks import TaskManager
+from redis_sre_agent.core.threads import ThreadManager
+from redis_sre_agent.tools.manager import ToolManager
+
+
+def _build_index(redis_client, schema_dict: dict) -> AsyncSearchIndex:
+    return AsyncSearchIndex(schema=IndexSchema.from_dict(schema_dict), redis_client=redis_client)
+
+
+@pytest.fixture
+def redis_backed_target_state(monkeypatch, async_redis_client):
+    """Patch storage helpers so instance/target state uses the test Redis client."""
+
+    async def _instances_index() -> AsyncSearchIndex:
+        return _build_index(async_redis_client, SRE_INSTANCES_SCHEMA)
+
+    async def _clusters_index() -> AsyncSearchIndex:
+        return _build_index(async_redis_client, SRE_CLUSTERS_SCHEMA)
+
+    async def _targets_index() -> AsyncSearchIndex:
+        return _build_index(async_redis_client, SRE_TARGETS_SCHEMA)
+
+    monkeypatch.setenv(
+        "REDIS_SRE_MASTER_KEY",
+        base64.b64encode(b"0123456789abcdef0123456789abcdef").decode("ascii"),
+    )
+    monkeypatch.setattr(
+        "redis_sre_agent.core.instances.get_redis_client", lambda: async_redis_client
+    )
+    monkeypatch.setattr(
+        "redis_sre_agent.core.clusters.get_redis_client", lambda: async_redis_client
+    )
+    monkeypatch.setattr("redis_sre_agent.core.targets.get_redis_client", lambda: async_redis_client)
+    monkeypatch.setattr(
+        "redis_sre_agent.core.docket_tasks.get_redis_client", lambda: async_redis_client
+    )
+    monkeypatch.setattr("redis_sre_agent.core.instances.get_instances_index", _instances_index)
+    monkeypatch.setattr("redis_sre_agent.core.clusters.get_clusters_index", _clusters_index)
+    monkeypatch.setattr("redis_sre_agent.core.targets.get_targets_index", _targets_index)
+
+
+@pytest.mark.asyncio
+async def test_target_discovery_tool_attaches_tools_and_reloads_from_thread(
+    async_redis_client,
+    redis_url,
+    redis_backed_target_state,
+):
+    """A resolved target should attach live tools and survive a new ToolManager session."""
+
+    instance = RedisInstance(
+        id="redis-prod-checkout-cache",
+        name="checkout-cache-prod",
+        connection_url=redis_url,
+        environment="production",
+        usage="cache",
+        description="Primary checkout cache",
+        instance_type="oss_single",
+        extension_data={"target_discovery": {"aliases": ["checkout cache", "checkout"]}},
+    )
+    await save_instances([instance])
+
+    thread_manager = ThreadManager(redis_client=async_redis_client)
+    thread_id = await thread_manager.create_thread(
+        user_id="test-user",
+        session_id="test-session",
+        initial_context={},
+    )
+
+    async with ToolManager(thread_id=thread_id, user_id="test-user") as mgr:
+        resolve_tool = next(t.name for t in mgr.get_tools() if "resolve_redis_targets" in t.name)
+        resolution = await mgr.resolve_tool_call(
+            resolve_tool,
+            {
+                "query": "prod checkout cache",
+                "attach_tools": True,
+            },
+        )
+
+        assert resolution["status"] == "resolved"
+        assert resolution["attached_target_handles"]
+        handle = resolution["attached_target_handles"][0]
+        assert mgr.get_toolset_generation() >= 2
+
+        redis_info_tools = [
+            t.name
+            for t in mgr.get_tools()
+            if "redis_command_" in t.name
+            and t.name.endswith("_info")
+            and "cluster_info" not in t.name
+            and "replication_info" not in t.name
+            and "search_index_info" not in t.name
+        ]
+        assert len([t for t in mgr.get_tools() if "redis_command_" in t.name]) == 11
+        assert len(redis_info_tools) == 1
+
+        info_tool = redis_info_tools[0]
+        info_result = await mgr.resolve_tool_call(info_tool, {"section": "server"})
+        assert info_result["status"] == "success"
+        assert info_result["section"] == "server"
+        assert "redis_version" in info_result["data"]
+
+    thread_state = await thread_manager.get_thread(thread_id)
+    assert thread_state is not None
+    assert thread_state.context["attached_target_handles"] == [handle]
+    assert thread_state.context["active_target_handle"] == handle
+    assert thread_state.context["instance_id"] == instance.id
+
+    async with ToolManager(thread_id=thread_id, user_id="test-user") as mgr:
+        reloaded_info_tools = [
+            t.name
+            for t in mgr.get_tools()
+            if "redis_command_" in t.name
+            and t.name.endswith("_info")
+            and "cluster_info" not in t.name
+            and "replication_info" not in t.name
+            and "search_index_info" not in t.name
+        ]
+        assert len([t for t in mgr.get_tools() if "redis_command_" in t.name]) == 11
+        assert len(reloaded_info_tools) == 1
+
+        memory_result = await mgr.resolve_tool_call(reloaded_info_tools[0], {"section": "memory"})
+        assert memory_result["status"] == "success"
+        assert memory_result["section"] == "memory"
+        assert "used_memory" in memory_result["data"]
+
+
+@pytest.mark.asyncio
+async def test_target_discovery_tool_can_attach_multiple_targets(
+    async_redis_client,
+    redis_url,
+    redis_backed_target_state,
+):
+    """Multi-target resolution should bind several handles and load tool variants for each."""
+
+    instances = [
+        RedisInstance(
+            id="redis-prod-checkout-cache",
+            name="checkout-cache-prod",
+            connection_url=redis_url,
+            environment="production",
+            usage="cache",
+            description="Checkout traffic cache",
+            instance_type="oss_single",
+            extension_data={"target_discovery": {"aliases": ["checkout cache"]}},
+        ),
+        RedisInstance(
+            id="redis-prod-session-cache",
+            name="session-cache-prod",
+            connection_url=redis_url,
+            environment="production",
+            usage="cache",
+            description="Session state cache",
+            instance_type="oss_single",
+            extension_data={"target_discovery": {"aliases": ["session cache"]}},
+        ),
+    ]
+    await save_instances(instances)
+
+    thread_manager = ThreadManager(redis_client=async_redis_client)
+    thread_id = await thread_manager.create_thread(
+        user_id="test-user",
+        session_id="test-session",
+        initial_context={},
+    )
+
+    async with ToolManager(thread_id=thread_id, user_id="test-user") as mgr:
+        resolve_tool = next(t.name for t in mgr.get_tools() if "resolve_redis_targets" in t.name)
+        resolution = await mgr.resolve_tool_call(
+            resolve_tool,
+            {
+                "query": "prod cache",
+                "allow_multiple": True,
+                "attach_tools": True,
+                "max_results": 5,
+            },
+        )
+
+        handles = resolution["attached_target_handles"]
+        assert resolution["status"] == "resolved"
+        assert len(handles) == 2
+
+        loaded_tool_names = [tool.name for tool in mgr.get_tools()]
+        redis_info_tools = [
+            name
+            for name in loaded_tool_names
+            if "redis_command_" in name
+            and name.endswith("_info")
+            and "cluster_info" not in name
+            and "replication_info" not in name
+            and "search_index_info" not in name
+        ]
+        assert len([name for name in loaded_tool_names if "redis_command_" in name]) == 22
+        assert len(redis_info_tools) == 2
+
+        for info_tool in redis_info_tools:
+            info_result = await mgr.resolve_tool_call(info_tool, {"section": "server"})
+            assert info_result["status"] == "success"
+            assert "redis_version" in info_result["data"]
+
+    thread_state = await thread_manager.get_thread(thread_id)
+    assert thread_state is not None
+    assert thread_state.context["attached_target_handles"] == handles
+    assert len(thread_state.context["target_bindings"]) == 2
+
+
+@pytest.mark.asyncio
+async def test_process_agent_turn_pre_resolves_target_scope_for_deep_triage(
+    async_redis_client,
+    redis_url,
+    redis_backed_target_state,
+):
+    """Deep-triage entry should persist resolved scope before the heavy agent runs."""
+
+    instance = RedisInstance(
+        id="redis-prod-orders-cache",
+        name="orders-cache-prod",
+        connection_url=redis_url,
+        environment="production",
+        usage="cache",
+        description="Orders cache",
+        instance_type="oss_single",
+        extension_data={"target_discovery": {"aliases": ["orders cache"]}},
+    )
+    await save_instances([instance])
+
+    thread_manager = ThreadManager(redis_client=async_redis_client)
+    task_manager = TaskManager(redis_client=async_redis_client)
+    thread_id = await thread_manager.create_thread(
+        user_id="test-user",
+        session_id="test-session",
+        initial_context={},
+    )
+
+    fake_agent_result = {
+        "response": "triage complete",
+        "search_results": [],
+        "tool_envelopes": [],
+        "metadata": {"iterations": 1},
+    }
+
+    with (
+        patch(
+            "redis_sre_agent.core.docket_tasks.route_to_appropriate_agent",
+            new=AsyncMock(return_value=AgentType.REDIS_TRIAGE),
+        ),
+        patch(
+            "redis_sre_agent.core.docket_tasks.run_agent_with_progress",
+            new=AsyncMock(return_value=fake_agent_result),
+        ),
+        patch(
+            "redis_sre_agent.core.docket_tasks.get_sre_agent",
+            return_value=MagicMock(),
+        ),
+    ):
+        result = await process_agent_turn(
+            thread_id=thread_id,
+            message="Do a deep triage on the prod orders cache",
+        )
+
+    thread_state = await thread_manager.get_thread(thread_id)
+    assert thread_state is not None
+    assert thread_state.context["instance_id"] == instance.id
+    assert thread_state.context["attached_target_handles"]
+    assert (
+        thread_state.context["active_target_handle"]
+        in thread_state.context["attached_target_handles"]
+    )
+
+    task_state = await task_manager.get_task_state(result["task_id"])
+    assert task_state is not None
+    assert any(update.update_type == "target_resolution" for update in task_state.updates)
+    target_update = next(
+        update for update in task_state.updates if update.update_type == "target_resolution"
+    )
+    assert target_update.metadata["match_count"] == 1

--- a/tests/unit/agent/test_chat_agent.py
+++ b/tests/unit/agent/test_chat_agent.py
@@ -288,6 +288,7 @@ class TestChatAgentWorkflowBuild:
         mock_tool_mgr = MagicMock()
         mock_tool_mgr.get_tools.return_value = []
         mock_tool_mgr.get_status_update.return_value = None
+        mock_tool_mgr.get_toolset_generation.return_value = 1
 
         # Create a mock emitter
         emitter = NullEmitter()
@@ -295,8 +296,6 @@ class TestChatAgentWorkflowBuild:
         # Should not raise - emitter is now accepted
         workflow = agent._build_workflow(
             tool_mgr=mock_tool_mgr,
-            llm_with_tools=mock_llm,
-            adapters=[],
             emitter=emitter,
         )
 
@@ -315,12 +314,11 @@ class TestChatAgentWorkflowBuild:
         # Create a mock tool manager
         mock_tool_mgr = MagicMock()
         mock_tool_mgr.get_tools.return_value = []
+        mock_tool_mgr.get_toolset_generation.return_value = 1
 
         # Should not raise when emitter is None
         workflow = agent._build_workflow(
             tool_mgr=mock_tool_mgr,
-            llm_with_tools=mock_llm,
-            adapters=[],
             emitter=None,
         )
 
@@ -679,10 +677,9 @@ class TestChatAgentStartupContext:
         agent = ChatAgent()
         mock_tool_mgr = MagicMock()
         mock_tool_mgr.get_tools.return_value = []
+        mock_tool_mgr.get_toolset_generation.return_value = 1
         workflow = agent._build_workflow(
             tool_mgr=mock_tool_mgr,
-            llm_with_tools=mock_llm,
-            adapters=[],
             emitter=None,
         )
         compiled = workflow.compile()
@@ -730,10 +727,9 @@ class TestChatAgentStartupContext:
         agent = ChatAgent()
         mock_tool_mgr = MagicMock()
         mock_tool_mgr.get_tools.return_value = []
+        mock_tool_mgr.get_toolset_generation.return_value = 1
         workflow = agent._build_workflow(
             tool_mgr=mock_tool_mgr,
-            llm_with_tools=mock_llm,
-            adapters=[],
             emitter=None,
         )
         compiled = workflow.compile()
@@ -776,10 +772,9 @@ class TestChatAgentStartupContext:
         agent = ChatAgent()
         mock_tool_mgr = MagicMock()
         mock_tool_mgr.get_tools.return_value = []
+        mock_tool_mgr.get_toolset_generation.return_value = 1
         workflow = agent._build_workflow(
             tool_mgr=mock_tool_mgr,
-            llm_with_tools=mock_llm,
-            adapters=[],
             emitter=None,
         )
         compiled = workflow.compile()
@@ -831,10 +826,9 @@ class TestChatAgentStartupContext:
         agent = ChatAgent()
         mock_tool_mgr = MagicMock()
         mock_tool_mgr.get_tools.return_value = []
+        mock_tool_mgr.get_toolset_generation.return_value = 1
         workflow = agent._build_workflow(
             tool_mgr=mock_tool_mgr,
-            llm_with_tools=mock_llm,
-            adapters=[],
             emitter=None,
         )
         compiled = workflow.compile()
@@ -874,10 +868,9 @@ class TestChatAgentStartupContext:
         agent = ChatAgent()
         mock_tool_mgr = MagicMock()
         mock_tool_mgr.get_tools.return_value = []
+        mock_tool_mgr.get_toolset_generation.return_value = 1
         workflow = agent._build_workflow(
             tool_mgr=mock_tool_mgr,
-            llm_with_tools=mock_llm,
-            adapters=[],
             emitter=None,
         )
         compiled = workflow.compile()
@@ -898,5 +891,56 @@ class TestChatAgentStartupContext:
 
         sent_messages = mock_llm.ainvoke.call_args.args[0]
         assert isinstance(sent_messages[0], SystemMessage)
-        assert sent_messages[0].content == "FRESH_CONTEXT"
-        mock_build_startup_context.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    @patch("redis_sre_agent.agent.helpers.build_adapters_for_tooldefs", new_callable=AsyncMock)
+    @patch("redis_sre_agent.agent.chat_agent.build_startup_knowledge_context")
+    @patch("redis_sre_agent.agent.chat_agent.create_llm")
+    @patch("redis_sre_agent.agent.chat_agent.create_mini_llm")
+    async def test_agent_node_rebinds_tools_when_toolset_generation_changes(
+        self,
+        mock_create_mini_llm,
+        mock_create_llm,
+        mock_build_startup_context,
+        mock_build_adapters,
+    ):
+        mock_llm = MagicMock()
+        mock_llm.bind_tools.return_value = mock_llm
+        mock_llm.ainvoke = AsyncMock(return_value=AIMessage(content="ok", tool_calls=[]))
+        mock_create_llm.return_value = mock_llm
+        mock_create_mini_llm.return_value = mock_llm
+        mock_build_startup_context.return_value = "CTX"
+        mock_build_adapters.return_value = []
+
+        agent = ChatAgent()
+        mock_tool_mgr = MagicMock()
+        mock_tool_mgr.get_tools.side_effect = [[], []]
+        mock_tool_mgr.get_toolset_generation.side_effect = [1, 2]
+        workflow = agent._build_workflow(tool_mgr=mock_tool_mgr, emitter=None)
+        compiled = workflow.compile()
+
+        first_state = {
+            "messages": [HumanMessage(content="first question")],
+            "session_id": "session-1",
+            "user_id": "test-user",
+            "current_tool_calls": [],
+            "iteration_count": 0,
+            "max_iterations": 10,
+            "startup_system_prompt": None,
+            "signals_envelopes": [],
+        }
+        second_state = {
+            "messages": [HumanMessage(content="second question")],
+            "session_id": "session-1",
+            "user_id": "test-user",
+            "current_tool_calls": [],
+            "iteration_count": 0,
+            "max_iterations": 10,
+            "startup_system_prompt": None,
+            "signals_envelopes": [],
+        }
+
+        await compiled.nodes["agent"].ainvoke(first_state)
+        await compiled.nodes["agent"].ainvoke(second_state)
+
+        assert mock_llm.bind_tools.call_count == 2

--- a/tests/unit/agent/test_chat_agent.py
+++ b/tests/unit/agent/test_chat_agent.py
@@ -623,6 +623,7 @@ class TestChatAgentStartupContext:
         mock_tool_manager.__aenter__.return_value = mock_tool_manager
         mock_tool_manager.__aexit__.return_value = None
         mock_tool_manager.get_tools.return_value = [mock_tool]
+        mock_tool_manager.get_toolset_generation.return_value = 3
 
         fake_app = AsyncMock()
         fake_app.ainvoke.return_value = {
@@ -656,6 +657,7 @@ class TestChatAgentStartupContext:
         system_message = initial_state["messages"][0]
         assert "Pinned documents:" in str(system_message.content)
         assert CHAT_SYSTEM_PROMPT in str(system_message.content)
+        assert initial_state["toolset_generation"] == 3
 
         mock_startup_context.assert_awaited_once()
         startup_kwargs = mock_startup_context.await_args.kwargs

--- a/tests/unit/agent/test_chat_agent.py
+++ b/tests/unit/agent/test_chat_agent.py
@@ -3,7 +3,7 @@
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
+from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, ToolMessage
 
 from redis_sre_agent.agent.chat_agent import (
     CHAT_SYSTEM_PROMPT,
@@ -258,6 +258,7 @@ class TestChatAgentState:
             "iteration_count": 0,
             "max_iterations": 10,
             "startup_system_prompt": None,
+            "toolset_generation": 0,
             "signals_envelopes": [],
         }
 
@@ -268,6 +269,7 @@ class TestChatAgentState:
         assert "iteration_count" in state
         assert "max_iterations" in state
         assert "startup_system_prompt" in state
+        assert "toolset_generation" in state
         assert "signals_envelopes" in state
 
 
@@ -944,3 +946,64 @@ class TestChatAgentStartupContext:
         await compiled.nodes["agent"].ainvoke(second_state)
 
         assert mock_llm.bind_tools.call_count == 2
+
+    @pytest.mark.asyncio
+    @patch("redis_sre_agent.agent.helpers.build_adapters_for_tooldefs", new_callable=AsyncMock)
+    @patch("redis_sre_agent.agent.chat_agent.build_startup_knowledge_context")
+    @patch("redis_sre_agent.agent.chat_agent.LGToolNode")
+    @patch("redis_sre_agent.agent.chat_agent.create_llm")
+    @patch("redis_sre_agent.agent.chat_agent.create_mini_llm")
+    async def test_tool_node_uses_agent_generation_when_toolset_changes_mid_turn(
+        self,
+        mock_create_mini_llm,
+        mock_create_llm,
+        mock_tool_node_class,
+        mock_build_startup_context,
+        mock_build_adapters,
+    ):
+        mock_llm = MagicMock()
+        mock_llm.bind_tools.return_value = mock_llm
+        mock_llm.ainvoke = AsyncMock(
+            return_value=AIMessage(
+                content="calling tool",
+                tool_calls=[{"id": "call-1", "name": "demo", "args": {}}],
+            )
+        )
+        mock_create_llm.return_value = mock_llm
+        mock_create_mini_llm.return_value = mock_llm
+        mock_build_startup_context.return_value = "CTX"
+        mock_build_adapters.return_value = []
+
+        cached_tool_node = MagicMock()
+        cached_tool_node.ainvoke = AsyncMock(
+            return_value={
+                "messages": [ToolMessage(content="ok", tool_call_id="call-1", name="demo")]
+            }
+        )
+        mock_tool_node_class.return_value = cached_tool_node
+
+        agent = ChatAgent()
+        mock_tool_mgr = MagicMock()
+        mock_tool_mgr.get_tools.return_value = []
+        mock_tool_mgr.get_toolset_generation.side_effect = [1, 2]
+        workflow = agent._build_workflow(tool_mgr=mock_tool_mgr, emitter=None)
+        compiled = workflow.compile()
+
+        first_state = {
+            "messages": [HumanMessage(content="first question")],
+            "session_id": "session-1",
+            "user_id": "test-user",
+            "current_tool_calls": [],
+            "iteration_count": 0,
+            "max_iterations": 10,
+            "startup_system_prompt": None,
+            "signals_envelopes": [],
+        }
+
+        agent_state = await compiled.nodes["agent"].ainvoke(first_state)
+        tool_state = await compiled.nodes["tools"].ainvoke(agent_state)
+
+        assert agent_state["toolset_generation"] == 1
+        cached_tool_node.ainvoke.assert_awaited_once()
+        assert mock_tool_node_class.call_count == 1
+        assert tool_state["toolset_generation"] == 1

--- a/tests/unit/agent/test_router.py
+++ b/tests/unit/agent/test_router.py
@@ -32,21 +32,16 @@ class TestAgentTypeEnum:
 class TestRouteToAppropriateAgent:
     """Test the route_to_appropriate_agent function."""
 
-    async def test_no_instance_routes_to_knowledge(self):
-        """Test that queries without instance context route to knowledge agent."""
+    async def test_no_instance_routes_to_chat(self):
+        """Zero-scope queries should use chat as the default general-purpose agent."""
         with patch("redis_sre_agent.agent.router.create_nano_llm") as mock_create:
-            mock_llm = MagicMock()
-            mock_response = MagicMock()
-            mock_response.content = "KNOWLEDGE_ONLY"
-            mock_llm.ainvoke = AsyncMock(return_value=mock_response)
-            mock_create.return_value = mock_llm
-
             result = await route_to_appropriate_agent(
                 query="What are Redis best practices?",
                 context=None,
             )
 
-            assert result == AgentType.KNOWLEDGE_ONLY
+            assert result == AgentType.REDIS_CHAT
+            mock_create.assert_not_called()
 
     async def test_instance_with_deep_triage_request_routes_to_triage(self):
         """Test that deep triage requests with instance route to triage agent."""
@@ -94,19 +89,14 @@ class TestRouteToAppropriateAgent:
 
             assert result == AgentType.REDIS_CHAT
 
-    async def test_llm_error_without_instance_defaults_to_knowledge(self):
-        """Test that LLM errors without instance default to knowledge agent."""
-        with patch("redis_sre_agent.agent.router.create_nano_llm") as mock_create:
-            mock_llm = MagicMock()
-            mock_llm.ainvoke = AsyncMock(side_effect=Exception("LLM error"))
-            mock_create.return_value = mock_llm
+    async def test_zero_scope_deep_language_still_defaults_to_chat(self):
+        """Until target discovery lands, zero-scope requests stay on chat even if phrased broadly."""
+        result = await route_to_appropriate_agent(
+            query="Do a deep triage on Redis best practices",
+            context=None,
+        )
 
-            result = await route_to_appropriate_agent(
-                query="What is Redis?",
-                context=None,
-            )
-
-            assert result == AgentType.KNOWLEDGE_ONLY
+        assert result == AgentType.REDIS_CHAT
 
     async def test_user_preference_respected(self):
         """Test that user preferences are respected when instance exists."""

--- a/tests/unit/cli/test_cli_query.py
+++ b/tests/unit/cli/test_cli_query.py
@@ -43,7 +43,7 @@ def test_query_cli_help_shows_options():
     assert "-c" in result.output
 
 
-def test_query_without_instance_uses_knowledge_agent(mock_thread_manager, mock_redis_client):
+def test_query_without_instance_uses_chat_agent(mock_thread_manager, mock_redis_client):
     runner = CliRunner()
 
     mock_agent = MagicMock()
@@ -52,9 +52,7 @@ def test_query_without_instance_uses_knowledge_agent(mock_thread_manager, mock_r
     )
 
     with (
-        patch(
-            "redis_sre_agent.cli.query.get_knowledge_agent", return_value=mock_agent
-        ) as mock_get_knowledge,
+        patch("redis_sre_agent.cli.query.get_chat_agent", return_value=mock_agent) as mock_get_chat,
         patch("redis_sre_agent.cli.query.get_sre_agent") as mock_get_sre,
         patch(
             "redis_sre_agent.cli.query.get_instance_by_id",
@@ -66,7 +64,7 @@ def test_query_without_instance_uses_knowledge_agent(mock_thread_manager, mock_r
         result = runner.invoke(query, ["What is Redis SRE?"])
 
     assert result.exit_code == 0, result.output
-    mock_get_knowledge.assert_called_once()
+    mock_get_chat.assert_called_once_with(redis_instance=None, redis_cluster=None)
     mock_get_sre.assert_not_called()
     mock_get_instance.assert_not_awaited()
     mock_agent.process_query.assert_awaited_once()

--- a/tests/unit/cli/test_cli_query.py
+++ b/tests/unit/cli/test_cli_query.py
@@ -364,8 +364,8 @@ def test_query_with_agent_triage_forces_triage_agent(mock_thread_manager, mock_r
     mock_agent.process_query.assert_awaited_once()
 
 
-def test_query_with_agent_knowledge_forces_knowledge_agent(mock_thread_manager, mock_redis_client):
-    """Test that --agent knowledge forces use of the knowledge agent."""
+def test_query_with_agent_knowledge_forces_chat_agent(mock_thread_manager, mock_redis_client):
+    """Test that --agent knowledge aliases to the chat agent."""
     runner = CliRunner()
 
     mock_agent = MagicMock()
@@ -374,11 +374,9 @@ def test_query_with_agent_knowledge_forces_knowledge_agent(mock_thread_manager, 
     )
 
     with (
-        patch(
-            "redis_sre_agent.cli.query.get_knowledge_agent", return_value=mock_agent
-        ) as mock_get_knowledge,
         patch("redis_sre_agent.cli.query.get_sre_agent") as mock_get_sre,
-        patch("redis_sre_agent.cli.query.get_chat_agent") as mock_get_chat,
+        patch("redis_sre_agent.cli.query.get_chat_agent", return_value=mock_agent) as mock_get_chat,
+        patch("redis_sre_agent.cli.query.get_knowledge_agent") as mock_get_knowledge,
         patch("redis_sre_agent.cli.query.route_to_appropriate_agent") as mock_router,
         patch("redis_sre_agent.cli.query.get_redis_client", return_value=mock_redis_client),
         patch("redis_sre_agent.cli.query.ThreadManager", return_value=mock_thread_manager),
@@ -386,12 +384,12 @@ def test_query_with_agent_knowledge_forces_knowledge_agent(mock_thread_manager, 
         result = runner.invoke(query, ["-a", "knowledge", "What is Redis replication?"])
 
     assert result.exit_code == 0, result.output
-    assert "Knowledge (selected)" in result.output
+    assert "Chat (selected)" in result.output
 
-    # Knowledge agent should be used
-    mock_get_knowledge.assert_called_once()
+    # Knowledge is now a chat alias
+    mock_get_chat.assert_called_once_with(redis_instance=None, redis_cluster=None)
     mock_get_sre.assert_not_called()
-    mock_get_chat.assert_not_called()
+    mock_get_knowledge.assert_not_called()
 
     # Router should NOT be called
     mock_router.assert_not_called()
@@ -459,9 +457,8 @@ def test_query_with_agent_auto_uses_router(mock_thread_manager, mock_redis_clien
     )
 
     with (
-        patch(
-            "redis_sre_agent.cli.query.get_knowledge_agent", return_value=mock_agent
-        ) as mock_get_knowledge,
+        patch("redis_sre_agent.cli.query.get_chat_agent", return_value=mock_agent) as mock_get_chat,
+        patch("redis_sre_agent.cli.query.get_knowledge_agent") as mock_get_knowledge,
         patch("redis_sre_agent.cli.query.get_sre_agent") as mock_get_sre,
         patch(
             "redis_sre_agent.cli.query.route_to_appropriate_agent",
@@ -474,14 +471,15 @@ def test_query_with_agent_auto_uses_router(mock_thread_manager, mock_redis_clien
         result = runner.invoke(query, ["What is Redis?"])
 
     assert result.exit_code == 0, result.output
-    # Should show "Knowledge" without "(selected)" since it was auto-routed
-    assert "Agent: Knowledge" in result.output
+    # Routed knowledge-only queries now use the unified chat agent
+    assert "Agent: Chat" in result.output
     assert "(selected)" not in result.output
 
     # Router should be called
     mock_router.assert_awaited_once()
 
-    mock_get_knowledge.assert_called_once()
+    mock_get_chat.assert_called_once_with(redis_instance=None, redis_cluster=None)
+    mock_get_knowledge.assert_not_called()
     mock_get_sre.assert_not_called()
 
 
@@ -495,7 +493,8 @@ def test_query_agent_option_is_case_insensitive(mock_thread_manager, mock_redis_
     )
 
     with (
-        patch("redis_sre_agent.cli.query.get_knowledge_agent", return_value=mock_agent),
+        patch("redis_sre_agent.cli.query.get_chat_agent", return_value=mock_agent),
+        patch("redis_sre_agent.cli.query.get_knowledge_agent"),
         patch("redis_sre_agent.cli.query.route_to_appropriate_agent"),
         patch("redis_sre_agent.cli.query.get_redis_client", return_value=mock_redis_client),
         patch("redis_sre_agent.cli.query.ThreadManager", return_value=mock_thread_manager),

--- a/tests/unit/core/test_redis.py
+++ b/tests/unit/core/test_redis.py
@@ -193,14 +193,15 @@ class TestRedisInfrastructure:
             patch("redis_sre_agent.core.redis.get_tasks_index", return_value=mock_search_index),
             patch("redis_sre_agent.core.redis.get_instances_index", return_value=mock_search_index),
             patch("redis_sre_agent.core.redis.get_clusters_index", return_value=mock_search_index),
+            patch("redis_sre_agent.core.redis.get_targets_index", return_value=mock_search_index),
         ):
             result = await create_indices()
 
         assert result is True
-        # Should be called eight times - knowledge, skills, support_tickets,
-        # schedules, threads, tasks, instances, clusters
-        assert mock_search_index.exists.call_count == 8
-        assert mock_search_index.create.call_count == 8
+        # Should be called nine times - knowledge, skills, support_tickets,
+        # schedules, threads, tasks, instances, clusters, targets
+        assert mock_search_index.exists.call_count == 9
+        assert mock_search_index.create.call_count == 9
 
     @pytest.mark.asyncio
     async def test_create_indices_existing_index(self, mock_search_index):
@@ -219,13 +220,14 @@ class TestRedisInfrastructure:
             patch("redis_sre_agent.core.redis.get_tasks_index", return_value=mock_search_index),
             patch("redis_sre_agent.core.redis.get_instances_index", return_value=mock_search_index),
             patch("redis_sre_agent.core.redis.get_clusters_index", return_value=mock_search_index),
+            patch("redis_sre_agent.core.redis.get_targets_index", return_value=mock_search_index),
         ):
             result = await create_indices()
 
         assert result is True
-        # Should be called eight times - knowledge, skills, support_tickets,
-        # schedules, threads, tasks, instances, clusters
-        assert mock_search_index.exists.call_count == 8
+        # Should be called nine times - knowledge, skills, support_tickets,
+        # schedules, threads, tasks, instances, clusters, targets
+        assert mock_search_index.exists.call_count == 9
         mock_search_index.create.assert_not_called()
 
     @pytest.mark.asyncio

--- a/tests/unit/core/test_targets.py
+++ b/tests/unit/core/test_targets.py
@@ -137,6 +137,36 @@ async def test_resolve_target_query_parses_hints_once_and_avoids_alias_substring
 
 
 @pytest.mark.asyncio
+async def test_resolve_target_query_keeps_token_overlap_from_all_aliases():
+    target = TargetCatalogDoc(
+        target_id="instance:prod-cache",
+        target_kind="instance",
+        resource_id="prod-cache",
+        display_name="prod-cache",
+        name="prod-cache",
+        environment="production",
+        usage=None,
+        target_type="oss_single",
+        capabilities=["redis"],
+        search_text="primary production target",
+        search_aliases=["alpha", "checkout cache"],
+    )
+
+    with patch(
+        "redis_sre_agent.core.targets.get_target_catalog",
+        new=AsyncMock(return_value=[target]),
+    ):
+        resolved = await resolve_target_query(query="checkout cache", allow_multiple=False)
+
+    assert resolved.status == "resolved"
+    assert resolved.selected_matches[0].resource_id == "prod-cache"
+    assert any(
+        reason == "matched tokens=cache,checkout"
+        for reason in resolved.selected_matches[0].match_reasons
+    )
+
+
+@pytest.mark.asyncio
 async def test_attach_target_matches_persists_safe_thread_context():
     match = ResolvedTargetMatch(
         target_kind="instance",

--- a/tests/unit/core/test_targets.py
+++ b/tests/unit/core/test_targets.py
@@ -1,0 +1,151 @@
+"""Tests for unified target discovery and safe thread binding state."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from redis_sre_agent.core.instances import RedisInstance
+from redis_sre_agent.core.targets import (
+    ResolvedTargetMatch,
+    TargetCatalogDoc,
+    attach_target_matches,
+    build_ephemeral_target_bindings,
+    build_target_doc_from_instance,
+    resolve_target_query,
+)
+from redis_sre_agent.core.threads import Thread, ThreadMetadata
+
+
+def test_build_target_doc_from_instance_excludes_secrets_and_includes_aliases():
+    instance = RedisInstance(
+        id="redis-prod-checkout-cache",
+        name="checkout-cache-prod",
+        connection_url="redis://user:secret@cache.internal:6379/0",
+        environment="production",
+        usage="cache",
+        description="Primary checkout cache",
+        notes="Handles checkout sessions",
+        repo_url="https://github.com/acme/checkout-service",
+        monitoring_identifier="checkout-cache-prod",
+        logging_identifier="checkout-cache",
+        instance_type="oss_single",
+        extension_data={"target_discovery": {"aliases": ["checkout", "cart cache"]}},
+    )
+
+    doc = build_target_doc_from_instance(instance)
+
+    assert "secret" not in doc.search_text
+    assert "cache.internal" not in doc.search_text
+    assert "checkout" in doc.search_aliases
+    assert "cart cache" in doc.search_aliases
+    assert doc.repo_slug == "acme/checkout-service"
+
+
+@pytest.mark.asyncio
+async def test_resolve_target_query_ranks_matching_environment_and_detects_ambiguity():
+    prod = TargetCatalogDoc(
+        target_id="instance:redis-prod-checkout-cache",
+        target_kind="instance",
+        resource_id="redis-prod-checkout-cache",
+        display_name="checkout-cache-prod",
+        name="checkout-cache-prod",
+        environment="production",
+        usage="cache",
+        target_type="oss_single",
+        capabilities=["redis", "diagnostics"],
+        search_text="checkout cache prod production cache",
+        search_aliases=["checkout"],
+    )
+    stage = TargetCatalogDoc(
+        target_id="instance:redis-stage-checkout-cache",
+        target_kind="instance",
+        resource_id="redis-stage-checkout-cache",
+        display_name="checkout-cache-stage",
+        name="checkout-cache-stage",
+        environment="staging",
+        usage="cache",
+        target_type="oss_single",
+        capabilities=["redis", "diagnostics"],
+        search_text="checkout cache stage staging cache",
+        search_aliases=["checkout"],
+    )
+
+    with patch(
+        "redis_sre_agent.core.targets.get_target_catalog",
+        new=AsyncMock(return_value=[prod, stage]),
+    ):
+        resolved = await resolve_target_query(query="prod checkout cache", allow_multiple=False)
+        ambiguous = await resolve_target_query(query="checkout cache", allow_multiple=False)
+
+    assert resolved.status == "resolved"
+    assert not resolved.clarification_required
+    assert len(resolved.selected_matches) == 1
+    assert resolved.selected_matches[0].resource_id == "redis-prod-checkout-cache"
+
+    assert ambiguous.status == "clarification_required"
+    assert ambiguous.clarification_required is True
+    assert len(ambiguous.matches) == 2
+
+
+@pytest.mark.asyncio
+async def test_attach_target_matches_persists_safe_thread_context():
+    match = ResolvedTargetMatch(
+        target_kind="instance",
+        resource_id="redis-prod-checkout-cache",
+        display_name="checkout-cache-prod",
+        environment="production",
+        target_type="oss_single",
+        capabilities=["redis", "diagnostics"],
+        confidence=0.94,
+        match_reasons=["matched environment=production"],
+    )
+    mock_thread_manager = AsyncMock()
+    mock_thread_manager.get_thread = AsyncMock(
+        return_value=Thread(
+            thread_id="thread-1", messages=[], context={}, metadata=ThreadMetadata()
+        )
+    )
+    mock_thread_manager.update_thread_context = AsyncMock(return_value=True)
+
+    with patch(
+        "redis_sre_agent.core.targets.ThreadManager",
+        return_value=mock_thread_manager,
+    ):
+        bindings, generation = await attach_target_matches(
+            thread_id="thread-1",
+            matches=[match],
+            task_id="task-1",
+            replace_existing=False,
+        )
+
+    assert len(bindings) == 1
+    assert bindings[0].target_handle.startswith("tgt_")
+    assert generation == 2
+
+    update_payload = mock_thread_manager.update_thread_context.await_args.args[1]
+    assert update_payload["instance_id"] == "redis-prod-checkout-cache"
+    assert update_payload["cluster_id"] == ""
+    assert update_payload["attached_target_handles"] == [bindings[0].target_handle]
+    assert "connection_url" not in str(update_payload)
+    assert "secret" not in str(update_payload)
+
+
+def test_build_ephemeral_target_bindings_generates_opaque_handles():
+    matches = [
+        ResolvedTargetMatch(
+            target_kind="cluster",
+            resource_id="cluster-1",
+            display_name="prod-enterprise-cluster",
+            environment="production",
+            target_type="redis_enterprise",
+            capabilities=["admin"],
+            confidence=0.9,
+            match_reasons=["matched kind=cluster"],
+        )
+    ]
+
+    bindings = build_ephemeral_target_bindings(matches, thread_id="thread-1", task_id="task-1")
+
+    assert len(bindings) == 1
+    assert bindings[0].target_handle.startswith("tgt_")
+    assert bindings[0].resource_id == "cluster-1"

--- a/tests/unit/core/test_targets.py
+++ b/tests/unit/core/test_targets.py
@@ -5,12 +5,14 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from redis_sre_agent.core import targets as target_module
+from redis_sre_agent.core.clusters import RedisCluster
 from redis_sre_agent.core.instances import RedisInstance
 from redis_sre_agent.core.targets import (
     ResolvedTargetMatch,
     TargetCatalogDoc,
     attach_target_matches,
     build_ephemeral_target_bindings,
+    build_target_doc_from_cluster,
     build_target_doc_from_instance,
     resolve_target_query,
     sync_target_catalog,
@@ -59,6 +61,23 @@ def test_build_target_doc_from_instance_normalizes_environment_aliases():
     assert doc.environment == "production"
 
 
+def test_build_target_doc_from_cluster_includes_base_capabilities():
+    cluster = RedisCluster(
+        id="cluster-prod-checkout",
+        name="checkout-cluster-prod",
+        cluster_type="oss_cluster",
+        environment="production",
+        description="Checkout Redis cluster",
+    )
+
+    doc = build_target_doc_from_cluster(cluster)
+
+    assert "redis" in doc.capabilities
+    assert "diagnostics" in doc.capabilities
+    assert "metrics" in doc.capabilities
+    assert "logs" in doc.capabilities
+
+
 @pytest.mark.asyncio
 async def test_resolve_target_query_ranks_matching_environment_and_detects_ambiguity():
     prod = TargetCatalogDoc(
@@ -103,6 +122,11 @@ async def test_resolve_target_query_ranks_matching_environment_and_detects_ambig
     assert ambiguous.status == "clarification_required"
     assert ambiguous.clarification_required is True
     assert len(ambiguous.matches) == 2
+    assert len(ambiguous.selected_matches) == 2
+    assert [match.resource_id for match in ambiguous.selected_matches] == [
+        "redis-prod-checkout-cache",
+        "redis-stage-checkout-cache",
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/core/test_targets.py
+++ b/tests/unit/core/test_targets.py
@@ -230,7 +230,39 @@ async def test_resolve_target_query_keeps_token_overlap_from_all_aliases():
     assert resolved.status == "resolved"
     assert resolved.selected_matches[0].resource_id == "prod-cache"
     assert any(
-        reason == "matched tokens=cache,checkout"
+        reason == "matched tokens=checkout" for reason in resolved.selected_matches[0].match_reasons
+    )
+
+
+@pytest.mark.asyncio
+async def test_resolve_target_query_excludes_hint_tokens_from_token_overlap():
+    target = TargetCatalogDoc(
+        target_id="instance:enterprise-cache",
+        target_kind="instance",
+        resource_id="enterprise-cache",
+        display_name="enterprise-cache",
+        name="enterprise-cache",
+        environment="production",
+        usage="cache",
+        target_type="redis_enterprise",
+        capabilities=["redis"],
+        search_text="production cache enterprise instance",
+        search_aliases=[],
+    )
+
+    with patch(
+        "redis_sre_agent.core.targets.get_target_catalog",
+        new=AsyncMock(return_value=[target]),
+    ):
+        resolved = await resolve_target_query(
+            query="prod cache instance enterprise",
+            allow_multiple=False,
+        )
+
+    assert resolved.status == "resolved"
+    assert resolved.selected_matches[0].resource_id == "enterprise-cache"
+    assert all(
+        not reason.startswith("matched tokens=")
         for reason in resolved.selected_matches[0].match_reasons
     )
 

--- a/tests/unit/core/test_targets.py
+++ b/tests/unit/core/test_targets.py
@@ -209,6 +209,61 @@ async def test_attach_target_matches_persists_safe_thread_context():
     assert "secret" not in str(update_payload)
 
 
+@pytest.mark.asyncio
+async def test_attach_target_matches_append_mode_preserves_existing_scope_ids():
+    matches = [
+        ResolvedTargetMatch(
+            target_kind="cluster",
+            resource_id="cluster-a",
+            display_name="cluster-a",
+            environment="production",
+            target_type="redis_enterprise",
+            capabilities=["admin"],
+            confidence=0.91,
+            match_reasons=["matched name=cluster-a"],
+        ),
+        ResolvedTargetMatch(
+            target_kind="cluster",
+            resource_id="cluster-b",
+            display_name="cluster-b",
+            environment="production",
+            target_type="redis_enterprise",
+            capabilities=["admin"],
+            confidence=0.9,
+            match_reasons=["matched name=cluster-b"],
+        ),
+    ]
+    mock_thread_manager = AsyncMock()
+    mock_thread_manager.get_thread = AsyncMock(
+        return_value=Thread(
+            thread_id="thread-1",
+            messages=[],
+            context={"instance_id": "redis-prod-checkout-cache", "cluster_id": ""},
+            metadata=ThreadMetadata(),
+        )
+    )
+    mock_thread_manager.update_thread_context = AsyncMock(return_value=True)
+
+    with patch(
+        "redis_sre_agent.core.targets.ThreadManager",
+        return_value=mock_thread_manager,
+    ):
+        bindings, generation = await attach_target_matches(
+            thread_id="thread-1",
+            matches=matches,
+            task_id="task-1",
+            replace_existing=False,
+        )
+
+    assert len(bindings) == 2
+    assert generation == 2
+
+    update_payload = mock_thread_manager.update_thread_context.await_args.args[1]
+    assert update_payload["instance_id"] == "redis-prod-checkout-cache"
+    assert update_payload["cluster_id"] == ""
+    assert len(update_payload["attached_target_handles"]) == 2
+
+
 def test_build_ephemeral_target_bindings_generates_opaque_handles():
     matches = [
         ResolvedTargetMatch(

--- a/tests/unit/core/test_targets.py
+++ b/tests/unit/core/test_targets.py
@@ -106,6 +106,34 @@ async def test_resolve_target_query_ranks_matching_environment_and_detects_ambig
 
 
 @pytest.mark.asyncio
+async def test_resolve_target_query_resolves_single_included_candidate_below_three_points():
+    low_score_match = TargetCatalogDoc(
+        target_id="instance:redis-prod-checkout-cache",
+        target_kind="instance",
+        resource_id="redis-prod-checkout-cache",
+        display_name="checkout-prod",
+        name="checkout-prod",
+        environment="production",
+        usage="cache",
+        target_type="oss_single",
+        capabilities=["redis"],
+        search_text="",
+        search_aliases=[],
+    )
+
+    with patch(
+        "redis_sre_agent.core.targets.get_target_catalog",
+        new=AsyncMock(return_value=[low_score_match]),
+    ):
+        resolved = await resolve_target_query(query="cache", allow_multiple=False)
+
+    assert resolved.status == "resolved"
+    assert resolved.clarification_required is False
+    assert len(resolved.selected_matches) == 1
+    assert resolved.selected_matches[0].resource_id == "redis-prod-checkout-cache"
+
+
+@pytest.mark.asyncio
 async def test_resolve_target_query_parses_hints_once_and_avoids_alias_substring_matches():
     ambiguous_alias = TargetCatalogDoc(
         target_id="instance:alias-only",

--- a/tests/unit/core/test_targets.py
+++ b/tests/unit/core/test_targets.py
@@ -43,6 +43,22 @@ def test_build_target_doc_from_instance_excludes_secrets_and_includes_aliases():
     assert doc.repo_slug == "acme/checkout-service"
 
 
+def test_build_target_doc_from_instance_normalizes_environment_aliases():
+    instance = RedisInstance(
+        id="redis-prod-checkout-cache",
+        name="checkout-cache-prod",
+        connection_url="redis://cache.internal:6379/0",
+        environment="prod",
+        usage="cache",
+        description="Primary checkout cache",
+        instance_type="oss_single",
+    )
+
+    doc = build_target_doc_from_instance(instance)
+
+    assert doc.environment == "production"
+
+
 @pytest.mark.asyncio
 async def test_resolve_target_query_ranks_matching_environment_and_detects_ambiguity():
     prod = TargetCatalogDoc(

--- a/tests/unit/core/test_targets.py
+++ b/tests/unit/core/test_targets.py
@@ -13,6 +13,7 @@ from redis_sre_agent.core.targets import (
     build_ephemeral_target_bindings,
     build_target_doc_from_instance,
     resolve_target_query,
+    sync_target_catalog,
 )
 from redis_sre_agent.core.threads import Thread, ThreadMetadata
 
@@ -283,3 +284,48 @@ def test_build_ephemeral_target_bindings_generates_opaque_handles():
     assert len(bindings) == 1
     assert bindings[0].target_handle.startswith("tgt_")
     assert bindings[0].resource_id == "cluster-1"
+
+
+@pytest.mark.asyncio
+async def test_sync_target_catalog_scan_fallback_only_deletes_prefixed_stale_keys():
+    instance = RedisInstance(
+        id="redis-prod-checkout-cache",
+        name="checkout-cache-prod",
+        connection_url="redis://cache.internal:6379/0",
+        environment="production",
+        usage="cache",
+        description="Primary checkout cache",
+        instance_type="oss_single",
+    )
+    mock_client = AsyncMock()
+    mock_client.scan = AsyncMock(
+        side_effect=[
+            (
+                0,
+                [
+                    b"sre_targets:instance:stale-target",
+                    b"sre_targets:instance:redis-prod-checkout-cache",
+                    b"not-sre_targets:instance:should-not-delete",
+                    b"sre_targets:",
+                ],
+            )
+        ]
+    )
+    mock_client.delete = AsyncMock()
+
+    with (
+        patch("redis_sre_agent.core.targets.get_redis_client", return_value=mock_client),
+        patch(
+            "redis_sre_agent.core.targets._ensure_targets_index_exists",
+            new=AsyncMock(return_value=None),
+        ),
+        patch(
+            "redis_sre_agent.core.targets.get_targets_index",
+            new=AsyncMock(side_effect=RuntimeError("index unavailable")),
+        ),
+    ):
+        result = await sync_target_catalog(instances=[instance], clusters=[])
+
+    assert result is True
+    deleted_keys = [call.args[0] for call in mock_client.delete.await_args_list]
+    assert deleted_keys == ["sre_targets:instance:stale-target"]

--- a/tests/unit/core/test_targets.py
+++ b/tests/unit/core/test_targets.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from redis_sre_agent.core import targets as target_module
 from redis_sre_agent.core.instances import RedisInstance
 from redis_sre_agent.core.targets import (
     ResolvedTargetMatch,
@@ -85,6 +86,54 @@ async def test_resolve_target_query_ranks_matching_environment_and_detects_ambig
     assert ambiguous.status == "clarification_required"
     assert ambiguous.clarification_required is True
     assert len(ambiguous.matches) == 2
+
+
+@pytest.mark.asyncio
+async def test_resolve_target_query_parses_hints_once_and_avoids_alias_substring_matches():
+    ambiguous_alias = TargetCatalogDoc(
+        target_id="instance:alias-only",
+        target_kind="instance",
+        resource_id="alias-only",
+        display_name="alias-only",
+        name="alias-only",
+        environment=None,
+        usage=None,
+        target_type=None,
+        capabilities=["redis"],
+        search_text="unrelated target",
+        search_aliases=["a"],
+    )
+    real_match = TargetCatalogDoc(
+        target_id="instance:checkout-cache",
+        target_kind="instance",
+        resource_id="checkout-cache",
+        display_name="checkout-cache-prod",
+        name="checkout-cache-prod",
+        environment="production",
+        usage="cache",
+        target_type="oss_single",
+        capabilities=["redis"],
+        search_text="checkout cache prod production cache",
+        search_aliases=["checkout"],
+    )
+
+    with (
+        patch(
+            "redis_sre_agent.core.targets.get_target_catalog",
+            new=AsyncMock(return_value=[ambiguous_alias, real_match]),
+        ),
+        patch(
+            "redis_sre_agent.core.targets._parse_query_hints",
+            wraps=target_module._parse_query_hints,
+        ) as parse_hints,
+    ):
+        resolved = await resolve_target_query(query="checkout cache", allow_multiple=False)
+
+    assert parse_hints.call_count == 1
+    assert resolved.status == "resolved"
+    assert len(resolved.selected_matches) == 1
+    assert resolved.selected_matches[0].resource_id == "checkout-cache"
+    assert all(match.resource_id != "alias-only" for match in resolved.matches)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/core/test_tasks.py
+++ b/tests/unit/core/test_tasks.py
@@ -8,6 +8,7 @@ from langchain_core.messages import AIMessage, HumanMessage
 from redisvl.query import VectorRangeQuery
 
 from redis_sre_agent.agent.models import AgentResponse
+from redis_sre_agent.agent.router import AgentType
 from redis_sre_agent.core.docket_tasks import (
     SRE_TASK_COLLECTION,
     _thread_messages_to_conversation_history,
@@ -22,6 +23,11 @@ from redis_sre_agent.core.docket_tasks import (
     search_knowledge_base,
     sre_task,
     test_task_system,
+)
+from redis_sre_agent.core.targets import (
+    ResolvedTargetMatch,
+    TargetBinding,
+    TargetResolutionResult,
 )
 from redis_sre_agent.core.tasks import TaskStatus
 from redis_sre_agent.core.threads import Message, Thread, ThreadMetadata
@@ -1102,6 +1108,116 @@ class TestProcessAgentTurn:
             tool_envelopes=[{"name": "redis_info", "status": "success"}],
             otel_trace_id=None,
         )
+
+    @pytest.mark.asyncio
+    async def test_process_agent_turn_passes_resolved_target_context_to_triage(self):
+        mock_redis = AsyncMock()
+        mock_thread = MagicMock()
+        mock_thread.id = "thread-123"
+        mock_thread.context = {}
+        mock_thread.metadata = MagicMock()
+        mock_thread.metadata.user_id = "user-1"
+        mock_thread.messages = []
+
+        mock_thread_manager = AsyncMock()
+        mock_thread_manager.get_thread = AsyncMock(return_value=mock_thread)
+        mock_thread_manager.update_thread_context = AsyncMock()
+        mock_thread_manager.append_messages = AsyncMock()
+        mock_thread_manager.set_message_trace = AsyncMock()
+
+        mock_task_manager = AsyncMock()
+        mock_task_manager.create_task = AsyncMock(return_value="new-task-123")
+        mock_task_manager.update_task_status = AsyncMock()
+        mock_task_manager.add_task_update = AsyncMock()
+        mock_task_manager.set_task_result = AsyncMock()
+        mock_task_manager.set_task_error = AsyncMock()
+        mock_task_manager.get_task_state = AsyncMock(return_value=MagicMock(updates=[]))
+        mock_task_manager._publish_stream_update = AsyncMock()
+
+        resolution = TargetResolutionResult(
+            status="resolved",
+            query="investigate checkout cache",
+            clarification_required=False,
+            selected_matches=[
+                ResolvedTargetMatch(
+                    target_kind="instance",
+                    resource_id="redis-prod-checkout-cache",
+                    display_name="checkout-cache-prod",
+                    environment="production",
+                    target_type="oss_single",
+                    capabilities=["redis", "diagnostics"],
+                    confidence=0.97,
+                    match_reasons=["matched environment=production"],
+                )
+            ],
+        )
+        bindings = [
+            TargetBinding(
+                target_handle="tgt_01",
+                target_kind="instance",
+                resource_id="redis-prod-checkout-cache",
+                display_name="checkout-cache-prod",
+                capabilities=["redis", "diagnostics"],
+                thread_id="thread-123",
+                task_id="provided-task-123",
+            )
+        ]
+        mock_run_agent = AsyncMock(
+            return_value={
+                "response": "Triage response",
+                "search_results": [],
+                "tool_envelopes": [],
+                "metadata": {"agent_type": "redis_triage"},
+            }
+        )
+
+        with (
+            patch("redis_sre_agent.core.docket_tasks.get_redis_client", return_value=mock_redis),
+            patch(
+                "redis_sre_agent.core.docket_tasks.ThreadManager", return_value=mock_thread_manager
+            ),
+            patch("redis_sre_agent.core.docket_tasks.TaskManager", return_value=mock_task_manager),
+            patch(
+                "redis_sre_agent.core.docket_tasks._extract_instance_details_from_message",
+                return_value=None,
+            ),
+            patch(
+                "redis_sre_agent.core.docket_tasks.route_to_appropriate_agent",
+                new=AsyncMock(return_value=AgentType.REDIS_TRIAGE),
+            ),
+            patch(
+                "redis_sre_agent.core.targets.resolve_target_query",
+                new=AsyncMock(return_value=resolution),
+            ),
+            patch(
+                "redis_sre_agent.core.targets.attach_target_matches",
+                new=AsyncMock(return_value=(bindings, 3)),
+            ),
+            patch("redis_sre_agent.core.docket_tasks.get_sre_agent", return_value=MagicMock()),
+            patch(
+                "redis_sre_agent.core.docket_tasks.run_agent_with_progress",
+                new=mock_run_agent,
+            ),
+            patch(
+                "redis_sre_agent.core.docket_tasks.ULID", return_value="01HXTESTMESSAGEID1234567890"
+            ),
+            patch("opentelemetry.trace.get_tracer") as mock_tracer,
+        ):
+            mock_span = MagicMock()
+            mock_span.end = MagicMock()
+            mock_span.set_attribute = MagicMock()
+            mock_tracer.return_value.start_span.return_value = mock_span
+
+            await process_agent_turn(
+                thread_id="thread-123",
+                message="Investigate checkout cache",
+                task_id="provided-task-123",
+            )
+
+        _, kwargs = mock_run_agent.await_args
+        assert kwargs["agent_context"]["instance_id"] == "redis-prod-checkout-cache"
+        assert kwargs["agent_context"]["attached_target_handles"] == ["tgt_01"]
+        assert kwargs["agent_context"]["target_toolset_generation"] == 3
 
 
 class TestRunAgentWithProgress:

--- a/tests/unit/core/test_tasks.py
+++ b/tests/unit/core/test_tasks.py
@@ -771,6 +771,54 @@ class TestProcessKnowledgeQuery:
         assert history[1].content == "It copies writes to replicas."
 
     @pytest.mark.asyncio
+    async def test_process_knowledge_query_excludes_duplicate_latest_user_message(self):
+        mock_redis = AsyncMock()
+        mock_task_manager = AsyncMock()
+        mock_task_manager.update_task_status = AsyncMock()
+        mock_task_manager.set_task_result = AsyncMock()
+        mock_thread_manager = AsyncMock()
+        mock_thread_manager.get_thread = AsyncMock(
+            return_value=Thread(
+                thread_id="thread-456",
+                messages=[
+                    Message(role="user", content="How does replication work?"),
+                    Message(role="assistant", content="It copies writes to replicas."),
+                    Message(role="user", content="What about failover?"),
+                ],
+                context={},
+                metadata=ThreadMetadata(),
+            )
+        )
+        mock_thread_manager.append_messages = AsyncMock()
+
+        agent_response = AgentResponse(response="Follow-up answer", search_results=[])
+        mock_agent = AsyncMock()
+        mock_agent.process_query = AsyncMock(return_value=agent_response)
+
+        with (
+            patch("redis_sre_agent.core.docket_tasks.get_redis_client", return_value=mock_redis),
+            patch("redis_sre_agent.core.docket_tasks.TaskManager", return_value=mock_task_manager),
+            patch(
+                "redis_sre_agent.core.docket_tasks.ThreadManager", return_value=mock_thread_manager
+            ),
+            patch("redis_sre_agent.core.docket_tasks.get_chat_agent", return_value=mock_agent),
+            patch("redis_sre_agent.core.docket_tasks.TaskEmitter"),
+        ):
+            await process_knowledge_query(
+                query="What about failover?",
+                task_id="task-123",
+                thread_id="thread-456",
+                user_id="user-1",
+            )
+
+        _, kwargs = mock_agent.process_query.call_args
+        history = kwargs["conversation_history"]
+        assert history is not None
+        assert len(history) == 2
+        assert history[0].content == "How does replication work?"
+        assert history[1].content == "It copies writes to replicas."
+
+    @pytest.mark.asyncio
     async def test_process_knowledge_query_respects_configured_max_iterations(self):
         mock_redis = AsyncMock()
         mock_task_manager = AsyncMock()

--- a/tests/unit/core/test_tasks.py
+++ b/tests/unit/core/test_tasks.py
@@ -764,6 +764,40 @@ class TestProcessKnowledgeQuery:
         assert isinstance(history[1], AIMessage)
         assert history[1].content == "It copies writes to replicas."
 
+    @pytest.mark.asyncio
+    async def test_process_knowledge_query_respects_configured_max_iterations(self):
+        mock_redis = AsyncMock()
+        mock_task_manager = AsyncMock()
+        mock_task_manager.update_task_status = AsyncMock()
+        mock_task_manager.set_task_result = AsyncMock()
+        mock_thread_manager = AsyncMock()
+        mock_thread_manager.get_thread = AsyncMock(return_value=None)
+        mock_thread_manager.append_messages = AsyncMock()
+
+        agent_response = AgentResponse(response="Answer", search_results=[])
+        mock_agent = AsyncMock()
+        mock_agent.process_query = AsyncMock(return_value=agent_response)
+
+        with (
+            patch("redis_sre_agent.core.docket_tasks.get_redis_client", return_value=mock_redis),
+            patch("redis_sre_agent.core.docket_tasks.TaskManager", return_value=mock_task_manager),
+            patch(
+                "redis_sre_agent.core.docket_tasks.ThreadManager", return_value=mock_thread_manager
+            ),
+            patch("redis_sre_agent.core.docket_tasks.get_chat_agent", return_value=mock_agent),
+            patch("redis_sre_agent.core.docket_tasks.TaskEmitter"),
+            patch("redis_sre_agent.core.docket_tasks.settings.max_iterations", 5),
+        ):
+            await process_knowledge_query(
+                query="What are Redis best practices?",
+                task_id="task-123",
+                thread_id="thread-456",
+                user_id="user-1",
+            )
+
+        _, kwargs = mock_agent.process_query.call_args
+        assert kwargs["max_iterations"] == 5
+
 
 def test_thread_messages_to_conversation_history_filters_non_dialog_roles():
     history = _thread_messages_to_conversation_history(

--- a/tests/unit/core/test_tasks.py
+++ b/tests/unit/core/test_tasks.py
@@ -4,11 +4,13 @@ from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
+from langchain_core.messages import AIMessage, HumanMessage
 from redisvl.query import VectorRangeQuery
 
 from redis_sre_agent.agent.models import AgentResponse
 from redis_sre_agent.core.docket_tasks import (
     SRE_TASK_COLLECTION,
+    _thread_messages_to_conversation_history,
     get_redis_url,
     ingest_sre_document,
     process_agent_turn,
@@ -22,6 +24,7 @@ from redis_sre_agent.core.docket_tasks import (
     test_task_system,
 )
 from redis_sre_agent.core.tasks import TaskStatus
+from redis_sre_agent.core.threads import Message, Thread, ThreadMetadata
 
 
 class TestSRETaskCollection:
@@ -590,6 +593,14 @@ class TestProcessKnowledgeQuery:
         mock_task_manager.update_task_status = AsyncMock()
         mock_task_manager.set_task_result = AsyncMock()
         mock_thread_manager = AsyncMock()
+        mock_thread_manager.get_thread = AsyncMock(
+            return_value=Thread(
+                thread_id="thread-456",
+                messages=[],
+                context={},
+                metadata=ThreadMetadata(),
+            )
+        )
         mock_thread_manager.append_messages = AsyncMock()
 
         mock_agent = AsyncMock()
@@ -614,6 +625,8 @@ class TestProcessKnowledgeQuery:
         assert result["response"] == "Knowledge response"
         mock_task_manager.update_task_status.assert_any_call("task-123", TaskStatus.IN_PROGRESS)
         mock_task_manager.update_task_status.assert_any_call("task-123", TaskStatus.DONE)
+        _, kwargs = mock_agent.process_query.call_args
+        assert kwargs["conversation_history"] is None
 
     @pytest.mark.asyncio
     async def test_process_knowledge_query_error(self):
@@ -623,6 +636,7 @@ class TestProcessKnowledgeQuery:
         mock_task_manager.update_task_status = AsyncMock()
         mock_task_manager.set_task_error = AsyncMock()
         mock_thread_manager = AsyncMock()
+        mock_thread_manager.get_thread = AsyncMock(return_value=None)
 
         mock_agent = AsyncMock()
         mock_agent.process_query = AsyncMock(side_effect=Exception("Knowledge error"))
@@ -658,6 +672,7 @@ class TestProcessKnowledgeQuery:
         mock_task_manager.update_task_status = AsyncMock()
         mock_task_manager.set_task_result = AsyncMock()
         mock_thread_manager = AsyncMock()
+        mock_thread_manager.get_thread = AsyncMock(return_value=None)
         mock_thread_manager.append_messages = AsyncMock()
 
         # Return an actual AgentResponse object (not a string)
@@ -698,6 +713,70 @@ class TestProcessKnowledgeQuery:
         assert len(messages) == 1
         assert messages[0]["content"] == "Knowledge response text"
         assert isinstance(messages[0]["content"], str)
+
+    @pytest.mark.asyncio
+    async def test_process_knowledge_query_passes_conversation_history(self):
+        """Compatibility path should preserve thread conversation history."""
+        mock_redis = AsyncMock()
+        mock_task_manager = AsyncMock()
+        mock_task_manager.update_task_status = AsyncMock()
+        mock_task_manager.set_task_result = AsyncMock()
+        mock_thread_manager = AsyncMock()
+        mock_thread_manager.get_thread = AsyncMock(
+            return_value=Thread(
+                thread_id="thread-456",
+                messages=[
+                    Message(role="user", content="How does replication work?"),
+                    Message(role="assistant", content="It copies writes to replicas."),
+                ],
+                context={},
+                metadata=ThreadMetadata(),
+            )
+        )
+        mock_thread_manager.append_messages = AsyncMock()
+
+        agent_response = AgentResponse(response="Follow-up answer", search_results=[])
+        mock_agent = AsyncMock()
+        mock_agent.process_query = AsyncMock(return_value=agent_response)
+
+        with (
+            patch("redis_sre_agent.core.docket_tasks.get_redis_client", return_value=mock_redis),
+            patch("redis_sre_agent.core.docket_tasks.TaskManager", return_value=mock_task_manager),
+            patch(
+                "redis_sre_agent.core.docket_tasks.ThreadManager", return_value=mock_thread_manager
+            ),
+            patch("redis_sre_agent.core.docket_tasks.get_chat_agent", return_value=mock_agent),
+            patch("redis_sre_agent.core.docket_tasks.TaskEmitter"),
+        ):
+            await process_knowledge_query(
+                query="What about failover?",
+                task_id="task-123",
+                thread_id="thread-456",
+                user_id="user-1",
+            )
+
+        _, kwargs = mock_agent.process_query.call_args
+        history = kwargs["conversation_history"]
+        assert history is not None
+        assert len(history) == 2
+        assert isinstance(history[0], HumanMessage)
+        assert history[0].content == "How does replication work?"
+        assert isinstance(history[1], AIMessage)
+        assert history[1].content == "It copies writes to replicas."
+
+
+def test_thread_messages_to_conversation_history_filters_non_dialog_roles():
+    history = _thread_messages_to_conversation_history(
+        [
+            Message(role="user", content="Question"),
+            Message(role="assistant", content="Answer"),
+            Message(role="system", content="Ignored"),
+        ]
+    )
+
+    assert len(history) == 2
+    assert isinstance(history[0], HumanMessage)
+    assert isinstance(history[1], AIMessage)
 
 
 class TestSchedulerTask:

--- a/tests/unit/core/test_tasks.py
+++ b/tests/unit/core/test_tasks.py
@@ -601,9 +601,7 @@ class TestProcessKnowledgeQuery:
             patch(
                 "redis_sre_agent.core.docket_tasks.ThreadManager", return_value=mock_thread_manager
             ),
-            patch(
-                "redis_sre_agent.agent.knowledge_agent.KnowledgeOnlyAgent", return_value=mock_agent
-            ),
+            patch("redis_sre_agent.core.docket_tasks.get_chat_agent", return_value=mock_agent),
             patch("redis_sre_agent.core.docket_tasks.TaskEmitter"),
         ):
             result = await process_knowledge_query(
@@ -635,9 +633,7 @@ class TestProcessKnowledgeQuery:
             patch(
                 "redis_sre_agent.core.docket_tasks.ThreadManager", return_value=mock_thread_manager
             ),
-            patch(
-                "redis_sre_agent.agent.knowledge_agent.KnowledgeOnlyAgent", return_value=mock_agent
-            ),
+            patch("redis_sre_agent.core.docket_tasks.get_chat_agent", return_value=mock_agent),
             patch("redis_sre_agent.core.docket_tasks.TaskEmitter"),
         ):
             with pytest.raises(Exception, match="Knowledge error"):
@@ -678,9 +674,7 @@ class TestProcessKnowledgeQuery:
             patch(
                 "redis_sre_agent.core.docket_tasks.ThreadManager", return_value=mock_thread_manager
             ),
-            patch(
-                "redis_sre_agent.agent.knowledge_agent.KnowledgeOnlyAgent", return_value=mock_agent
-            ),
+            patch("redis_sre_agent.core.docket_tasks.get_chat_agent", return_value=mock_agent),
             patch("redis_sre_agent.core.docket_tasks.TaskEmitter"),
         ):
             result = await process_knowledge_query(
@@ -930,13 +924,13 @@ class TestProcessAgentTurn:
         mock_task_manager.set_task_result = AsyncMock()
         mock_task_manager.set_task_error = AsyncMock()
 
-        mock_knowledge_agent = AsyncMock()
+        mock_chat_agent = AsyncMock()
         mock_response = AgentResponse(
-            response="Knowledge response",
+            response="Chat response",
             search_results=[],
             tool_envelopes=[{"name": "redis_info", "status": "success"}],
         )
-        mock_knowledge_agent.process_query = AsyncMock(return_value=mock_response)
+        mock_chat_agent.process_query = AsyncMock(return_value=mock_response)
 
         with (
             patch("redis_sre_agent.core.docket_tasks.get_redis_client", return_value=mock_redis),
@@ -949,8 +943,8 @@ class TestProcessAgentTurn:
                 return_value=None,
             ),
             patch(
-                "redis_sre_agent.agent.knowledge_agent.KnowledgeOnlyAgent",
-                return_value=mock_knowledge_agent,
+                "redis_sre_agent.core.docket_tasks.get_chat_agent",
+                return_value=mock_chat_agent,
             ),
             patch(
                 "redis_sre_agent.core.docket_tasks.ULID", return_value="01HXTESTMESSAGEID1234567890"

--- a/tests/unit/tools/test_manager.py
+++ b/tests/unit/tools/test_manager.py
@@ -7,6 +7,8 @@ import pytest
 
 from redis_sre_agent.core.clusters import RedisCluster, RedisClusterType
 from redis_sre_agent.core.config import MCPServerConfig
+from redis_sre_agent.core.instances import RedisInstance
+from redis_sre_agent.core.targets import TargetBinding
 from redis_sre_agent.tools.manager import ToolManager, _command_is_available
 from redis_sre_agent.tools.models import ToolCapability, ToolDefinition
 
@@ -45,6 +47,7 @@ async def test_tool_manager_knowledge_tools():
 
         # Knowledge tools (always loaded)
         assert len(knowledge_tools) == 8
+        assert any("target_discovery_" in n and "resolve_redis_targets" in n for n in tool_names)
         assert any("search" in n for n in knowledge_tools)
         assert any("ingest" in n for n in knowledge_tools)
         assert any("get_all_fragments" in n for n in knowledge_tools)
@@ -62,6 +65,44 @@ async def test_tool_manager_knowledge_tools():
         # Instance-specific tools should NOT be loaded without an instance
         assert len(prometheus_tools) == 0
         assert len(redis_command_tools) == 0
+
+
+@pytest.mark.asyncio
+async def test_attach_bound_targets_scopes_instance_tools_to_opaque_handle():
+    """Attached targets should re-scope providers to the opaque target handle."""
+    binding = TargetBinding(
+        target_handle="tgt_opaque_1",
+        target_kind="instance",
+        resource_id="inst-1",
+        display_name="checkout-cache-prod",
+        capabilities=["redis", "diagnostics"],
+    )
+    instance = RedisInstance(
+        id="inst-1",
+        name="checkout-cache-prod",
+        connection_url="redis://localhost:6379",
+        environment="production",
+        usage="cache",
+        description="test",
+        instance_type="oss_single",
+    )
+
+    mgr = ToolManager()
+    mgr._toolset_generation = 1
+    with (
+        patch(
+            "redis_sre_agent.core.instances.get_instance_by_id",
+            new=AsyncMock(return_value=instance),
+        ),
+        patch.object(mgr, "_load_instance_scoped_providers", new=AsyncMock()) as mock_load,
+    ):
+        attached = await mgr.attach_bound_targets([binding])
+
+    assert attached == [binding]
+    scoped_instance = mock_load.await_args.args[0]
+    assert scoped_instance.id == "tgt_opaque_1"
+    assert scoped_instance.name == "checkout-cache-prod"
+    assert mgr.get_toolset_generation() == 2
 
 
 @pytest.mark.asyncio
@@ -298,7 +339,7 @@ class TestToolManagerMcpConfigValidation:
                 }
                 await mgr._load_mcp_providers()
 
-            assert "mcp:github" not in mgr._loaded_provider_paths
+            assert "mcp:github" not in mgr._loaded_provider_keys
             assert "Skipping MCP provider 'github'" in caplog.text
         finally:
             await mgr._stack.__aexit__(None, None, None)

--- a/tests/unit/tools/test_tool_manager_protocols.py
+++ b/tests/unit/tools/test_tool_manager_protocols.py
@@ -39,6 +39,8 @@ async def test_protocol_selection_for_utilities_subset():
             # Skip MCP tools which have a different naming convention (mcp_servername_hash_toolname)
             if t.name.startswith("mcp_"):
                 continue
+            if t.name.startswith("target_discovery_"):
+                continue
             assert t.name.startswith("utilities_"), f"Unexpected provider prefix: {t.name}"
             parts = t.name.split("_", 2)
             op = parts[2] if len(parts) >= 3 else parts[-1]


### PR DESCRIPTION
## Problem
The agent currently depends on explicit `instance_id` or `cluster_id` inputs to access live Redis tooling. That creates two gaps:

1. Users cannot naturally describe targets in plain language and have the agent discover the right cluster or database.
2. Tool binding is too static: the agent does not have a first-class way to start with base tools, discover scope, and then attach authenticated target-specific tools safely.

Our goal is to support user-provided target discovery tools, while providing a reference implementation backed by the `RedisInstance` and `RedisCluster` records already stored by the agent. The runtime should be able to resolve targets from safe metadata, keep credentials below the LLM boundary, and dynamically bind the right authenticated tools after a target is chosen.

## This PR
- add a unified `sre_targets` catalog and deterministic natural-language resolver built from `RedisInstance` and `RedisCluster` metadata
- add an always-on `TargetDiscoveryToolProvider` with `resolve_redis_targets` as the reference implementation for target discovery
- return only secret-safe match metadata plus opaque target handles, and persist attached bindings in thread state
- extend `ToolManager` so it can attach target-scoped providers dynamically after discovery and rebuild the bound toolset mid-conversation
- route zero-scope chat through the default chat path, and allow deep triage to pre-resolve target scope before running heavier diagnostics
- add Redis-backed unit and integration coverage for catalog indexing, resolution, attachment, and follow-up tool use

## Why This Shape
This PR is intentionally a reference implementation. It proves the end-to-end flow using the existing `RedisInstance` and `RedisCluster` models as the source of truth for safe metadata and stored credentials, while keeping the model-facing contract generic:

- discovery returns safe matches and opaque handles
- runtime state stores bindings, not secrets
- authenticated tools are attached server-side after resolution

That gives us a concrete path to support user-provided discovery tools later, including external MCP-based discovery, without changing the model-facing workflow.

## Follow-Up PR
The next PR should generalize the interfaces introduced here so deployments can customize both discovery and binding behavior. In particular, it should:

- formalize a pluggable target discovery contract so the reference implementation is only one option
- support user-provided target discovery tools, especially MCP-based discovery tools
- formalize the authenticated target binding contract so deployments can customize how resolved targets become live tool bindings
- separate the generic target-handle workflow from the current `RedisInstance` and `RedisCluster`-backed binding logic
- introduce the runtime abstraction for constructing authenticated clients from resolved targets without exposing credentials to the LLM
