### PR TITLE
Keep MCP stdio logs off stdout

### DIFF
--- a/redis_sre_agent/cli/mcp.py
+++ b/redis_sre_agent/cli/mcp.py
@@ -1,5 +1,8 @@
 """MCP server CLI commands."""
 
+import logging
+import sys
+
 import click
 
 
@@ -7,6 +10,22 @@ import click
 def mcp():
     """MCP server commands - expose agent capabilities via Model Context Protocol."""
     pass
+
+
+def _configure_stdio_logging() -> None:
+    """Reserve stdout for MCP protocol traffic before importing server dependencies.
+
+    Some dependencies configure root logging at import time and default to stdout.
+    In stdio transport that corrupts the JSON-RPC stream, so force logs to stderr
+    before importing the MCP server module.
+    """
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(name)s %(levelname)s   %(message)s",
+        datefmt="%H:%M:%S",
+        stream=sys.stderr,
+        force=True,
+    )
 
 
 @mcp.command("serve")
@@ -57,17 +76,22 @@ def serve(transport: str, host: str, port: int):
       # Run in SSE mode (legacy, for older clients)
       redis-sre-agent mcp serve --transport sse --port 8081
     """
-    from redis_sre_agent.mcp_server.server import run_http, run_sse, run_stdio
-
     if transport == "stdio":
+        _configure_stdio_logging()
+        from redis_sre_agent.mcp_server.server import run_stdio
+
         # Don't print anything to stdout in stdio mode - it corrupts the JSON-RPC stream
         run_stdio()
     elif transport == "http":
+        from redis_sre_agent.mcp_server.server import run_http
+
         click.echo(f"Starting MCP server in HTTP mode on {host}:{port}...")
         click.echo(f"MCP endpoint: http://{host}:{port}/mcp")
         click.echo("Add this URL as a Custom Connector in Claude settings.")
         run_http(host=host, port=port)
     else:
+        from redis_sre_agent.mcp_server.server import run_sse
+
         click.echo(f"Starting MCP server in SSE mode on {host}:{port}...")
         run_sse(host=host, port=port)
 

--- a/tests/unit/cli/test_cli_mcp.py
+++ b/tests/unit/cli/test_cli_mcp.py
@@ -1,5 +1,7 @@
 """Unit tests for MCP CLI commands."""
 
+import logging
+import sys
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -36,6 +38,27 @@ class TestMCPServeCLI:
 
             # stdio mode doesn't print anything
             mock_run.assert_called_once()
+
+    def test_serve_stdio_routes_logs_to_stderr(self, cli_runner):
+        """Test that stdio mode reserves stdout for JSON-RPC traffic."""
+        root_logger = logging.getLogger()
+        original_handlers = root_logger.handlers[:]
+        original_level = root_logger.level
+        try:
+            root_logger.handlers.clear()
+            root_logger.setLevel(logging.WARNING)
+
+            with patch("redis_sre_agent.mcp_server.server.run_stdio") as mock_run:
+                result = cli_runner.invoke(mcp, ["serve"])
+
+            assert result.exit_code == 0
+            mock_run.assert_called_once()
+            assert root_logger.handlers
+            assert root_logger.handlers[0].stream is not sys.stdout
+            assert getattr(root_logger.handlers[0].stream, "name", "") == "<stderr>"
+        finally:
+            root_logger.handlers = original_handlers
+            root_logger.setLevel(original_level)
 
     def test_serve_http_mode(self, cli_runner):
         """Test serve in HTTP mode."""


### PR DESCRIPTION
## Summary
- force stdio MCP logging onto `stderr` before importing server dependencies
- avoid RedisVL import-time logging from claiming `stdout` during stdio MCP startup
- add a regression test that asserts stdio mode reserves `stdout` for JSON-RPC

## Root cause
`redis_sre_agent.core.targets` imports `redisvl.query` at module import time. `redisvl.query` initializes logging via `redisvl.utils.log.get_logger()`, which calls `logging.basicConfig(..., stream=sys.stdout)` when no handlers are configured. In `redis-sre-agent mcp serve` stdio mode that polluted the MCP protocol stream, causing JSON-RPC parse failures like `invalid number at line 1 column 2`.

## Fix
In stdio mode, configure root logging to `stderr` before importing `redis_sre_agent.mcp_server.server`. That keeps `stdout` reserved for MCP frames and makes RedisVL's later `basicConfig()` a no-op.

## Verification
- `uv run pytest tests/unit/cli/test_cli_mcp.py`
- direct MCP repro with a Python client: `initialize`, `list_tools`, and `redis_sre_general_chat` now complete without any `Failed to parse JSONRPC message from server` errors

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are isolated to the `mcp serve` CLI path and only affect logging/stdio behavior, with a unit test to prevent stdout corruption in stdio mode.
> 
> **Overview**
> Ensures `redis-sre-agent mcp serve` in *stdio* mode keeps `stdout` reserved for MCP JSON-RPC frames by configuring root logging to `stderr` **before** importing MCP server dependencies.
> 
> Refactors the `serve` command to import `run_stdio`/`run_http`/`run_sse` only in their respective transport branches, and adds a regression test asserting stdio startup attaches a non-stdout log handler.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1542b3d6b060a8284ad8028e5168f918a9e8683f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->