### PR TITLE
Pin UI Vite to stabilize fresh Docker builds

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -25,7 +25,7 @@
         "postcss": "^8.5.3",
         "tailwindcss": "^4.1.6",
         "typescript": "~5.8.3",
-        "vite": "^6.3.5"
+        "vite": "6.4.2"
       }
     },
     "../ui-kit": {
@@ -9860,9 +9860,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
-      "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
+      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10493,7 +10493,7 @@
         "tailwindcss": "^4.1.6",
         "typescript": "~5.8.3",
         "typescript-eslint": "^8.30.1",
-        "vite": "^6.4.1",
+        "vite": "6.4.2",
         "vite-plugin-dts": "^4.5.3",
         "vitest": "^3.1.3"
       },

--- a/ui/package.json
+++ b/ui/package.json
@@ -32,6 +32,6 @@
     "postcss": "^8.5.3",
     "tailwindcss": "^4.1.6",
     "typescript": "~5.8.3",
-    "vite": "^6.3.5"
+    "vite": "6.4.2"
   }
 }

--- a/ui/ui-kit/package-lock.json
+++ b/ui/ui-kit/package-lock.json
@@ -46,7 +46,7 @@
         "tailwindcss": "^4.1.6",
         "typescript": "~5.8.3",
         "typescript-eslint": "^8.30.1",
-        "vite": "^6.4.1",
+        "vite": "6.4.2",
         "vite-plugin-dts": "^4.5.3",
         "vitest": "^3.1.3"
       },
@@ -8403,9 +8403,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
-      "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
+      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/ui/ui-kit/package.json
+++ b/ui/ui-kit/package.json
@@ -94,7 +94,7 @@
     "tailwindcss": "^4.1.6",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.30.1",
-    "vite": "^6.4.1",
+    "vite": "6.4.2",
     "vite-plugin-dts": "^4.5.3",
     "vitest": "^3.1.3"
   },


### PR DESCRIPTION
## Summary
Pin Vite exactly in the UI app and `ui-kit` so fresh installs and Docker builds do not drift when a new patch release is published after merge.

## Root cause
The UI manifests used floating Vite ranges while the committed lockfiles still referenced the previously resolved patch release. After `vite` `6.4.2` was published on April 6, 2026, fresh `npm ci` runs in Docker started rejecting the stale lockfiles.

## What changed
- pin `vite` to `6.4.2` in `ui/package.json`
- pin `vite` to `6.4.2` in `ui/ui-kit/package.json`
- regenerate `ui/package-lock.json`
- regenerate `ui/ui-kit/package-lock.json`

## Validation
- `cd ui/ui-kit && npm ci --ignore-scripts`
- `cd ui && npm ci --ignore-scripts`
- `docker compose build`

## Impact
This keeps the reviewed lockfiles aligned with fresh installs for the Docker-critical frontend build path, preventing the same post-merge patch-drift failure from recurring for Vite.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency pin/lockfile update; primary impact is on frontend build tooling and install reproducibility.
> 
> **Overview**
> Pins `vite` to the exact version `6.4.2` (instead of a caret range) in both the `ui` app and `ui-kit` package manifests to prevent patch-version drift.
> 
> Updates the corresponding `package-lock.json` files so `npm ci`/Docker builds resolve consistently with the pinned Vite version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c4353197e9cf08607022b140addc14ab330cf9ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->