### PR TITLE
Fix UI example build wiring and dev startup

### DIFF
--- a/ui/example/package-lock.json
+++ b/ui/example/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@radar/ui-kit-example",
       "version": "0.0.0",
       "dependencies": {
-        "@radar/ui-kit": "file:..",
+        "@radar/ui-kit": "file:../ui-kit",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-router-dom": "^7.6.0"
@@ -52,7 +52,58 @@
         "postcss": "^8.5.3",
         "tailwindcss": "^4.1.6",
         "typescript": "~5.8.3",
-        "vite": "^6.3.5"
+        "vite": "6.4.2"
+      }
+    },
+    "../ui-kit": {
+      "name": "@radar/ui-kit",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
+      },
+      "devDependencies": {
+        "@eslint/js": "^9.25.0",
+        "@storybook/addon-essentials": "^8.5.6",
+        "@storybook/addon-interactions": "^8.5.6",
+        "@storybook/addon-links": "^8.5.6",
+        "@storybook/blocks": "^8.5.6",
+        "@storybook/react": "^8.5.6",
+        "@storybook/react-vite": "^8.5.6",
+        "@storybook/test": "^8.5.6",
+        "@tailwindcss/postcss": "^4.1.6",
+        "@testing-library/jest-dom": "^6.9.0",
+        "@testing-library/react": "^16.3.0",
+        "@testing-library/user-event": "^14.6.1",
+        "@types/node": "^22.15.17",
+        "@types/react": "^19.1.3",
+        "@types/react-dom": "^19.1.3",
+        "@vitejs/plugin-react": "^4.4.1",
+        "@vitest/coverage-v8": "^3.1.3",
+        "autoprefixer": "^10.4.21",
+        "eslint": "^9.25.0",
+        "eslint-config-prettier": "^9.1.0",
+        "eslint-plugin-prettier": "^5.1.3",
+        "eslint-plugin-react-hooks": "^5.2.0",
+        "eslint-plugin-react-refresh": "^0.4.19",
+        "globals": "^16.0.0",
+        "jsdom": "^26.1.0",
+        "postcss": "^8.5.3",
+        "prettier": "^3.2.5",
+        "prettier-plugin-tailwindcss": "^0.5.11",
+        "sort-package-json": "^3.4.0",
+        "storybook": "^8.6.17",
+        "tailwindcss": "^4.1.6",
+        "typescript": "~5.8.3",
+        "typescript-eslint": "^8.30.1",
+        "vite": "6.4.2",
+        "vite-plugin-dts": "^4.5.3",
+        "vitest": "^3.1.3"
+      },
+      "peerDependencies": {
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -1117,7 +1168,7 @@
       }
     },
     "node_modules/@radar/ui-kit": {
-      "resolved": "..",
+      "resolved": "../ui-kit",
       "link": true
     },
     "node_modules/@rolldown/pluginutils": {

--- a/ui/example/package.json
+++ b/ui/example/package.json
@@ -4,14 +4,18 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "build:ui-kit": "npm --prefix ../ui-kit ci --ignore-scripts --no-audit --no-fund && npm --prefix ../ui-kit run build",
     "build": "tsc -b && vite build",
     "dev": "vite",
     "lint": "eslint .",
     "preview": "vite preview",
+    "prebuild": "npm run build:ui-kit",
+    "predev": "npm run build:ui-kit",
+    "pretypecheck": "npm run build:ui-kit",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@radar/ui-kit": "file:..",
+    "@radar/ui-kit": "file:../ui-kit",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router-dom": "^7.6.0"

--- a/ui/example/src/index.css
+++ b/ui/example/src/index.css
@@ -1,5 +1,5 @@
 /* UI Kit styles */
-@import '../../src/styles/index.css';
+@import '../../ui-kit/src/styles/index.css';
 
 /* Custom application styles */
 body {

--- a/ui/example/src/main.tsx
+++ b/ui/example/src/main.tsx
@@ -3,7 +3,6 @@ import { createRoot } from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import { ThemeProvider } from '@radar/ui-kit';
 import App from './App';
-import TestApp from './TestApp';
 
 // Import styles (includes UI Kit styles)
 import './index.css';
@@ -33,7 +32,6 @@ class ErrorBoundary extends React.Component<{children: React.ReactNode}, {hasErr
   }
 }
 
-// Try the real App now
 const CurrentApp = App;
 
 createRoot(document.getElementById('root')!).render(

--- a/ui/example/src/pages/AdvancedForms.tsx
+++ b/ui/example/src/pages/AdvancedForms.tsx
@@ -551,8 +551,7 @@ const AdvancedForms = () => {
 
 // Dynamic Form Example Component
 const DynamicFormExample = () => {
-  const [formType] = useState<'user' | 'organization' | 'api'>('user');
-  const [conditionalFields, setConditionalFields] = useState<FormFieldConfig[]>([]);
+  const [formType, setFormType] = useState<'user' | 'organization' | 'api'>('user');
 
   const baseFields: FormFieldConfig[] = [
     {
@@ -619,22 +618,12 @@ const DynamicFormExample = () => {
     }
   ];
 
-  const handleFormTypeChange = (data: Record<string, any>) => {
-    const type = data.formType as 'user' | 'organization' | 'api';
-    setFormType(type);
-
-    switch (type) {
-      case 'user':
-        setConditionalFields(userFields);
-        break;
-      case 'organization':
-        setConditionalFields(organizationFields);
-        break;
-      case 'api':
-        setConditionalFields(apiFields);
-        break;
-    }
-  };
+  const conditionalFields =
+    formType === 'organization'
+      ? organizationFields
+      : formType === 'api'
+        ? apiFields
+        : userFields;
 
   const allFields = [...baseFields, ...conditionalFields];
 
@@ -645,6 +634,10 @@ const DynamicFormExample = () => {
         onSubmit={(data) => {
           console.log('Dynamic form submitted:', data);
           alert('Dynamic form submitted successfully!');
+        }}
+        onChange={(data) => {
+          const nextFormType = data.formType as 'user' | 'organization' | 'api' | undefined;
+          setFormType(nextFormType ?? 'user');
         }}
         submitLabel="Submit Dynamic Form"
         layout="vertical"

--- a/ui/example/src/pages/Deployments.tsx
+++ b/ui/example/src/pages/Deployments.tsx
@@ -7,8 +7,6 @@ import {
   Input,
   CollapsibleCard,
   Tooltip,
-  ErrorMessage,
-  Avatar,
   DropdownMenu,
   Loader,
   type CollapsibleSection,

--- a/ui/example/tsconfig.json
+++ b/ui/example/tsconfig.json
@@ -23,8 +23,7 @@
     // Path mapping
     "baseUrl": ".",
     "paths": {
-      "@/*": ["src/*"],
-      "@radar/ui-kit": ["../src/index.ts"]
+      "@/*": ["src/*"]
     }
   },
   "include": ["src"]

--- a/ui/example/vite.config.ts
+++ b/ui/example/vite.config.ts
@@ -7,8 +7,6 @@ export default defineConfig({
   resolve: {
     alias: {
       '@': resolve(__dirname, 'src'),
-      '@radar/ui-kit': resolve(__dirname, '../src/index.ts'),
-      '@radar/ui-kit/styles': resolve(__dirname, '../src/styles/index.css'),
     },
   },
 });

--- a/ui/package.json
+++ b/ui/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "build": "vite build",
-    "dev": "vite",
+    "dev": "vite --force",
     "e2e": "playwright test",
     "e2e:clean": "node scripts/cleanup-e2e.mjs",
     "e2e:headed": "playwright test --headed --project=chromium",

--- a/ui/ui-kit/src/components/Form/Form.test.tsx
+++ b/ui/ui-kit/src/components/Form/Form.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import { Form, type FormFieldConfig } from "./Form";
 
 describe("Form", () => {
@@ -32,5 +32,36 @@ describe("Form", () => {
 
     expect(onChange).toHaveBeenCalledTimes(1);
     expect(onChange).toHaveBeenCalledWith({ formType: "organization" });
+  });
+
+  it("preserves queued field changes in the emitted form state", () => {
+    const onChange = vi.fn();
+    const fields: FormFieldConfig[] = [
+      { name: "firstName", label: "First Name", type: "text" },
+      { name: "lastName", label: "Last Name", type: "text" },
+    ];
+
+    render(
+      <Form
+        fields={fields}
+        initialData={{ firstName: "", lastName: "" }}
+        onChange={onChange}
+        onSubmit={() => {}}
+      />,
+    );
+
+    act(() => {
+      fireEvent.change(screen.getByLabelText("First Name"), {
+        target: { value: "Ada" },
+      });
+      fireEvent.change(screen.getByLabelText("Last Name"), {
+        target: { value: "Lovelace" },
+      });
+    });
+
+    expect(onChange).toHaveBeenLastCalledWith({
+      firstName: "Ada",
+      lastName: "Lovelace",
+    });
   });
 });

--- a/ui/ui-kit/src/components/Form/Form.test.tsx
+++ b/ui/ui-kit/src/components/Form/Form.test.tsx
@@ -1,0 +1,31 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { Form } from "./Form";
+
+describe("Form", () => {
+  it("calls onChange once per field update", () => {
+    const handleChange = vi.fn();
+
+    render(
+      <Form
+        fields={[
+          {
+            name: "name",
+            label: "Name",
+            type: "text",
+          },
+        ]}
+        initialData={{ name: "" }}
+        onSubmit={() => {}}
+        onChange={handleChange}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText("Name"), {
+      target: { value: "Alice" },
+    });
+
+    expect(handleChange).toHaveBeenCalledTimes(1);
+    expect(handleChange).toHaveBeenCalledWith({ name: "Alice" });
+  });
+});

--- a/ui/ui-kit/src/components/Form/Form.tsx
+++ b/ui/ui-kit/src/components/Form/Form.tsx
@@ -32,6 +32,8 @@ export interface FormProps {
   initialData?: Record<string, any>;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   onSubmit: (data: Record<string, any>) => Promise<void> | void;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  onChange?: (data: Record<string, any>) => void;
   onCancel?: () => void;
   submitLabel?: string;
   cancelLabel?: string;
@@ -46,6 +48,7 @@ export const Form: React.FC<FormProps> = ({
   fields,
   initialData = {},
   onSubmit,
+  onChange,
   onCancel,
   submitLabel = "Submit",
   cancelLabel = "Cancel",
@@ -63,10 +66,14 @@ export const Form: React.FC<FormProps> = ({
   const handleFieldChange = useCallback(
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (fieldName: string, value: any) => {
-      setFormData((prev) => ({
-        ...prev,
-        [fieldName]: value,
-      }));
+      setFormData((prev) => {
+        const nextFormData = {
+          ...prev,
+          [fieldName]: value,
+        };
+        onChange?.(nextFormData);
+        return nextFormData;
+      });
 
       // Clear field error when user starts typing
       if (errors[fieldName]) {
@@ -77,7 +84,7 @@ export const Form: React.FC<FormProps> = ({
         });
       }
     },
-    [errors],
+    [errors, onChange],
   );
 
   const validateForm = () => {

--- a/ui/ui-kit/src/components/Form/Form.tsx
+++ b/ui/ui-kit/src/components/Form/Form.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef, useState } from "react";
+import React, { useCallback, useRef, useState } from "react";
 import { Button } from "../Button/Button";
 import { ErrorMessage } from "../ErrorMessage/ErrorMessage";
 import { FormField, type Option } from "./FormField";
@@ -64,10 +64,6 @@ export const Form: React.FC<FormProps> = ({
   const formDataRef = useRef<Record<string, any>>(initialData);
   const [errors, setErrors] = useState<Record<string, string>>({});
   const [submitError, setSubmitError] = useState<string>("");
-
-  useEffect(() => {
-    formDataRef.current = formData;
-  }, [formData]);
 
   const handleFieldChange = useCallback(
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/ui/ui-kit/src/components/Form/Form.tsx
+++ b/ui/ui-kit/src/components/Form/Form.tsx
@@ -66,14 +66,13 @@ export const Form: React.FC<FormProps> = ({
   const handleFieldChange = useCallback(
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (fieldName: string, value: any) => {
-      setFormData((prev) => {
-        const nextFormData = {
-          ...prev,
-          [fieldName]: value,
-        };
-        onChange?.(nextFormData);
-        return nextFormData;
-      });
+      const nextFormData = {
+        ...formData,
+        [fieldName]: value,
+      };
+
+      setFormData(nextFormData);
+      onChange?.(nextFormData);
 
       // Clear field error when user starts typing
       if (errors[fieldName]) {
@@ -84,7 +83,7 @@ export const Form: React.FC<FormProps> = ({
         });
       }
     },
-    [errors, onChange],
+    [errors, formData, onChange],
   );
 
   const validateForm = () => {

--- a/ui/ui-kit/src/components/Form/Form.tsx
+++ b/ui/ui-kit/src/components/Form/Form.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 import { Button } from "../Button/Button";
 import { ErrorMessage } from "../ErrorMessage/ErrorMessage";
 import { FormField, type Option } from "./FormField";
@@ -60,16 +60,23 @@ export const Form: React.FC<FormProps> = ({
 }) => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const [formData, setFormData] = useState<Record<string, any>>(initialData);
+  // Keep a synchronous snapshot so consecutive field updates don't clobber each other.
+  const formDataRef = useRef<Record<string, any>>(initialData);
   const [errors, setErrors] = useState<Record<string, string>>({});
   const [submitError, setSubmitError] = useState<string>("");
+
+  useEffect(() => {
+    formDataRef.current = formData;
+  }, [formData]);
 
   const handleFieldChange = useCallback(
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (fieldName: string, value: any) => {
       const nextFormData = {
-        ...formData,
+        ...formDataRef.current,
         [fieldName]: value,
       };
+      formDataRef.current = nextFormData;
       setFormData(nextFormData);
       onChange?.(nextFormData);
 
@@ -82,7 +89,7 @@ export const Form: React.FC<FormProps> = ({
         });
       }
     },
-    [errors, formData, onChange],
+    [errors, onChange],
   );
 
   const validateForm = () => {


### PR DESCRIPTION
## Summary
- fix the `ui/example` local package wiring so the demo app can build against `ui-kit`
- remove stale example code and use `Form` change events for the conditional form demo
- force Vite to refresh optimized deps on `ui` dev startup to avoid the blank-page `Outdated Optimize Dep` failure

## Validation
- `docker run --rm -e HOME=/tmp -e npm_config_cache=/tmp/.npm -v /Users/andrew.brookins/src/tmp/review-redis-sre-agent-main:/src:ro -w /tmp node:20 bash -lc 'cp -a /src /work && cd /work/ui/ui-kit && npm ci --ignore-scripts --no-audit --no-fund && npm test && npm run build && cd /work/ui && npm ci --ignore-scripts --no-audit --no-fund && npm --prefix ./ui-kit run build && npm run build && cd /work/ui/example && npm ci --ignore-scripts --no-audit --no-fund && npm run build'`

## Notes
- intentionally excludes the local docker-compose network workaround used during PR #132 verification

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new `Form` prop and changes internal state update behavior, which could subtly affect consumers relying on previous form update timing; the rest is build/dev wiring and lockfile churn.
> 
> **Overview**
> **Example app build wiring is corrected** by pointing `ui/example` at `file:../ui-kit`, removing `tsconfig`/Vite aliases to `../src`, updating CSS imports, and adding pre-scripts to build `ui-kit` before `dev`/`build`/`typecheck`.
> 
> **UI dev startup is adjusted** by running `vite --force` to avoid stale optimized-deps issues.
> 
> **`ui-kit` `Form` now supports `onChange`** and updates form state via a synchronous ref snapshot to avoid clobbered consecutive field updates; the example’s dynamic form demo is updated to drive conditional fields via `onChange`, and a new `Form.test.tsx` covers the change-emission behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0872aa3c25be9faa7ae521e161793430839b7b7f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->