### PR TITLE
Make target binding pluggable

### DIFF
--- a/redis_sre_agent/core/agent_memory.py
+++ b/redis_sre_agent/core/agent_memory.py
@@ -9,6 +9,7 @@ from typing import Any, Dict, List, Optional
 
 from redis_sre_agent.core.config import settings
 from redis_sre_agent.core.progress import ProgressEmitter
+from redis_sre_agent.core.targets import resolve_binding_subject
 from redis_sre_agent.core.turn_scope import TurnScope
 
 logger = logging.getLogger(__name__)
@@ -576,9 +577,9 @@ async def prepare_agent_turn_memory(
     instance_id = normalized_context.get("instance_id")
     cluster_id = normalized_context.get("cluster_id")
     if not instance_id and turn_scope.single_binding_kind == "instance":
-        instance_id = turn_scope.single_resource_id
+        instance_id = await resolve_binding_subject(turn_scope.single_binding)
     if not cluster_id and turn_scope.single_binding_kind == "cluster":
-        cluster_id = turn_scope.single_resource_id
+        cluster_id = await resolve_binding_subject(turn_scope.single_binding)
     memory_context = await memory_service.prepare_turn_context(
         query=query,
         session_id=session_id,

--- a/redis_sre_agent/core/config.py
+++ b/redis_sre_agent/core/config.py
@@ -109,6 +109,47 @@ class MCPServerConfig(BaseModel):
     )
 
 
+class TargetIntegrationComponentConfig(BaseModel):
+    """Config for a discovery backend, binding strategy, or client factory."""
+
+    class_path: str
+    config: Dict[str, Any] = Field(default_factory=dict)
+
+
+class TargetIntegrationsConfig(BaseModel):
+    """Configuration for pluggable Redis target discovery and binding."""
+
+    default_discovery_backend: str = "redis_catalog"
+    default_binding_strategy: str = "redis_default"
+    discovery_backends: Dict[str, TargetIntegrationComponentConfig] = Field(
+        default_factory=lambda: {
+            "redis_catalog": TargetIntegrationComponentConfig(
+                class_path="redis_sre_agent.targets.redis_catalog.RedisCatalogDiscoveryBackend"
+            )
+        }
+    )
+    binding_strategies: Dict[str, TargetIntegrationComponentConfig] = Field(
+        default_factory=lambda: {
+            "redis_default": TargetIntegrationComponentConfig(
+                class_path="redis_sre_agent.targets.redis_binding.RedisTargetBindingStrategy"
+            )
+        }
+    )
+    client_factories: Dict[str, TargetIntegrationComponentConfig] = Field(
+        default_factory=lambda: {
+            "redis.data": TargetIntegrationComponentConfig(
+                class_path="redis_sre_agent.targets.redis_binding.RedisDataClientFactory"
+            ),
+            "redis.enterprise_admin": TargetIntegrationComponentConfig(
+                class_path="redis_sre_agent.targets.redis_binding.RedisEnterpriseAdminClientFactory"
+            ),
+            "redis.cloud": TargetIntegrationComponentConfig(
+                class_path="redis_sre_agent.targets.redis_binding.RedisCloudClientFactory"
+            ),
+        }
+    )
+
+
 # Load environment variables from .env file if it exists
 # In Docker/production, environment variables are set directly
 ENV_FILE_OPT: str | None = None
@@ -461,6 +502,11 @@ class Settings(BaseSettings):
         "Each key is the server name, and the value is the server configuration. "
         "Example: {'memory': {'command': 'npx', 'args': ['-y', '@modelcontextprotocol/server-memory'], "
         "'tools': {'search_memories': {'capability': 'logs'}}}}",
+    )
+
+    target_integrations: TargetIntegrationsConfig = Field(
+        default_factory=TargetIntegrationsConfig,
+        description="Target discovery/binding integrations used to resolve and attach Redis targets.",
     )
 
     @classmethod

--- a/redis_sre_agent/core/docket_tasks.py
+++ b/redis_sre_agent/core/docket_tasks.py
@@ -78,11 +78,24 @@ async def _ensure_handle_backed_turn_scope(
     normalized_instance_id = str(legacy_instance_id or "").strip() or None
     normalized_cluster_id = str(legacy_cluster_id or "").strip() or None
 
-    if turn_scope.bindings and normalized_instance_id and normalized_cluster_id:
-        # Attached bindings already define the target set. Ignore conflicting
-        # legacy single-target hints so the seed-hint resolver does not raise.
-        normalized_instance_id = None
-        normalized_cluster_id = None
+    if normalized_instance_id and normalized_cluster_id:
+        routing_instance_id = str(routing_context.get("instance_id") or "").strip() or None
+        routing_cluster_id = str(routing_context.get("cluster_id") or "").strip() or None
+
+        if turn_scope.bindings:
+            # Attached bindings already define the target set. Ignore conflicting
+            # legacy single-target hints so the seed-hint resolver does not raise.
+            normalized_instance_id = None
+            normalized_cluster_id = None
+        elif routing_instance_id and not routing_cluster_id:
+            normalized_cluster_id = None
+        elif routing_cluster_id and not routing_instance_id:
+            normalized_instance_id = None
+        else:
+            # Conflicting legacy single-target hints are ambiguous. Drop both
+            # rather than raising while rebuilding handle-backed scope.
+            normalized_instance_id = None
+            normalized_cluster_id = None
 
     needs_materialization = False
     if turn_scope.scope_kind != "target_bindings":

--- a/redis_sre_agent/core/docket_tasks.py
+++ b/redis_sre_agent/core/docket_tasks.py
@@ -78,6 +78,12 @@ async def _ensure_handle_backed_turn_scope(
     normalized_instance_id = str(legacy_instance_id or "").strip() or None
     normalized_cluster_id = str(legacy_cluster_id or "").strip() or None
 
+    if turn_scope.bindings and normalized_instance_id and normalized_cluster_id:
+        # Attached bindings already define the target set. Ignore conflicting
+        # legacy single-target hints so the seed-hint resolver does not raise.
+        normalized_instance_id = None
+        normalized_cluster_id = None
+
     needs_materialization = False
     if turn_scope.scope_kind != "target_bindings":
         needs_materialization = bool(normalized_instance_id or normalized_cluster_id)

--- a/redis_sre_agent/core/docket_tasks.py
+++ b/redis_sre_agent/core/docket_tasks.py
@@ -101,9 +101,8 @@ async def _ensure_handle_backed_turn_scope(
     if turn_scope.scope_kind != "target_bindings":
         needs_materialization = bool(normalized_instance_id or normalized_cluster_id)
     elif turn_scope.bindings:
-        handle_records = await get_target_handle_store().get_records(
-            binding.target_handle for binding in turn_scope.bindings
-        )
+        bound_handles = [binding.target_handle for binding in turn_scope.bindings]
+        handle_records = await get_target_handle_store().get_records(bound_handles)
         needs_materialization = any(
             binding.target_handle not in handle_records for binding in turn_scope.bindings
         )

--- a/redis_sre_agent/core/docket_tasks.py
+++ b/redis_sre_agent/core/docket_tasks.py
@@ -58,6 +58,77 @@ def _thread_messages_to_conversation_history(thread_messages: List[Message]) -> 
     return history
 
 
+async def _ensure_handle_backed_turn_scope(
+    *,
+    turn_scope: TurnScope,
+    routing_context: Dict[str, Any],
+    thread_context: Dict[str, Any],
+    thread_id: str,
+    task_id: str,
+    legacy_instance_id: Optional[str] = None,
+    legacy_cluster_id: Optional[str] = None,
+) -> TurnScope:
+    """Materialize legacy seed-hint scope through private handle records when needed."""
+    from redis_sre_agent.core.targets import (
+        build_seed_hint_candidates,
+        materialize_bound_target_scope,
+    )
+    from redis_sre_agent.targets import get_target_handle_store
+
+    normalized_instance_id = str(legacy_instance_id or "").strip() or None
+    normalized_cluster_id = str(legacy_cluster_id or "").strip() or None
+
+    needs_materialization = False
+    if turn_scope.scope_kind != "target_bindings":
+        needs_materialization = bool(normalized_instance_id or normalized_cluster_id)
+    elif turn_scope.bindings:
+        handle_records = await get_target_handle_store().get_records(
+            binding.target_handle for binding in turn_scope.bindings
+        )
+        needs_materialization = any(
+            binding.target_handle not in handle_records for binding in turn_scope.bindings
+        )
+
+    if not needs_materialization:
+        return turn_scope
+
+    candidates = await build_seed_hint_candidates(
+        bindings=turn_scope.bindings,
+        instance_id=normalized_instance_id,
+        cluster_id=normalized_cluster_id,
+    )
+    if not candidates:
+        return turn_scope
+
+    materialized_scope = await materialize_bound_target_scope(
+        matches=candidates,
+        thread_id=thread_id,
+        task_id=task_id,
+        replace_existing=bool(turn_scope.bindings),
+    )
+    scope_updates = dict(materialized_scope.context_updates)
+    if normalized_instance_id:
+        scope_updates["instance_id"] = normalized_instance_id
+        scope_updates["cluster_id"] = ""
+    elif normalized_cluster_id:
+        scope_updates["cluster_id"] = normalized_cluster_id
+        scope_updates["instance_id"] = ""
+
+    routing_context.update(scope_updates)
+    thread_context.update(scope_updates)
+
+    return TurnScope.from_context(
+        routing_context,
+        thread_id=thread_id,
+        session_id=turn_scope.session_id,
+        seed_hints={
+            key: routing_context[key]
+            for key in ("instance_id", "cluster_id")
+            if routing_context.get(key)
+        },
+    )
+
+
 # NOTE: analyze_system_metrics was removed as it was never actually provided
 # as a tool to the LLM. Metrics/diagnostics will be implemented via the
 # ToolProvider system in a future PR.
@@ -1037,6 +1108,20 @@ async def process_agent_turn(
             routing_context.pop("instance_id", None)
 
         current_scope = _materialize_turn_scope(routing_context)
+        current_scope = await _ensure_handle_backed_turn_scope(
+            turn_scope=current_scope,
+            routing_context=routing_context,
+            thread_context=thread.context,
+            thread_id=thread_id,
+            task_id=task_id,
+            legacy_instance_id=(
+                routing_context.get("instance_id") or current_scope.seed_hints.get("instance_id")
+            ),
+            legacy_cluster_id=(
+                routing_context.get("cluster_id") or current_scope.seed_hints.get("cluster_id")
+            ),
+        )
+        routing_context["turn_scope"] = current_scope.model_dump(mode="json")
 
         requested_agent_type = (context or {}).get("requested_agent_type")
         if requested_agent_type == "triage":

--- a/redis_sre_agent/core/targets.py
+++ b/redis_sre_agent/core/targets.py
@@ -1117,9 +1117,8 @@ async def attach_target_matches(
     current_state = await get_thread_target_state(thread_id)
     binding_service = TargetBindingService()
     handle_store = get_target_handle_store()
-    existing_records = await handle_store.get_records(
-        binding.target_handle for binding in current_state.target_bindings
-    )
+    current_handles = [binding.target_handle for binding in current_state.target_bindings]
+    existing_records = await handle_store.get_records(current_handles)
     existing_by_subject: Dict[tuple[str, str], TargetBinding] = {}
     for binding in current_state.target_bindings:
         record = existing_records.get(binding.target_handle)

--- a/redis_sre_agent/core/targets.py
+++ b/redis_sre_agent/core/targets.py
@@ -21,6 +21,7 @@ from redis_sre_agent.targets import (
     TargetBindingService,
     TargetDiscoveryService,
     get_target_handle_store,
+    get_target_integration_registry,
 )
 from redis_sre_agent.targets.contracts import (
     DiscoveryCandidate,
@@ -998,6 +999,7 @@ async def build_seed_hint_candidates(
     if instance_id and cluster_id:
         raise ValueError("Please provide only one of instance_id or cluster_id")
 
+    registry = get_target_integration_registry()
     candidates: List[DiscoveryCandidate] = []
     seen: set[tuple[str, str]] = set()
 
@@ -1045,14 +1047,12 @@ async def build_seed_hint_candidates(
             )
 
         candidates.append(
-            DiscoveryCandidate(
-                public_match=public_match,
-                binding_strategy="redis_default",
+            DiscoveryCandidate.from_public_match(
+                public_match,
+                binding_strategy=registry.default_binding_strategy,
                 binding_subject=subject,
                 private_binding_ref={"target_kind": kind, "seed_hint": True},
-                discovery_backend="redis_catalog",
-                score=public_match.score,
-                confidence=public_match.confidence,
+                discovery_backend=registry.default_discovery_backend,
             )
         )
 

--- a/redis_sre_agent/core/targets.py
+++ b/redis_sre_agent/core/targets.py
@@ -977,8 +977,6 @@ def build_public_match_from_doc(
         public_metadata={
             key: value
             for key, value in {
-                "environment": doc.environment,
-                "target_type": doc.target_type,
                 "usage": doc.usage,
                 "status": doc.status,
             }.items()

--- a/redis_sre_agent/core/targets.py
+++ b/redis_sre_agent/core/targets.py
@@ -958,7 +958,7 @@ async def resolve_target_query(
     )
 
 
-def _build_public_match_from_doc(
+def build_public_match_from_doc(
     doc: TargetCatalogDoc,
     *,
     match_reasons: Optional[Sequence[str]] = None,
@@ -1030,7 +1030,7 @@ async def build_seed_hint_candidates(
                 doc = build_target_doc_from_cluster(cluster)
 
         if doc is not None:
-            public_match = _build_public_match_from_doc(
+            public_match = build_public_match_from_doc(
                 doc,
                 match_reasons=[f"matched {kind}_id"],
             )

--- a/redis_sre_agent/core/targets.py
+++ b/redis_sre_agent/core/targets.py
@@ -90,17 +90,22 @@ ResolvedTargetMatch = PublicTargetMatch
 TargetResolutionResult = DiscoveryResponse
 
 
-def build_single_attached_binding_prompt(binding: TargetBinding) -> str:
-    """Build minimal scope context when richer attached-target prompt loading fails."""
-    capability_text = ", ".join(binding.capabilities or []) or "unspecified"
-    metadata_text = (
+def _format_public_metadata_text(public_metadata: Optional[dict[str, Any]]) -> str:
+    """Render public binding metadata consistently in prompt text."""
+    return (
         ", ".join(
             f"{key}={value}"
-            for key, value in (binding.public_metadata or {}).items()
+            for key, value in (public_metadata or {}).items()
             if value not in (None, "")
         )
         or "none"
     )
+
+
+def build_single_attached_binding_prompt(binding: TargetBinding) -> str:
+    """Build minimal scope context when richer attached-target prompt loading fails."""
+    capability_text = ", ".join(binding.capabilities or []) or "unspecified"
+    metadata_text = _format_public_metadata_text(binding.public_metadata)
     return (
         "ATTACHED TARGET SCOPE: This conversation has 1 attached Redis target.\n"
         "Attached target:\n"
@@ -141,14 +146,7 @@ def build_attached_target_prompt_fallback(
                 continue
 
             capability_text = ", ".join(binding.capabilities or []) or "unspecified"
-            metadata_text = (
-                ", ".join(
-                    f"{key}={value}"
-                    for key, value in (binding.public_metadata or {}).items()
-                    if value not in (None, "")
-                )
-                or "none"
-            )
+            metadata_text = _format_public_metadata_text(binding.public_metadata)
             prompt_lines.append(
                 "- "
                 f"{binding.display_name} [handle={binding.target_handle}, "
@@ -322,14 +320,7 @@ async def build_attached_target_scope_prompt(context: Optional[Dict[str, Any]]) 
                     f"type={instance.instance_type}, capabilities={capability_text}]"
                 )
             else:
-                metadata_text = (
-                    ", ".join(
-                        f"{key}={value}"
-                        for key, value in (binding_summary.public_metadata or {}).items()
-                        if value not in (None, "")
-                    )
-                    or "none"
-                )
+                metadata_text = _format_public_metadata_text(binding_summary.public_metadata)
                 target_lines.append(
                     "- "
                     f"{binding_summary.display_name} [handle={handle}, kind=instance, "
@@ -350,28 +341,14 @@ async def build_attached_target_scope_prompt(context: Optional[Dict[str, Any]]) 
                     f"capabilities={capability_text}]"
                 )
             else:
-                metadata_text = (
-                    ", ".join(
-                        f"{key}={value}"
-                        for key, value in (binding_summary.public_metadata or {}).items()
-                        if value not in (None, "")
-                    )
-                    or "none"
-                )
+                metadata_text = _format_public_metadata_text(binding_summary.public_metadata)
                 target_lines.append(
                     "- "
                     f"{binding_summary.display_name} [handle={handle}, kind=cluster, "
                     f"capabilities={capability_text}, metadata={metadata_text}, state=missing]"
                 )
         else:
-            metadata_text = (
-                ", ".join(
-                    f"{key}={value}"
-                    for key, value in (binding_summary.public_metadata or {}).items()
-                    if value not in (None, "")
-                )
-                or "none"
-            )
+            metadata_text = _format_public_metadata_text(binding_summary.public_metadata)
             target_lines.append(
                 "- "
                 f"{binding_summary.display_name} [handle={handle}, kind={binding_summary.target_kind}, "
@@ -1092,20 +1069,6 @@ async def build_seed_hint_candidates(
         await _append_candidate(target_kind="cluster", binding_subject=cluster_id)
 
     return candidates
-
-
-def build_ephemeral_target_bindings(
-    matches: Sequence[DiscoveryCandidate],
-    *,
-    thread_id: Optional[str] = None,
-    task_id: Optional[str] = None,
-) -> List[TargetBinding]:
-    """Build opaque target handles without persisting them."""
-    service = TargetBindingService()
-    return [
-        service.build_public_binding(match, thread_id=thread_id, task_id=task_id)
-        for match in matches
-    ]
 
 
 async def get_thread_target_state(thread_id: str) -> ThreadTargetState:

--- a/redis_sre_agent/core/targets.py
+++ b/redis_sre_agent/core/targets.py
@@ -6,18 +6,29 @@ import copy
 import inspect
 import logging
 import re
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 from typing import Any, Awaitable, Callable, Dict, Iterable, List, Optional, Sequence
 from urllib.parse import urlparse
 
 from pydantic import BaseModel, Field
 from redisvl.query import CountQuery, FilterQuery
-from ulid import ULID
 
 from redis_sre_agent.core.clusters import RedisCluster, get_cluster_by_id, get_clusters
 from redis_sre_agent.core.instances import RedisInstance, get_instance_by_id, get_instances
 from redis_sre_agent.core.redis import SRE_TARGETS_INDEX, get_redis_client, get_targets_index
 from redis_sre_agent.core.threads import ThreadManager
+from redis_sre_agent.targets import (
+    TargetBindingService,
+    TargetDiscoveryService,
+    get_target_handle_store,
+)
+from redis_sre_agent.targets.contracts import (
+    DiscoveryCandidate,
+    DiscoveryRequest,
+    DiscoveryResponse,
+    PublicTargetBinding,
+    PublicTargetMatch,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -74,31 +85,28 @@ class TargetCatalogDoc(BaseModel):
     user_id: Optional[str] = None
 
 
-class TargetBinding(BaseModel):
-    """Opaque handle persisted in thread context for attached targets."""
-
-    target_handle: str
-    target_kind: str
-    resource_id: str
-    display_name: str
-    capabilities: List[str] = Field(default_factory=list)
-    thread_id: Optional[str] = None
-    task_id: Optional[str] = None
-    created_at: str = Field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
-    expires_at: Optional[str] = Field(
-        default_factory=lambda: (datetime.now(timezone.utc) + timedelta(hours=24)).isoformat()
-    )
+TargetBinding = PublicTargetBinding
+ResolvedTargetMatch = PublicTargetMatch
+TargetResolutionResult = DiscoveryResponse
 
 
 def build_single_attached_binding_prompt(binding: TargetBinding) -> str:
     """Build minimal scope context when richer attached-target prompt loading fails."""
     capability_text = ", ".join(binding.capabilities or []) or "unspecified"
+    metadata_text = (
+        ", ".join(
+            f"{key}={value}"
+            for key, value in (binding.public_metadata or {}).items()
+            if value not in (None, "")
+        )
+        or "none"
+    )
     return (
         "ATTACHED TARGET SCOPE: This conversation has 1 attached Redis target.\n"
         "Attached target:\n"
         f"- {binding.display_name} [handle={binding.target_handle}, "
-        f"kind={binding.target_kind}, resource_id={binding.resource_id}, "
-        f"capabilities={capability_text}]"
+        f"kind={binding.target_kind}, capabilities={capability_text}, "
+        f"metadata={metadata_text}]"
     )
 
 
@@ -133,11 +141,19 @@ def build_attached_target_prompt_fallback(
                 continue
 
             capability_text = ", ".join(binding.capabilities or []) or "unspecified"
+            metadata_text = (
+                ", ".join(
+                    f"{key}={value}"
+                    for key, value in (binding.public_metadata or {}).items()
+                    if value not in (None, "")
+                )
+                or "none"
+            )
             prompt_lines.append(
                 "- "
                 f"{binding.display_name} [handle={binding.target_handle}, "
-                f"kind={binding.target_kind}, resource_id={binding.resource_id}, "
-                f"capabilities={capability_text}]"
+                f"kind={binding.target_kind}, capabilities={capability_text}, "
+                f"metadata={metadata_text}]"
             )
     else:
         prompt_lines.append("- [metadata unavailable]")
@@ -163,31 +179,6 @@ def build_attached_target_prompt_fallback(
         )
 
     return "\n".join(prompt_lines)
-
-
-class ResolvedTargetMatch(BaseModel):
-    """A ranked candidate returned by the deterministic resolver."""
-
-    target_kind: str
-    resource_id: str
-    display_name: str
-    environment: Optional[str] = None
-    target_type: Optional[str] = None
-    capabilities: List[str] = Field(default_factory=list)
-    confidence: float
-    match_reasons: List[str] = Field(default_factory=list)
-    score: float = Field(default=0.0, exclude=True)
-
-
-class TargetResolutionResult(BaseModel):
-    """Public result shape for target resolution."""
-
-    status: str
-    clarification_required: bool = False
-    matches: List[ResolvedTargetMatch] = Field(default_factory=list)
-    attached_target_handles: List[str] = Field(default_factory=list)
-    toolset_generation: int = 0
-    selected_matches: List[ResolvedTargetMatch] = Field(default_factory=list, exclude=True)
 
 
 class ThreadTargetState(BaseModel):
@@ -251,6 +242,18 @@ def get_target_bindings_from_context(context: Optional[Dict[str, Any]]) -> List[
     return bindings
 
 
+async def resolve_binding_subject(binding: Optional[TargetBinding]) -> Optional[str]:
+    """Resolve the private binding subject for a public binding summary."""
+    if binding is None:
+        return None
+    if binding.resource_id:
+        return binding.resource_id
+    record = await get_target_handle_store().get_record(binding.target_handle)
+    if record is None:
+        return None
+    return record.binding_subject
+
+
 def build_bound_target_scope_context(
     bindings: Sequence[TargetBinding],
     *,
@@ -268,7 +271,7 @@ def build_bound_target_scope_context(
         "attached_target_handles": attached_handles,
         "active_target_handle": resolved_active_handle or "",
         "target_toolset_generation": generation,
-        "target_bindings": [binding.model_dump(mode="json") for binding in attached_bindings],
+        "target_bindings": [binding.public_dump() for binding in attached_bindings],
         "instance_id": "",
         "cluster_id": "",
     }
@@ -292,50 +295,87 @@ async def build_attached_target_scope_prompt(context: Optional[Dict[str, Any]]) 
     for binding in bindings:
         if binding.target_handle not in ordered_handles:
             ordered_handles.append(binding.target_handle)
+    handle_records = await get_target_handle_store().get_records(ordered_handles)
 
     target_lines: List[str] = []
     for handle in ordered_handles:
         binding = binding_by_handle.get(handle)
-        if binding is None:
+        handle_record = handle_records.get(handle)
+        binding_summary = binding or (handle_record.public_summary if handle_record else None)
+        if binding_summary is None:
             target_lines.append(f"- handle={handle} [metadata unavailable]")
             continue
 
-        capability_text = ", ".join(binding.capabilities or []) or "unspecified"
-        if binding.target_kind == "instance":
-            instance = await get_instance_by_id(binding.resource_id)
+        capability_text = ", ".join(binding_summary.capabilities or []) or "unspecified"
+        if binding_summary.target_kind == "instance":
+            instance_id = (
+                handle_record.binding_subject
+                if handle_record is not None
+                else getattr(binding_summary, "resource_id", None)
+            )
+            instance = await get_instance_by_id(instance_id) if instance_id else None
             if instance is not None:
                 target_lines.append(
                     "- "
-                    f"{binding.display_name} [handle={handle}, kind=instance, instance_id={instance.id}, "
+                    f"{binding_summary.display_name} [handle={handle}, kind=instance, "
                     f"environment={instance.environment}, usage={instance.usage}, "
                     f"type={instance.instance_type}, capabilities={capability_text}]"
                 )
             else:
+                metadata_text = (
+                    ", ".join(
+                        f"{key}={value}"
+                        for key, value in (binding_summary.public_metadata or {}).items()
+                        if value not in (None, "")
+                    )
+                    or "none"
+                )
                 target_lines.append(
                     "- "
-                    f"{binding.display_name} [handle={handle}, kind=instance, instance_id={binding.resource_id}, "
-                    f"capabilities={capability_text}, state=missing]"
+                    f"{binding_summary.display_name} [handle={handle}, kind=instance, "
+                    f"capabilities={capability_text}, metadata={metadata_text}, state=missing]"
                 )
-        elif binding.target_kind == "cluster":
-            cluster = await get_cluster_by_id(binding.resource_id)
+        elif binding_summary.target_kind == "cluster":
+            cluster_id = (
+                handle_record.binding_subject
+                if handle_record is not None
+                else getattr(binding_summary, "resource_id", None)
+            )
+            cluster = await get_cluster_by_id(cluster_id) if cluster_id else None
             if cluster is not None:
                 target_lines.append(
                     "- "
-                    f"{binding.display_name} [handle={handle}, kind=cluster, cluster_id={cluster.id}, "
+                    f"{binding_summary.display_name} [handle={handle}, kind=cluster, "
                     f"environment={cluster.environment}, type={cluster.cluster_type}, "
                     f"capabilities={capability_text}]"
                 )
             else:
+                metadata_text = (
+                    ", ".join(
+                        f"{key}={value}"
+                        for key, value in (binding_summary.public_metadata or {}).items()
+                        if value not in (None, "")
+                    )
+                    or "none"
+                )
                 target_lines.append(
                     "- "
-                    f"{binding.display_name} [handle={handle}, kind=cluster, cluster_id={binding.resource_id}, "
-                    f"capabilities={capability_text}, state=missing]"
+                    f"{binding_summary.display_name} [handle={handle}, kind=cluster, "
+                    f"capabilities={capability_text}, metadata={metadata_text}, state=missing]"
                 )
         else:
+            metadata_text = (
+                ", ".join(
+                    f"{key}={value}"
+                    for key, value in (binding_summary.public_metadata or {}).items()
+                    if value not in (None, "")
+                )
+                or "none"
+            )
             target_lines.append(
                 "- "
-                f"{binding.display_name} [handle={handle}, kind={binding.target_kind}, "
-                f"resource_id={binding.resource_id}, capabilities={capability_text}]"
+                f"{binding_summary.display_name} [handle={handle}, kind={binding_summary.target_kind}, "
+                f"capabilities={capability_text}, metadata={metadata_text}]"
             )
 
     prompt_lines = [
@@ -928,85 +968,142 @@ async def resolve_target_query(
     preferred_capabilities: Optional[Sequence[str]] = None,
 ) -> TargetResolutionResult:
     """Resolve natural-language query text against the safe target catalog."""
-    docs = await get_target_catalog(user_id=user_id)
-    if not docs:
-        return TargetResolutionResult(status="no_match")
-
-    hints = _parse_query_hints(query)
-    ranked: List[ResolvedTargetMatch] = []
-    for doc in docs:
-        score, reasons = _score_target_doc(
-            query,
-            doc,
-            preferred_capabilities=preferred_capabilities,
-            hints=hints,
+    service = TargetDiscoveryService()
+    return await service.resolve(
+        DiscoveryRequest(
+            query=query,
+            allow_multiple=allow_multiple,
+            max_results=max_results,
+            preferred_capabilities=list(preferred_capabilities or []),
+            user_id=user_id,
         )
-        if score < 2.5:
-            continue
-        ranked.append(
-            ResolvedTargetMatch(
-                target_kind=doc.target_kind,
-                resource_id=doc.resource_id,
-                display_name=doc.display_name,
-                environment=doc.environment,
-                target_type=doc.target_type,
-                capabilities=doc.capabilities,
-                confidence=_confidence_from_score(score),
-                match_reasons=reasons,
-                score=score,
+    )
+
+
+def _build_public_match_from_doc(
+    doc: TargetCatalogDoc,
+    *,
+    match_reasons: Optional[Sequence[str]] = None,
+    score: float = 100.0,
+    confidence: float = 1.0,
+) -> PublicTargetMatch:
+    """Build a public match payload from a target catalog doc."""
+    return PublicTargetMatch(
+        target_kind=doc.target_kind,
+        display_name=doc.display_name,
+        environment=doc.environment,
+        target_type=doc.target_type,
+        capabilities=list(doc.capabilities or []),
+        confidence=confidence,
+        match_reasons=list(match_reasons or []),
+        public_metadata={
+            key: value
+            for key, value in {
+                "environment": doc.environment,
+                "target_type": doc.target_type,
+                "usage": doc.usage,
+                "status": doc.status,
+            }.items()
+            if value not in (None, "")
+        },
+        resource_id=doc.resource_id,
+        score=score,
+    )
+
+
+async def build_seed_hint_candidates(
+    *,
+    bindings: Optional[Sequence[TargetBinding]] = None,
+    instance_id: Optional[str] = None,
+    cluster_id: Optional[str] = None,
+) -> List[DiscoveryCandidate]:
+    """Build discovery candidates from legacy single-target scope hints."""
+    if instance_id and cluster_id:
+        raise ValueError("Please provide only one of instance_id or cluster_id")
+
+    candidates: List[DiscoveryCandidate] = []
+    seen: set[tuple[str, str]] = set()
+
+    async def _append_candidate(
+        *,
+        target_kind: str,
+        binding_subject: str,
+        binding: Optional[TargetBinding] = None,
+    ) -> None:
+        subject = str(binding_subject or "").strip()
+        kind = str(target_kind or "").strip().lower()
+        if not subject or kind not in {"instance", "cluster"}:
+            return
+
+        identity = (kind, subject)
+        if identity in seen:
+            return
+        seen.add(identity)
+
+        doc: Optional[TargetCatalogDoc] = None
+        if kind == "instance":
+            instance = await get_instance_by_id(subject)
+            if instance is not None:
+                doc = build_target_doc_from_instance(instance)
+        elif kind == "cluster":
+            cluster = await get_cluster_by_id(subject)
+            if cluster is not None:
+                doc = build_target_doc_from_cluster(cluster)
+
+        if doc is not None:
+            public_match = _build_public_match_from_doc(
+                doc,
+                match_reasons=[f"matched {kind}_id"],
+            )
+        else:
+            public_match = PublicTargetMatch(
+                target_kind=kind,
+                display_name=(binding.display_name if binding else None) or subject,
+                capabilities=list((binding.capabilities if binding else None) or []),
+                confidence=1.0,
+                match_reasons=[f"matched {kind}_id"],
+                public_metadata=dict((binding.public_metadata if binding else None) or {}),
+                resource_id=subject,
+                score=100.0,
+            )
+
+        candidates.append(
+            DiscoveryCandidate(
+                public_match=public_match,
+                binding_strategy="redis_default",
+                binding_subject=subject,
+                private_binding_ref={"target_kind": kind, "seed_hint": True},
+                discovery_backend="redis_catalog",
+                score=public_match.score,
+                confidence=public_match.confidence,
             )
         )
 
-    ranked.sort(key=lambda match: (match.score, match.confidence), reverse=True)
-    limited = ranked[: max(1, min(max_results, 10))]
+    for binding in bindings or []:
+        await _append_candidate(
+            target_kind=binding.target_kind,
+            binding_subject=binding.resource_id or "",
+            binding=binding,
+        )
 
-    if not limited:
-        return TargetResolutionResult(status="no_match")
+    if instance_id:
+        await _append_candidate(target_kind="instance", binding_subject=instance_id)
+    if cluster_id:
+        await _append_candidate(target_kind="cluster", binding_subject=cluster_id)
 
-    top = limited[0]
-    selected: List[ResolvedTargetMatch] = []
-    clarification_required = False
-
-    if allow_multiple:
-        selected = [match for match in limited if match.score >= max(3.0, top.score - 1.5)]
-        selected = selected[: min(3, max_results)]
-    else:
-        if len(limited) > 1 and limited[1].score >= top.score - 0.75:
-            clarification_required = True
-            selected = limited[: min(3, max_results)]
-        else:
-            selected = [top]
-
-    status = (
-        "clarification_required"
-        if clarification_required
-        else ("resolved" if selected else "no_match")
-    )
-    return TargetResolutionResult(
-        status=status,
-        clarification_required=clarification_required,
-        matches=limited,
-        selected_matches=selected,
-    )
+    return candidates
 
 
 def build_ephemeral_target_bindings(
-    matches: Sequence[ResolvedTargetMatch],
+    matches: Sequence[DiscoveryCandidate],
     *,
     thread_id: Optional[str] = None,
     task_id: Optional[str] = None,
 ) -> List[TargetBinding]:
     """Build opaque target handles without persisting them."""
+    service = TargetBindingService()
     return [
-        TargetBinding(
-            target_handle=f"tgt_{ULID()}",
-            target_kind=match.target_kind,
-            resource_id=match.resource_id,
-            display_name=match.display_name,
-            capabilities=match.capabilities,
-            thread_id=thread_id,
-            task_id=task_id,
-        )
+        service.build_public_binding(match, thread_id=thread_id, task_id=task_id)
         for match in matches
     ]
 
@@ -1048,38 +1145,41 @@ async def get_thread_target_state(thread_id: str) -> ThreadTargetState:
 async def attach_target_matches(
     *,
     thread_id: str,
-    matches: Sequence[ResolvedTargetMatch],
+    matches: Sequence[DiscoveryCandidate],
     task_id: Optional[str] = None,
     replace_existing: bool = False,
 ) -> tuple[List[TargetBinding], int]:
     """Persist safe target handles on a thread and return attached bindings."""
     thread_manager = ThreadManager(redis_client=get_redis_client())
     current_state = await get_thread_target_state(thread_id)
-
-    existing_by_resource = {
-        (binding.target_kind, binding.resource_id): binding
-        for binding in current_state.target_bindings
-    }
+    binding_service = TargetBindingService()
+    handle_store = get_target_handle_store()
+    existing_records = await handle_store.get_records(
+        binding.target_handle for binding in current_state.target_bindings
+    )
+    existing_by_subject: Dict[tuple[str, str], TargetBinding] = {}
+    for binding in current_state.target_bindings:
+        record = existing_records.get(binding.target_handle)
+        subject = None
+        if record is not None:
+            subject = record.binding_subject
+        elif binding.resource_id:
+            subject = binding.resource_id
+        if subject:
+            existing_by_subject[(binding.target_kind, subject)] = binding
     attached_bindings = [] if replace_existing else list(current_state.target_bindings)
     attached_by_handle = {binding.target_handle: binding for binding in attached_bindings}
-    selected_bindings: List[TargetBinding] = []
+    selected_bindings = await binding_service.build_and_persist_records(
+        matches,
+        thread_id=thread_id,
+        task_id=task_id,
+        existing_by_subject=existing_by_subject,
+    )
 
-    for match in matches:
-        binding = existing_by_resource.get((match.target_kind, match.resource_id))
-        if binding is None:
-            binding = TargetBinding(
-                target_handle=f"tgt_{ULID()}",
-                target_kind=match.target_kind,
-                resource_id=match.resource_id,
-                display_name=match.display_name,
-                capabilities=match.capabilities,
-                thread_id=thread_id,
-                task_id=task_id,
-            )
+    for binding in selected_bindings:
         if binding.target_handle not in attached_by_handle:
             attached_bindings.append(binding)
             attached_by_handle[binding.target_handle] = binding
-        selected_bindings.append(binding)
 
     bindings_to_store = selected_bindings if replace_existing else attached_bindings
     active_handle = (
@@ -1100,7 +1200,7 @@ async def attach_target_matches(
 
 async def materialize_bound_target_scope(
     *,
-    matches: Sequence[ResolvedTargetMatch],
+    matches: Sequence[DiscoveryCandidate],
     thread_id: Optional[str] = None,
     task_id: Optional[str] = None,
     replace_existing: bool = False,
@@ -1117,7 +1217,8 @@ async def materialize_bound_target_scope(
         attached_bindings = list(state.target_bindings)
         active_handle = state.active_target_handle
     else:
-        selected_bindings = build_ephemeral_target_bindings(
+        binding_service = TargetBindingService()
+        selected_bindings = await binding_service.build_and_persist_records(
             matches,
             thread_id=thread_id,
             task_id=task_id,
@@ -1140,7 +1241,7 @@ async def materialize_bound_target_scope(
 
 async def bind_target_matches(
     *,
-    matches: Sequence[ResolvedTargetMatch],
+    matches: Sequence[DiscoveryCandidate],
     thread_id: Optional[str] = None,
     task_id: Optional[str] = None,
     replace_existing: bool = False,

--- a/redis_sre_agent/core/turn_scope.py
+++ b/redis_sre_agent/core/turn_scope.py
@@ -140,9 +140,7 @@ class TurnScope(BaseModel):
             context["attached_target_handles"] = [
                 binding.target_handle for binding in self.bindings
             ]
-            context["target_bindings"] = [
-                binding.model_dump(mode="json") for binding in self.bindings
-            ]
+            context["target_bindings"] = [binding.public_dump() for binding in self.bindings]
         context.update(self.support_package_context)
         return context
 

--- a/redis_sre_agent/core/turn_scope.py
+++ b/redis_sre_agent/core/turn_scope.py
@@ -64,12 +64,6 @@ class TurnScope(BaseModel):
         binding = self.single_binding
         return binding.target_kind if binding else None
 
-    @property
-    def single_resource_id(self) -> Optional[str]:
-        """Return the resource id of the only bound target, if present."""
-        binding = self.single_binding
-        return binding.resource_id if binding else None
-
     @classmethod
     def from_context(
         cls,

--- a/redis_sre_agent/targets/__init__.py
+++ b/redis_sre_agent/targets/__init__.py
@@ -1,0 +1,48 @@
+"""Pluggable Redis target discovery and binding runtime."""
+
+from .contracts import (
+    AuthenticatedClientFactory,
+    BindingRequest,
+    BindingResult,
+    DiscoveryCandidate,
+    DiscoveryRequest,
+    DiscoveryResponse,
+    ProviderLoadRequest,
+    PublicTargetBinding,
+    PublicTargetMatch,
+    TargetBindingStrategy,
+    TargetDiscoveryBackend,
+    TargetHandleRecord,
+)
+from .fake_integration import (
+    FakeAuthenticatedClientFactory,
+    FakeTargetBindingStrategy,
+    FakeTargetDiscoveryBackend,
+)
+from .handle_store import RedisTargetHandleStore, get_target_handle_store
+from .registry import TargetIntegrationRegistry, get_target_integration_registry
+from .services import TargetBindingService, TargetDiscoveryService
+
+__all__ = [
+    "AuthenticatedClientFactory",
+    "BindingRequest",
+    "BindingResult",
+    "DiscoveryCandidate",
+    "DiscoveryRequest",
+    "DiscoveryResponse",
+    "FakeAuthenticatedClientFactory",
+    "FakeTargetBindingStrategy",
+    "FakeTargetDiscoveryBackend",
+    "ProviderLoadRequest",
+    "PublicTargetBinding",
+    "PublicTargetMatch",
+    "RedisTargetHandleStore",
+    "TargetBindingService",
+    "TargetBindingStrategy",
+    "TargetDiscoveryBackend",
+    "TargetDiscoveryService",
+    "TargetHandleRecord",
+    "TargetIntegrationRegistry",
+    "get_target_handle_store",
+    "get_target_integration_registry",
+]

--- a/redis_sre_agent/targets/__init__.py
+++ b/redis_sre_agent/targets/__init__.py
@@ -14,11 +14,6 @@ from .contracts import (
     TargetDiscoveryBackend,
     TargetHandleRecord,
 )
-from .fake_integration import (
-    FakeAuthenticatedClientFactory,
-    FakeTargetBindingStrategy,
-    FakeTargetDiscoveryBackend,
-)
 from .handle_store import RedisTargetHandleStore, get_target_handle_store
 from .registry import TargetIntegrationRegistry, get_target_integration_registry
 from .services import TargetBindingService, TargetDiscoveryService
@@ -30,9 +25,6 @@ __all__ = [
     "DiscoveryCandidate",
     "DiscoveryRequest",
     "DiscoveryResponse",
-    "FakeAuthenticatedClientFactory",
-    "FakeTargetBindingStrategy",
-    "FakeTargetDiscoveryBackend",
     "ProviderLoadRequest",
     "PublicTargetBinding",
     "PublicTargetMatch",

--- a/redis_sre_agent/targets/contracts.py
+++ b/redis_sre_agent/targets/contracts.py
@@ -85,23 +85,34 @@ class DiscoveryCandidate(BaseModel):
     score: float
     confidence: float
 
+    @staticmethod
+    def _resolve_default_integration_names() -> tuple[str, str]:
+        """Return the configured discovery backend and binding strategy defaults."""
+        from .registry import get_target_integration_registry
+
+        registry = get_target_integration_registry()
+        return registry.default_discovery_backend, registry.default_binding_strategy
+
     @classmethod
     def from_public_match(
         cls,
         public_match: PublicTargetMatch,
         *,
-        binding_strategy: str = "redis_default",
+        binding_strategy: Optional[str] = None,
         binding_subject: Optional[str] = None,
         private_binding_ref: Optional[Dict[str, Any]] = None,
-        discovery_backend: str = "redis_catalog",
+        discovery_backend: Optional[str] = None,
     ) -> "DiscoveryCandidate":
         """Build an internal candidate from a public match payload."""
+        default_discovery_backend, default_binding_strategy = (
+            cls._resolve_default_integration_names()
+        )
         return cls(
             public_match=public_match,
-            binding_strategy=binding_strategy,
+            binding_strategy=binding_strategy or default_binding_strategy,
             binding_subject=binding_subject or public_match.resource_id or "",
             private_binding_ref=private_binding_ref or {"target_kind": public_match.target_kind},
-            discovery_backend=discovery_backend,
+            discovery_backend=discovery_backend or default_discovery_backend,
             score=public_match.score,
             confidence=public_match.confidence,
         )

--- a/redis_sre_agent/targets/contracts.py
+++ b/redis_sre_agent/targets/contracts.py
@@ -22,6 +22,19 @@ class PublicTargetMatch(BaseModel):
     resource_id: Optional[str] = Field(default=None, exclude=True)
     score: float = Field(default=0.0, exclude=True)
 
+    @staticmethod
+    def _strip_duplicate_public_metadata(payload: Dict[str, Any]) -> Dict[str, Any]:
+        metadata = dict(payload.get("public_metadata") or {})
+        for key in ("environment", "target_type"):
+            if metadata.get(key) == payload.get(key):
+                metadata.pop(key, None)
+        payload["public_metadata"] = metadata
+        return payload
+
+    def public_dump(self) -> Dict[str, Any]:
+        """Return the model-facing payload without duplicated metadata keys."""
+        return self._strip_duplicate_public_metadata(self.model_dump(mode="json"))
+
 
 class PublicTargetBinding(BaseModel):
     """Public binding summary stored in thread context and shown to the model."""
@@ -151,6 +164,12 @@ class DiscoveryResponse(BaseModel):
     attached_target_handles: List[str] = Field(default_factory=list)
     toolset_generation: int = 0
     selected_matches: List[DiscoveryCandidate] = Field(default_factory=list, exclude=True)
+
+    def public_dump(self) -> Dict[str, Any]:
+        """Return the model-facing discovery payload."""
+        payload = self.model_dump(mode="json")
+        payload["matches"] = [match.public_dump() for match in self.matches]
+        return payload
 
     @field_validator("selected_matches", mode="before")
     @classmethod

--- a/redis_sre_agent/targets/contracts.py
+++ b/redis_sre_agent/targets/contracts.py
@@ -85,6 +85,27 @@ class DiscoveryCandidate(BaseModel):
     score: float
     confidence: float
 
+    @classmethod
+    def from_public_match(
+        cls,
+        public_match: PublicTargetMatch,
+        *,
+        binding_strategy: str = "redis_default",
+        binding_subject: Optional[str] = None,
+        private_binding_ref: Optional[Dict[str, Any]] = None,
+        discovery_backend: str = "redis_catalog",
+    ) -> "DiscoveryCandidate":
+        """Build an internal candidate from a public match payload."""
+        return cls(
+            public_match=public_match,
+            binding_strategy=binding_strategy,
+            binding_subject=binding_subject or public_match.resource_id or "",
+            private_binding_ref=private_binding_ref or {"target_kind": public_match.target_kind},
+            discovery_backend=discovery_backend,
+            score=public_match.score,
+            confidence=public_match.confidence,
+        )
+
     @property
     def target_kind(self) -> str:
         return self.public_match.target_kind
@@ -127,17 +148,7 @@ class DiscoveryResponse(BaseModel):
                 coerced.append(item)
                 continue
             if isinstance(item, PublicTargetMatch):
-                coerced.append(
-                    DiscoveryCandidate(
-                        public_match=item,
-                        binding_strategy="redis_default",
-                        binding_subject=item.resource_id or "",
-                        private_binding_ref={"target_kind": item.target_kind},
-                        discovery_backend="redis_catalog",
-                        score=item.score,
-                        confidence=item.confidence,
-                    )
-                )
+                coerced.append(DiscoveryCandidate.from_public_match(item))
                 continue
             coerced.append(item)
         return coerced

--- a/redis_sre_agent/targets/contracts.py
+++ b/redis_sre_agent/targets/contracts.py
@@ -41,8 +41,8 @@ class PublicTargetBinding(BaseModel):
     resource_id: Optional[str] = None
 
     def public_dump(self) -> Dict[str, Any]:
-        """Return the thread-safe binding payload."""
-        return self.model_dump(mode="json", exclude={"resource_id"})
+        """Return the thread-context binding payload."""
+        return self.model_dump(mode="json")
 
 
 class TargetHandleRecord(BaseModel):

--- a/redis_sre_agent/targets/contracts.py
+++ b/redis_sre_agent/targets/contracts.py
@@ -1,0 +1,192 @@
+"""Contracts and models for pluggable Redis target discovery and binding."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, List, Optional, Protocol
+
+from pydantic import BaseModel, Field, field_validator
+
+
+class PublicTargetMatch(BaseModel):
+    """Secret-safe target match shown to the model."""
+
+    target_kind: str
+    display_name: str
+    environment: Optional[str] = None
+    target_type: Optional[str] = None
+    capabilities: List[str] = Field(default_factory=list)
+    confidence: float
+    match_reasons: List[str] = Field(default_factory=list)
+    public_metadata: Dict[str, Any] = Field(default_factory=dict)
+    resource_id: Optional[str] = Field(default=None, exclude=True)
+    score: float = Field(default=0.0, exclude=True)
+
+
+class PublicTargetBinding(BaseModel):
+    """Public binding summary stored in thread context and shown to the model."""
+
+    target_handle: str
+    target_kind: str
+    display_name: str
+    capabilities: List[str] = Field(default_factory=list)
+    public_metadata: Dict[str, Any] = Field(default_factory=dict)
+    thread_id: Optional[str] = None
+    task_id: Optional[str] = None
+    created_at: str = Field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
+    expires_at: Optional[str] = Field(
+        default_factory=lambda: (datetime.now(timezone.utc) + timedelta(hours=24)).isoformat()
+    )
+    # Compatibility-only fallback while legacy seed-hint paths still exist.
+    resource_id: Optional[str] = None
+
+    def public_dump(self) -> Dict[str, Any]:
+        """Return the thread-safe binding payload."""
+        return self.model_dump(mode="json", exclude={"resource_id"})
+
+
+class TargetHandleRecord(BaseModel):
+    """Server-only record keyed by target_handle."""
+
+    target_handle: str
+    discovery_backend: str
+    binding_strategy: str
+    binding_subject: str
+    private_binding_ref: Dict[str, Any] = Field(default_factory=dict)
+    public_summary: PublicTargetBinding
+    thread_id: Optional[str] = None
+    task_id: Optional[str] = None
+    created_at: str = Field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
+    expires_at: Optional[str] = Field(
+        default_factory=lambda: (datetime.now(timezone.utc) + timedelta(hours=24)).isoformat()
+    )
+
+
+class DiscoveryRequest(BaseModel):
+    """Natural-language discovery request."""
+
+    query: str
+    allow_multiple: bool = False
+    max_results: int = 5
+    preferred_capabilities: List[str] = Field(default_factory=list)
+    user_id: Optional[str] = None
+    thread_id: Optional[str] = None
+    task_id: Optional[str] = None
+
+
+class DiscoveryCandidate(BaseModel):
+    """Internal selected match with private binding metadata."""
+
+    public_match: PublicTargetMatch
+    binding_strategy: str
+    binding_subject: str
+    private_binding_ref: Dict[str, Any] = Field(default_factory=dict)
+    discovery_backend: str
+    score: float
+    confidence: float
+
+    @property
+    def target_kind(self) -> str:
+        return self.public_match.target_kind
+
+    @property
+    def display_name(self) -> str:
+        return self.public_match.display_name
+
+    @property
+    def capabilities(self) -> List[str]:
+        return list(self.public_match.capabilities or [])
+
+    @property
+    def resource_id(self) -> Optional[str]:
+        return self.public_match.resource_id or self.binding_subject
+
+    @property
+    def match_reasons(self) -> List[str]:
+        return list(self.public_match.match_reasons or [])
+
+
+class DiscoveryResponse(BaseModel):
+    """Public discovery response with private selected candidates excluded."""
+
+    status: str
+    clarification_required: bool = False
+    matches: List[PublicTargetMatch] = Field(default_factory=list)
+    attached_target_handles: List[str] = Field(default_factory=list)
+    toolset_generation: int = 0
+    selected_matches: List[DiscoveryCandidate] = Field(default_factory=list, exclude=True)
+
+    @field_validator("selected_matches", mode="before")
+    @classmethod
+    def _coerce_selected_matches(cls, value: Any) -> Any:
+        if not isinstance(value, list):
+            return value
+        coerced: List[Any] = []
+        for item in value:
+            if isinstance(item, DiscoveryCandidate):
+                coerced.append(item)
+                continue
+            if isinstance(item, PublicTargetMatch):
+                coerced.append(
+                    DiscoveryCandidate(
+                        public_match=item,
+                        binding_strategy="redis_default",
+                        binding_subject=item.resource_id or "",
+                        private_binding_ref={"target_kind": item.target_kind},
+                        discovery_backend="redis_catalog",
+                        score=item.score,
+                        confidence=item.confidence,
+                    )
+                )
+                continue
+            coerced.append(item)
+        return coerced
+
+
+class BindingRequest(BaseModel):
+    """Request to turn a private handle record into runtime provider loads."""
+
+    handle_record: TargetHandleRecord
+    thread_id: Optional[str] = None
+    task_id: Optional[str] = None
+
+
+class ProviderLoadRequest(BaseModel):
+    """Description of a provider load ToolManager can perform generically."""
+
+    provider_path: str
+    provider_key: str
+    target_handle: str
+    provider_context: Dict[str, Any] = Field(default_factory=dict)
+
+
+class BindingResult(BaseModel):
+    """Result of binding a private handle record into provider loads."""
+
+    public_summary: PublicTargetBinding
+    provider_loads: List[ProviderLoadRequest] = Field(default_factory=list)
+    client_refs: Dict[str, Any] = Field(default_factory=dict)
+
+
+class TargetDiscoveryBackend(Protocol):
+    """Resolve natural-language Redis targets into safe matches and private candidates."""
+
+    backend_name: str
+
+    async def resolve(self, request: DiscoveryRequest) -> DiscoveryResponse: ...
+
+
+class TargetBindingStrategy(Protocol):
+    """Bind a private Redis handle record into provider loads."""
+
+    strategy_name: str
+
+    async def bind(self, request: BindingRequest) -> BindingResult: ...
+
+
+class AuthenticatedClientFactory(Protocol):
+    """Build a live client or provider input from a private handle record."""
+
+    client_family: str
+
+    async def build(self, handle_record: TargetHandleRecord) -> Any: ...

--- a/redis_sre_agent/targets/contracts.py
+++ b/redis_sre_agent/targets/contracts.py
@@ -104,9 +104,13 @@ class DiscoveryCandidate(BaseModel):
         discovery_backend: Optional[str] = None,
     ) -> "DiscoveryCandidate":
         """Build an internal candidate from a public match payload."""
-        default_discovery_backend, default_binding_strategy = (
-            cls._resolve_default_integration_names()
-        )
+        if binding_strategy is None or discovery_backend is None:
+            default_discovery_backend, default_binding_strategy = (
+                cls._resolve_default_integration_names()
+            )
+        else:
+            default_discovery_backend = discovery_backend
+            default_binding_strategy = binding_strategy
         return cls(
             public_match=public_match,
             binding_strategy=binding_strategy or default_binding_strategy,

--- a/redis_sre_agent/targets/fake_integration.py
+++ b/redis_sre_agent/targets/fake_integration.py
@@ -130,7 +130,7 @@ class FakeTargetDiscoveryBackend:
                 status="clarification_required",
                 clarification_required=True,
                 matches=matches,
-                selected_matches=[],
+                selected_matches=candidates[: min(3, request.max_results)],
             )
         selected = candidates if request.allow_multiple else candidates[:1]
         return DiscoveryResponse(

--- a/redis_sre_agent/targets/fake_integration.py
+++ b/redis_sre_agent/targets/fake_integration.py
@@ -1,0 +1,207 @@
+"""Fake pluggable target integration used to prove runtime configurability."""
+
+from __future__ import annotations
+
+from typing import Any, Sequence
+
+from pydantic import BaseModel, Field, SecretStr
+
+from redis_sre_agent.core.instances import RedisInstance
+
+from .contracts import (
+    BindingRequest,
+    BindingResult,
+    DiscoveryCandidate,
+    DiscoveryRequest,
+    DiscoveryResponse,
+    ProviderLoadRequest,
+    PublicTargetMatch,
+)
+
+
+class FakeDiscoveryTarget(BaseModel):
+    """Config for one fake target discovery record."""
+
+    display_name: str
+    binding_subject: str
+    aliases: list[str] = Field(default_factory=list)
+    target_kind: str = "instance"
+    environment: str = "test"
+    target_type: str = "fake"
+    capabilities: list[str] = Field(default_factory=lambda: ["fake", "auth"])
+    public_metadata: dict[str, Any] = Field(default_factory=dict)
+    username: str = "demo-user"
+    token: SecretStr = Field(default_factory=lambda: SecretStr("demo-token"))
+    audience: str = "fake-control-plane"
+
+
+class FakeTargetDiscoveryBackend:
+    """Resolve targets from a configured in-memory catalog."""
+
+    backend_name = "fake_demo"
+
+    def __init__(
+        self,
+        *,
+        targets: Sequence[dict[str, Any]] | None = None,
+        binding_strategy: str = "fake_authenticated",
+    ) -> None:
+        configured_targets = targets or [
+            {
+                "display_name": "demo fake cache",
+                "binding_subject": "fake-demo-cache",
+                "aliases": ["demo cache", "fake cache"],
+                "environment": "test",
+                "public_metadata": {"owner": "demo"},
+                "username": "demo-user",
+                "token": "demo-token",
+            }
+        ]
+        self.binding_strategy = binding_strategy
+        self.targets = [FakeDiscoveryTarget.model_validate(target) for target in configured_targets]
+
+    @staticmethod
+    def _normalize(text: str) -> str:
+        return " ".join((text or "").lower().split())
+
+    def _match_score(self, query: str, target: FakeDiscoveryTarget) -> float | None:
+        normalized_query = self._normalize(query)
+        if not normalized_query:
+            return None
+
+        candidates = [target.display_name, target.binding_subject, *target.aliases]
+        normalized_candidates = [
+            self._normalize(candidate) for candidate in candidates if candidate
+        ]
+        if any(normalized_query == candidate for candidate in normalized_candidates):
+            return 1.0
+        if any(normalized_query in candidate for candidate in normalized_candidates):
+            return 0.95
+        query_tokens = normalized_query.split()
+        if query_tokens and any(
+            all(token in candidate for token in query_tokens) for candidate in normalized_candidates
+        ):
+            return 0.8
+        return None
+
+    def _build_candidate(self, target: FakeDiscoveryTarget, score: float) -> DiscoveryCandidate:
+        public_metadata = {"audience": target.audience, **(target.public_metadata or {})}
+        public_match = PublicTargetMatch(
+            target_kind=target.target_kind,
+            display_name=target.display_name,
+            environment=target.environment,
+            target_type=target.target_type,
+            capabilities=list(target.capabilities or []),
+            confidence=score,
+            match_reasons=[f"matched fake target catalog score={score:.2f}"],
+            public_metadata=public_metadata,
+            resource_id=target.binding_subject,
+            score=score,
+        )
+        return DiscoveryCandidate(
+            public_match=public_match,
+            binding_strategy=self.binding_strategy,
+            binding_subject=target.binding_subject,
+            private_binding_ref={
+                "username": target.username,
+                "token": target.token.get_secret_value(),
+                "audience": target.audience,
+            },
+            discovery_backend=self.backend_name,
+            score=score,
+            confidence=score,
+        )
+
+    async def resolve(self, request: DiscoveryRequest) -> DiscoveryResponse:
+        scored_candidates: list[tuple[float, DiscoveryCandidate]] = []
+        for target in self.targets:
+            score = self._match_score(request.query, target)
+            if score is None:
+                continue
+            scored_candidates.append((score, self._build_candidate(target, score)))
+
+        scored_candidates.sort(key=lambda item: item[0], reverse=True)
+        candidates = [candidate for _, candidate in scored_candidates[: request.max_results]]
+        matches = [candidate.public_match for candidate in candidates]
+        if not candidates:
+            return DiscoveryResponse(status="not_found", clarification_required=False, matches=[])
+        if len(candidates) > 1 and not request.allow_multiple:
+            return DiscoveryResponse(
+                status="clarification_required",
+                clarification_required=True,
+                matches=matches,
+                selected_matches=[],
+            )
+        selected = candidates if request.allow_multiple else candidates[:1]
+        return DiscoveryResponse(
+            status="resolved",
+            clarification_required=False,
+            matches=matches,
+            selected_matches=selected,
+        )
+
+
+class FakeAuthenticatedClientFactory:
+    """Build a fake authenticated target instance from a handle record."""
+
+    client_family = "fake.auth"
+
+    async def build(self, handle_record) -> Any:
+        auth_ref = dict(handle_record.private_binding_ref or {})
+        token = str(auth_ref.get("token") or "demo-token")
+        username = str(auth_ref.get("username") or "demo-user")
+        audience = str(auth_ref.get("audience") or "fake-control-plane")
+        environment = str(handle_record.public_summary.public_metadata.get("environment") or "test")
+        return RedisInstance(
+            id=handle_record.target_handle,
+            name=handle_record.public_summary.display_name,
+            connection_url="redis://fake.invalid:6379/0",
+            environment=environment,
+            usage="custom",
+            description=f"Fake authenticated target for {handle_record.public_summary.display_name}",
+            instance_type="unknown",
+            extension_data={
+                "fake_target.username": username,
+                "fake_target.audience": audience,
+            },
+            extension_secrets={"fake_target.token": SecretStr(token)},
+        )
+
+
+class FakeTargetBindingStrategy:
+    """Bind fake targets through the fake auth client factory."""
+
+    strategy_name = "fake_authenticated"
+
+    def __init__(
+        self,
+        *,
+        client_family: str = "fake.auth",
+        provider_path: str = "redis_sre_agent.tools.fake.provider.FakeAuthenticatedToolProvider",
+    ) -> None:
+        self.client_family = client_family
+        self.provider_path = provider_path
+
+    async def bind(self, request: BindingRequest) -> BindingResult:
+        from .registry import get_target_integration_registry
+
+        registry = get_target_integration_registry()
+        fake_instance = await registry.get_client_factory(self.client_family).build(
+            request.handle_record
+        )
+        if fake_instance is None:
+            return BindingResult(public_summary=request.handle_record.public_summary)
+
+        handle = request.handle_record.target_handle
+        return BindingResult(
+            public_summary=request.handle_record.public_summary,
+            provider_loads=[
+                ProviderLoadRequest(
+                    provider_path=self.provider_path,
+                    provider_key=f"target:{handle}:fake_target",
+                    target_handle=handle,
+                    provider_context={"redis_instance_override": fake_instance},
+                )
+            ],
+            client_refs={self.client_family: fake_instance},
+        )

--- a/redis_sre_agent/targets/handle_store.py
+++ b/redis_sre_agent/targets/handle_store.py
@@ -59,8 +59,26 @@ class RedisTargetHandleStore:
             )
 
     async def save_records(self, records: Iterable[TargetHandleRecord]) -> None:
-        for record in records:
-            await self.save_record(record)
+        record_list = list(records)
+        if not record_list:
+            return
+
+        client = get_redis_client()
+        try:
+            async with client.pipeline(transaction=True) as pipe:
+                for record in record_list:
+                    pipe.set(
+                        self._key(record.target_handle),
+                        record.model_dump_json(),
+                        ex=self._ttl_seconds(record),
+                    )
+                await pipe.execute()
+        except Exception:
+            logger.warning(
+                "Target handle store unavailable while saving %s records",
+                len(record_list),
+                exc_info=True,
+            )
 
     async def get_record(self, target_handle: str) -> Optional[TargetHandleRecord]:
         client = get_redis_client()
@@ -80,11 +98,30 @@ class RedisTargetHandleStore:
             return None
 
     async def get_records(self, target_handles: Iterable[str]) -> Dict[str, TargetHandleRecord]:
+        handle_list = list(target_handles)
+        if not handle_list:
+            return {}
+
+        client = get_redis_client()
+        keys = [self._key(target_handle) for target_handle in handle_list]
         records: Dict[str, TargetHandleRecord] = {}
-        for target_handle in target_handles:
-            record = await self.get_record(target_handle)
-            if record is not None:
-                records[target_handle] = record
+        try:
+            raw_values = await client.mget(*keys)
+        except Exception:
+            logger.debug("Target handle store unavailable while loading records")
+            return {}
+
+        for target_handle, raw in zip(handle_list, raw_values or []):
+            if not raw:
+                continue
+            if isinstance(raw, bytes):
+                raw = raw.decode("utf-8")
+            try:
+                record = TargetHandleRecord.model_validate_json(raw)
+            except Exception:
+                logger.warning("Invalid target handle record for %s", target_handle)
+                continue
+            records[target_handle] = record
         return records
 
 

--- a/redis_sre_agent/targets/handle_store.py
+++ b/redis_sre_agent/targets/handle_store.py
@@ -90,3 +90,9 @@ def get_target_handle_store() -> RedisTargetHandleStore:
     if _DEFAULT_STORE is None:
         _DEFAULT_STORE = RedisTargetHandleStore()
     return _DEFAULT_STORE
+
+
+def reset_target_handle_store() -> None:
+    """Clear the cached target handle store singleton."""
+    global _DEFAULT_STORE
+    _DEFAULT_STORE = None

--- a/redis_sre_agent/targets/handle_store.py
+++ b/redis_sre_agent/targets/handle_store.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 from datetime import datetime, timezone
+from threading import Lock
 from typing import Dict, Iterable, Optional
 
 from redis_sre_agent.core.redis import get_redis_client
@@ -15,6 +16,7 @@ logger = logging.getLogger(__name__)
 _TARGET_HANDLE_STORE_PREFIX = "sre_target_handles"
 _DEFAULT_TTL_SECONDS = 24 * 60 * 60
 _DEFAULT_STORE: "RedisTargetHandleStore | None" = None
+_DEFAULT_STORE_LOCK = Lock()
 
 
 class RedisTargetHandleStore:
@@ -129,11 +131,14 @@ def get_target_handle_store() -> RedisTargetHandleStore:
     """Return the default target handle store."""
     global _DEFAULT_STORE
     if _DEFAULT_STORE is None:
-        _DEFAULT_STORE = RedisTargetHandleStore()
+        with _DEFAULT_STORE_LOCK:
+            if _DEFAULT_STORE is None:
+                _DEFAULT_STORE = RedisTargetHandleStore()
     return _DEFAULT_STORE
 
 
 def reset_target_handle_store() -> None:
     """Clear the cached target handle store singleton."""
     global _DEFAULT_STORE
-    _DEFAULT_STORE = None
+    with _DEFAULT_STORE_LOCK:
+        _DEFAULT_STORE = None

--- a/redis_sre_agent/targets/handle_store.py
+++ b/redis_sre_agent/targets/handle_store.py
@@ -1,0 +1,92 @@
+"""Redis-backed private target handle storage."""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import Dict, Iterable, Optional
+
+from redis_sre_agent.core.redis import get_redis_client
+
+from .contracts import TargetHandleRecord
+
+logger = logging.getLogger(__name__)
+
+_TARGET_HANDLE_STORE_PREFIX = "sre_target_handles"
+_DEFAULT_TTL_SECONDS = 24 * 60 * 60
+_DEFAULT_STORE: "RedisTargetHandleStore | None" = None
+
+
+class RedisTargetHandleStore:
+    """Persist private target handle records separately from thread context."""
+
+    def __init__(self, *, key_prefix: str = _TARGET_HANDLE_STORE_PREFIX):
+        self.key_prefix = key_prefix
+
+    def _key(self, target_handle: str) -> str:
+        return f"{self.key_prefix}:{target_handle}"
+
+    @staticmethod
+    def _ttl_seconds(record: TargetHandleRecord) -> int:
+        expires_at = record.expires_at
+        if not expires_at:
+            return _DEFAULT_TTL_SECONDS
+        try:
+            value = expires_at.replace("Z", "+00:00") if expires_at.endswith("Z") else expires_at
+            ttl = int(
+                max(
+                    1,
+                    (datetime.fromisoformat(value) - datetime.now(timezone.utc)).total_seconds(),
+                )
+            )
+            return ttl
+        except Exception:
+            return _DEFAULT_TTL_SECONDS
+
+    async def save_record(self, record: TargetHandleRecord) -> None:
+        client = get_redis_client()
+        try:
+            await client.set(
+                self._key(record.target_handle),
+                record.model_dump_json(),
+                ex=self._ttl_seconds(record),
+            )
+        except Exception:
+            logger.debug("Target handle store unavailable while saving %s", record.target_handle)
+
+    async def save_records(self, records: Iterable[TargetHandleRecord]) -> None:
+        for record in records:
+            await self.save_record(record)
+
+    async def get_record(self, target_handle: str) -> Optional[TargetHandleRecord]:
+        client = get_redis_client()
+        try:
+            raw = await client.get(self._key(target_handle))
+        except Exception:
+            logger.debug("Target handle store unavailable while loading %s", target_handle)
+            return None
+        if not raw:
+            return None
+        if isinstance(raw, bytes):
+            raw = raw.decode("utf-8")
+        try:
+            return TargetHandleRecord.model_validate_json(raw)
+        except Exception:
+            logger.warning("Invalid target handle record for %s", target_handle)
+            return None
+
+    async def get_records(self, target_handles: Iterable[str]) -> Dict[str, TargetHandleRecord]:
+        records: Dict[str, TargetHandleRecord] = {}
+        for target_handle in target_handles:
+            record = await self.get_record(target_handle)
+            if record is not None:
+                records[target_handle] = record
+        return records
+
+
+def get_target_handle_store() -> RedisTargetHandleStore:
+    """Return the default target handle store."""
+    global _DEFAULT_STORE
+    if _DEFAULT_STORE is None:
+        _DEFAULT_STORE = RedisTargetHandleStore()
+    return _DEFAULT_STORE

--- a/redis_sre_agent/targets/handle_store.py
+++ b/redis_sre_agent/targets/handle_store.py
@@ -52,7 +52,11 @@ class RedisTargetHandleStore:
                 ex=self._ttl_seconds(record),
             )
         except Exception:
-            logger.debug("Target handle store unavailable while saving %s", record.target_handle)
+            logger.warning(
+                "Target handle store unavailable while saving %s",
+                record.target_handle,
+                exc_info=True,
+            )
 
     async def save_records(self, records: Iterable[TargetHandleRecord]) -> None:
         for record in records:

--- a/redis_sre_agent/targets/redis_binding.py
+++ b/redis_sre_agent/targets/redis_binding.py
@@ -1,0 +1,209 @@
+"""Default Redis target binding strategy and client factories."""
+
+from __future__ import annotations
+
+import os
+from typing import Any, List, Optional
+
+from redis_sre_agent.core import clusters as core_clusters
+from redis_sre_agent.core.config import settings
+from redis_sre_agent.core.instances import RedisInstance, get_instance_by_id
+
+from .contracts import BindingRequest, BindingResult, ProviderLoadRequest, TargetHandleRecord
+
+
+class RedisDataClientFactory:
+    """Return a RedisInstance for instance-scoped provider loads."""
+
+    client_family = "redis.data"
+
+    async def build(self, handle_record: TargetHandleRecord) -> Any:
+        if handle_record.public_summary.target_kind != "instance":
+            return None
+        instance = await get_instance_by_id(handle_record.binding_subject)
+        if instance is None:
+            return None
+        return instance.model_copy(update={"id": handle_record.target_handle})
+
+
+class RedisEnterpriseAdminClientFactory:
+    """Return an effective Redis Enterprise admin instance."""
+
+    client_family = "redis.enterprise_admin"
+
+    @staticmethod
+    def _build_cluster_admin_instance(
+        cluster: "core_clusters.RedisCluster",
+        *,
+        target_handle: str,
+    ) -> Optional[RedisInstance]:
+        cluster_type = (
+            cluster.cluster_type.value
+            if hasattr(cluster.cluster_type, "value")
+            else str(cluster.cluster_type or "").strip().lower()
+        )
+        has_admin_url = bool((cluster.admin_url or "").strip())
+        has_admin_username = bool((cluster.admin_username or "").strip())
+        has_admin_password = bool(cluster.admin_password)
+        if cluster_type != "redis_enterprise" or not (
+            has_admin_url and has_admin_username and has_admin_password
+        ):
+            return None
+        connection_host = (cluster.admin_url or "").strip()
+        return RedisInstance(
+            id=target_handle,
+            name=f"{cluster.name} (cluster admin)",
+            connection_url="redis://cluster-only.invalid:6379",
+            environment=cluster.environment,
+            usage="custom",
+            description=f"Synthetic cluster admin target for {cluster.name}",
+            instance_type="redis_enterprise",
+            cluster_id=cluster.id,
+            admin_url=cluster.admin_url,
+            admin_username=cluster.admin_username,
+            admin_password=cluster.admin_password,
+            monitoring_identifier=cluster.name,
+            logging_identifier=cluster.name,
+            notes=f"Cluster-scoped admin tooling target for {connection_host}",
+            created_by="agent",
+            user_id=cluster.user_id,
+        )
+
+    async def build(self, handle_record: TargetHandleRecord) -> Any:
+        public_summary = handle_record.public_summary
+        if public_summary.target_kind == "cluster":
+            cluster = await core_clusters.get_cluster_by_id(handle_record.binding_subject)
+            if cluster is None:
+                return None
+            return self._build_cluster_admin_instance(
+                cluster, target_handle=handle_record.target_handle
+            )
+
+        instance = await get_instance_by_id(handle_record.binding_subject)
+        if instance is None:
+            return None
+
+        instance_type = (
+            instance.instance_type.value
+            if hasattr(instance.instance_type, "value")
+            else instance.instance_type
+        )
+        if str(instance_type or "").strip().lower() != "redis_enterprise":
+            return None
+
+        cluster_id = (instance.cluster_id or "").strip()
+        if cluster_id:
+            cluster = await core_clusters.get_cluster_by_id(cluster_id)
+            if cluster is not None:
+                cluster_admin = self._build_cluster_admin_instance(
+                    cluster, target_handle=handle_record.target_handle
+                )
+                if cluster_admin is not None:
+                    return cluster_admin
+
+        has_admin_url = bool((instance.admin_url or "").strip())
+        if not has_admin_url:
+            return None
+        return instance.model_copy(update={"id": handle_record.target_handle})
+
+
+class RedisCloudClientFactory:
+    """Return a cloud-capable RedisInstance when cloud credentials are configured."""
+
+    client_family = "redis.cloud"
+
+    async def build(self, handle_record: TargetHandleRecord) -> Any:
+        if handle_record.public_summary.target_kind != "instance":
+            return None
+        if not (
+            os.getenv("TOOLS_REDIS_CLOUD_API_KEY") and os.getenv("TOOLS_REDIS_CLOUD_API_SECRET_KEY")
+        ):
+            return None
+        instance = await get_instance_by_id(handle_record.binding_subject)
+        if instance is None:
+            return None
+        instance_type = (
+            instance.instance_type.value
+            if hasattr(instance.instance_type, "value")
+            else instance.instance_type
+        )
+        if str(instance_type or "").strip().lower() != "redis_cloud":
+            return None
+        return instance.model_copy(update={"id": handle_record.target_handle})
+
+
+class RedisTargetBindingStrategy:
+    """Default Redis binding strategy."""
+
+    strategy_name = "redis_default"
+
+    async def bind(self, request: BindingRequest) -> BindingResult:
+        from .registry import get_target_integration_registry
+
+        registry = get_target_integration_registry()
+        handle_record = request.handle_record
+        public_summary = handle_record.public_summary
+
+        provider_loads: List[ProviderLoadRequest] = []
+        client_refs: dict[str, Any] = {}
+
+        if public_summary.target_kind == "instance":
+            data_instance = await registry.get_client_factory("redis.data").build(handle_record)
+            if data_instance is not None:
+                client_refs["redis.data"] = data_instance
+                for provider_path in settings.tool_providers:
+                    provider_loads.append(
+                        ProviderLoadRequest(
+                            provider_path=provider_path,
+                            provider_key=f"target:{public_summary.target_handle}:{provider_path}",
+                            target_handle=public_summary.target_handle,
+                            provider_context={"redis_instance_override": data_instance},
+                        )
+                    )
+
+            admin_instance = await registry.get_client_factory("redis.enterprise_admin").build(
+                handle_record
+            )
+            if admin_instance is not None:
+                client_refs["redis.enterprise_admin"] = admin_instance
+                provider_loads.append(
+                    ProviderLoadRequest(
+                        provider_path="redis_sre_agent.tools.admin.redis_enterprise.provider.RedisEnterpriseAdminToolProvider",
+                        provider_key=f"target:{public_summary.target_handle}:enterprise_admin",
+                        target_handle=public_summary.target_handle,
+                        provider_context={"redis_instance_override": admin_instance},
+                    )
+                )
+
+            cloud_instance = await registry.get_client_factory("redis.cloud").build(handle_record)
+            if cloud_instance is not None:
+                client_refs["redis.cloud"] = cloud_instance
+                provider_loads.append(
+                    ProviderLoadRequest(
+                        provider_path="redis_sre_agent.tools.cloud.redis_cloud.provider.RedisCloudToolProvider",
+                        provider_key=f"target:{public_summary.target_handle}:redis_cloud",
+                        target_handle=public_summary.target_handle,
+                        provider_context={"redis_instance_override": cloud_instance},
+                    )
+                )
+
+        elif public_summary.target_kind == "cluster":
+            admin_instance = await registry.get_client_factory("redis.enterprise_admin").build(
+                handle_record
+            )
+            if admin_instance is not None:
+                client_refs["redis.enterprise_admin"] = admin_instance
+                provider_loads.append(
+                    ProviderLoadRequest(
+                        provider_path="redis_sre_agent.tools.admin.redis_enterprise.provider.RedisEnterpriseAdminToolProvider",
+                        provider_key=f"target:{public_summary.target_handle}:enterprise_admin",
+                        target_handle=public_summary.target_handle,
+                        provider_context={"redis_instance_override": admin_instance},
+                    )
+                )
+
+        return BindingResult(
+            public_summary=public_summary,
+            provider_loads=provider_loads,
+            client_refs=client_refs,
+        )

--- a/redis_sre_agent/targets/redis_catalog.py
+++ b/redis_sre_agent/targets/redis_catalog.py
@@ -1,0 +1,100 @@
+"""Default Redis catalog-backed target discovery backend."""
+
+from __future__ import annotations
+
+from typing import List
+
+from .contracts import DiscoveryCandidate, DiscoveryRequest, DiscoveryResponse, PublicTargetMatch
+
+
+class RedisCatalogDiscoveryBackend:
+    """Resolve Redis targets from the built-in target catalog."""
+
+    backend_name = "redis_catalog"
+
+    async def resolve(self, request: DiscoveryRequest) -> DiscoveryResponse:
+        from redis_sre_agent.core.targets import (
+            _confidence_from_score,
+            _parse_query_hints,
+            _score_target_doc,
+            get_target_catalog,
+        )
+
+        docs = await get_target_catalog(user_id=request.user_id)
+        if not docs:
+            return DiscoveryResponse(status="no_match")
+
+        hints = _parse_query_hints(request.query)
+        ranked: List[DiscoveryCandidate] = []
+        for doc in docs:
+            score, reasons = _score_target_doc(
+                request.query,
+                doc,
+                preferred_capabilities=request.preferred_capabilities,
+                hints=hints,
+            )
+            if score < 2.5:
+                continue
+            public_match = PublicTargetMatch(
+                target_kind=doc.target_kind,
+                display_name=doc.display_name,
+                environment=doc.environment,
+                target_type=doc.target_type,
+                capabilities=doc.capabilities,
+                confidence=_confidence_from_score(score),
+                match_reasons=reasons,
+                public_metadata={
+                    key: value
+                    for key, value in {
+                        "environment": doc.environment,
+                        "target_type": doc.target_type,
+                        "usage": doc.usage,
+                        "status": doc.status,
+                    }.items()
+                    if value not in (None, "")
+                },
+                resource_id=doc.resource_id,
+                score=score,
+            )
+            ranked.append(
+                DiscoveryCandidate(
+                    public_match=public_match,
+                    binding_strategy="redis_default",
+                    binding_subject=doc.resource_id,
+                    private_binding_ref={"target_kind": doc.target_kind},
+                    discovery_backend=self.backend_name,
+                    score=score,
+                    confidence=public_match.confidence,
+                )
+            )
+
+        ranked.sort(key=lambda candidate: (candidate.score, candidate.confidence), reverse=True)
+        limited = ranked[: max(1, min(request.max_results, 10))]
+        if not limited:
+            return DiscoveryResponse(status="no_match")
+
+        top = limited[0]
+        selected: List[DiscoveryCandidate] = []
+        clarification_required = False
+
+        if request.allow_multiple:
+            selected = [
+                candidate for candidate in limited if candidate.score >= max(3.0, top.score - 1.5)
+            ][: min(3, request.max_results)]
+        else:
+            if len(limited) > 1 and limited[1].score >= top.score - 0.75:
+                clarification_required = True
+                selected = limited[: min(3, request.max_results)]
+            else:
+                selected = [top]
+
+        return DiscoveryResponse(
+            status=(
+                "clarification_required"
+                if clarification_required
+                else ("resolved" if selected else "no_match")
+            ),
+            clarification_required=clarification_required,
+            matches=[candidate.public_match for candidate in limited],
+            selected_matches=selected,
+        )

--- a/redis_sre_agent/targets/redis_catalog.py
+++ b/redis_sre_agent/targets/redis_catalog.py
@@ -14,10 +14,10 @@ class RedisCatalogDiscoveryBackend:
 
     async def resolve(self, request: DiscoveryRequest) -> DiscoveryResponse:
         from redis_sre_agent.core.targets import (
-            _build_public_match_from_doc,
             _confidence_from_score,
             _parse_query_hints,
             _score_target_doc,
+            build_public_match_from_doc,
             get_target_catalog,
         )
 
@@ -36,7 +36,7 @@ class RedisCatalogDiscoveryBackend:
             )
             if score < 2.5:
                 continue
-            public_match = _build_public_match_from_doc(
+            public_match = build_public_match_from_doc(
                 doc,
                 confidence=_confidence_from_score(score),
                 match_reasons=reasons,

--- a/redis_sre_agent/targets/redis_catalog.py
+++ b/redis_sre_agent/targets/redis_catalog.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import List
 
-from .contracts import DiscoveryCandidate, DiscoveryRequest, DiscoveryResponse, PublicTargetMatch
+from .contracts import DiscoveryCandidate, DiscoveryRequest, DiscoveryResponse
 
 
 class RedisCatalogDiscoveryBackend:
@@ -14,6 +14,7 @@ class RedisCatalogDiscoveryBackend:
 
     async def resolve(self, request: DiscoveryRequest) -> DiscoveryResponse:
         from redis_sre_agent.core.targets import (
+            _build_public_match_from_doc,
             _confidence_from_score,
             _parse_query_hints,
             _score_target_doc,
@@ -35,25 +36,10 @@ class RedisCatalogDiscoveryBackend:
             )
             if score < 2.5:
                 continue
-            public_match = PublicTargetMatch(
-                target_kind=doc.target_kind,
-                display_name=doc.display_name,
-                environment=doc.environment,
-                target_type=doc.target_type,
-                capabilities=doc.capabilities,
+            public_match = _build_public_match_from_doc(
+                doc,
                 confidence=_confidence_from_score(score),
                 match_reasons=reasons,
-                public_metadata={
-                    key: value
-                    for key, value in {
-                        "environment": doc.environment,
-                        "target_type": doc.target_type,
-                        "usage": doc.usage,
-                        "status": doc.status,
-                    }.items()
-                    if value not in (None, "")
-                },
-                resource_id=doc.resource_id,
                 score=score,
             )
             ranked.append(

--- a/redis_sre_agent/targets/redis_catalog.py
+++ b/redis_sre_agent/targets/redis_catalog.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import List
 
 from .contracts import DiscoveryCandidate, DiscoveryRequest, DiscoveryResponse
+from .registry import get_target_integration_registry
 
 
 class RedisCatalogDiscoveryBackend:
@@ -25,6 +26,7 @@ class RedisCatalogDiscoveryBackend:
         if not docs:
             return DiscoveryResponse(status="no_match")
 
+        registry = get_target_integration_registry()
         hints = _parse_query_hints(request.query)
         ranked: List[DiscoveryCandidate] = []
         for doc in docs:
@@ -45,7 +47,7 @@ class RedisCatalogDiscoveryBackend:
             ranked.append(
                 DiscoveryCandidate(
                     public_match=public_match,
-                    binding_strategy="redis_default",
+                    binding_strategy=registry.default_binding_strategy,
                     binding_subject=doc.resource_id,
                     private_binding_ref={"target_kind": doc.target_kind},
                     discovery_backend=self.backend_name,

--- a/redis_sre_agent/targets/registry.py
+++ b/redis_sre_agent/targets/registry.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib
+from threading import Lock
 from typing import Any, Dict, Optional
 
 from redis_sre_agent.core.config import settings
@@ -15,6 +16,7 @@ from .contracts import (
 )
 
 _DEFAULT_REGISTRY: "TargetIntegrationRegistry | None" = None
+_DEFAULT_REGISTRY_LOCK = Lock()
 
 
 def _load_object(class_path: str) -> Any:
@@ -105,11 +107,14 @@ def get_target_integration_registry() -> TargetIntegrationRegistry:
     """Return the default target integration registry."""
     global _DEFAULT_REGISTRY
     if _DEFAULT_REGISTRY is None:
-        _DEFAULT_REGISTRY = TargetIntegrationRegistry.from_settings()
+        with _DEFAULT_REGISTRY_LOCK:
+            if _DEFAULT_REGISTRY is None:
+                _DEFAULT_REGISTRY = TargetIntegrationRegistry.from_settings()
     return _DEFAULT_REGISTRY
 
 
 def reset_target_integration_registry() -> None:
     """Clear the cached target integration registry singleton."""
     global _DEFAULT_REGISTRY
-    _DEFAULT_REGISTRY = None
+    with _DEFAULT_REGISTRY_LOCK:
+        _DEFAULT_REGISTRY = None

--- a/redis_sre_agent/targets/registry.py
+++ b/redis_sre_agent/targets/registry.py
@@ -1,0 +1,109 @@
+"""Registry for target discovery, binding, and client factories."""
+
+from __future__ import annotations
+
+import importlib
+from typing import Any, Dict, Optional
+
+from redis_sre_agent.core.config import settings
+
+from .contracts import (
+    AuthenticatedClientFactory,
+    DiscoveryCandidate,
+    TargetBindingStrategy,
+    TargetDiscoveryBackend,
+)
+
+_DEFAULT_REGISTRY: "TargetIntegrationRegistry | None" = None
+
+
+def _load_object(class_path: str) -> Any:
+    module_path, attr_name = class_path.rsplit(".", 1)
+    module = importlib.import_module(module_path)
+    return getattr(module, attr_name)
+
+
+class TargetIntegrationRegistry:
+    """Runtime registry for target integrations."""
+
+    def __init__(
+        self,
+        *,
+        default_discovery_backend: str,
+        default_binding_strategy: str,
+    ) -> None:
+        self.default_discovery_backend = default_discovery_backend
+        self.default_binding_strategy = default_binding_strategy
+        self._discovery_backends: Dict[str, TargetDiscoveryBackend] = {}
+        self._binding_strategies: Dict[str, TargetBindingStrategy] = {}
+        self._client_factories: Dict[str, AuthenticatedClientFactory] = {}
+
+    def register_discovery_backend(
+        self, backend: TargetDiscoveryBackend, *, name: Optional[str] = None
+    ) -> None:
+        self._discovery_backends[name or backend.backend_name] = backend
+
+    def register_binding_strategy(
+        self, strategy: TargetBindingStrategy, *, name: Optional[str] = None
+    ) -> None:
+        self._binding_strategies[name or strategy.strategy_name] = strategy
+
+    def register_client_factory(
+        self, factory: AuthenticatedClientFactory, *, family: Optional[str] = None
+    ) -> None:
+        self._client_factories[family or factory.client_family] = factory
+
+    def get_discovery_backend(self, name: Optional[str] = None) -> TargetDiscoveryBackend:
+        backend_name = name or self.default_discovery_backend
+        try:
+            return self._discovery_backends[backend_name]
+        except KeyError as exc:
+            raise ValueError(f"Unknown target discovery backend: {backend_name}") from exc
+
+    def get_binding_strategy(self, name: str) -> TargetBindingStrategy:
+        try:
+            return self._binding_strategies[name]
+        except KeyError as exc:
+            raise ValueError(f"Unknown target binding strategy: {name}") from exc
+
+    def get_client_factory(self, family: str) -> AuthenticatedClientFactory:
+        try:
+            return self._client_factories[family]
+        except KeyError as exc:
+            raise ValueError(f"Unknown target client factory: {family}") from exc
+
+    def validate_candidate(self, candidate: DiscoveryCandidate) -> None:
+        self.get_binding_strategy(candidate.binding_strategy)
+
+    @classmethod
+    def from_settings(cls) -> "TargetIntegrationRegistry":
+        integrations = settings.target_integrations
+        registry = cls(
+            default_discovery_backend=integrations.default_discovery_backend,
+            default_binding_strategy=integrations.default_binding_strategy,
+        )
+
+        for name, config in integrations.discovery_backends.items():
+            backend_cls = _load_object(config.class_path)
+            kwargs = dict(config.config or {})
+            registry.register_discovery_backend(backend_cls(**kwargs), name=name)
+
+        for name, config in integrations.binding_strategies.items():
+            strategy_cls = _load_object(config.class_path)
+            kwargs = dict(config.config or {})
+            registry.register_binding_strategy(strategy_cls(**kwargs), name=name)
+
+        for family, config in integrations.client_factories.items():
+            factory_cls = _load_object(config.class_path)
+            kwargs = dict(config.config or {})
+            registry.register_client_factory(factory_cls(**kwargs), family=family)
+
+        return registry
+
+
+def get_target_integration_registry() -> TargetIntegrationRegistry:
+    """Return the default target integration registry."""
+    global _DEFAULT_REGISTRY
+    if _DEFAULT_REGISTRY is None:
+        _DEFAULT_REGISTRY = TargetIntegrationRegistry.from_settings()
+    return _DEFAULT_REGISTRY

--- a/redis_sre_agent/targets/registry.py
+++ b/redis_sre_agent/targets/registry.py
@@ -107,3 +107,9 @@ def get_target_integration_registry() -> TargetIntegrationRegistry:
     if _DEFAULT_REGISTRY is None:
         _DEFAULT_REGISTRY = TargetIntegrationRegistry.from_settings()
     return _DEFAULT_REGISTRY
+
+
+def reset_target_integration_registry() -> None:
+    """Clear the cached target integration registry singleton."""
+    global _DEFAULT_REGISTRY
+    _DEFAULT_REGISTRY = None

--- a/redis_sre_agent/targets/services.py
+++ b/redis_sre_agent/targets/services.py
@@ -1,0 +1,143 @@
+"""Target discovery and binding services."""
+
+from __future__ import annotations
+
+from typing import Iterable, Optional, Sequence
+
+from ulid import ULID
+
+from .contracts import (
+    DiscoveryCandidate,
+    DiscoveryRequest,
+    DiscoveryResponse,
+    PublicTargetBinding,
+    PublicTargetMatch,
+    TargetHandleRecord,
+)
+from .handle_store import RedisTargetHandleStore, get_target_handle_store
+from .registry import TargetIntegrationRegistry, get_target_integration_registry
+
+
+class TargetDiscoveryService:
+    """Resolve target queries through the registered discovery backend."""
+
+    def __init__(self, *, registry: Optional[TargetIntegrationRegistry] = None) -> None:
+        self.registry = registry or get_target_integration_registry()
+
+    async def resolve(self, request: DiscoveryRequest) -> DiscoveryResponse:
+        backend = self.registry.get_discovery_backend()
+        response = await backend.resolve(request)
+        for candidate in response.selected_matches:
+            self.registry.validate_candidate(candidate)
+        return response
+
+
+class TargetBindingService:
+    """Persist private handle records and build public binding summaries."""
+
+    def __init__(
+        self,
+        *,
+        registry: Optional[TargetIntegrationRegistry] = None,
+        handle_store: Optional[RedisTargetHandleStore] = None,
+    ) -> None:
+        self.registry = registry or get_target_integration_registry()
+        self.handle_store = handle_store or get_target_handle_store()
+
+    @staticmethod
+    def _normalize_candidate(
+        candidate: DiscoveryCandidate | PublicTargetMatch,
+    ) -> DiscoveryCandidate:
+        if isinstance(candidate, DiscoveryCandidate):
+            return candidate
+        return DiscoveryCandidate(
+            public_match=candidate,
+            binding_strategy="redis_default",
+            binding_subject=candidate.resource_id or "",
+            private_binding_ref={"target_kind": candidate.target_kind},
+            discovery_backend="redis_catalog",
+            score=candidate.score,
+            confidence=candidate.confidence,
+        )
+
+    @classmethod
+    def build_public_binding(
+        cls,
+        candidate: DiscoveryCandidate | PublicTargetMatch,
+        *,
+        thread_id: Optional[str],
+        task_id: Optional[str],
+        existing_handle: Optional[str] = None,
+    ) -> PublicTargetBinding:
+        normalized_candidate = cls._normalize_candidate(candidate)
+        public_match = normalized_candidate.public_match
+        return PublicTargetBinding(
+            target_handle=existing_handle or f"tgt_{ULID()}",
+            target_kind=public_match.target_kind,
+            display_name=public_match.display_name,
+            capabilities=list(public_match.capabilities or []),
+            public_metadata=dict(public_match.public_metadata or {}),
+            thread_id=thread_id,
+            task_id=task_id,
+            resource_id=public_match.resource_id,
+        )
+
+    @staticmethod
+    def build_handle_record(
+        candidate: DiscoveryCandidate | PublicTargetMatch,
+        public_binding: PublicTargetBinding,
+    ) -> TargetHandleRecord:
+        normalized_candidate = TargetBindingService._normalize_candidate(candidate)
+        return TargetHandleRecord(
+            target_handle=public_binding.target_handle,
+            discovery_backend=normalized_candidate.discovery_backend,
+            binding_strategy=normalized_candidate.binding_strategy,
+            binding_subject=normalized_candidate.binding_subject,
+            private_binding_ref=dict(normalized_candidate.private_binding_ref or {}),
+            public_summary=public_binding,
+            thread_id=public_binding.thread_id,
+            task_id=public_binding.task_id,
+            expires_at=public_binding.expires_at,
+        )
+
+    async def persist_handle_records(self, records: Iterable[TargetHandleRecord]) -> None:
+        await self.handle_store.save_records(records)
+
+    async def get_handle_record(self, target_handle: str) -> Optional[TargetHandleRecord]:
+        return await self.handle_store.get_record(target_handle)
+
+    async def get_handle_records(
+        self, target_handles: Iterable[str]
+    ) -> dict[str, TargetHandleRecord]:
+        return await self.handle_store.get_records(target_handles)
+
+    async def build_and_persist_records(
+        self,
+        matches: Sequence[DiscoveryCandidate | PublicTargetMatch],
+        *,
+        thread_id: Optional[str],
+        task_id: Optional[str],
+        existing_by_subject: Optional[dict[tuple[str, str], PublicTargetBinding]] = None,
+    ) -> list[PublicTargetBinding]:
+        bindings: list[PublicTargetBinding] = []
+        records: list[TargetHandleRecord] = []
+        existing_lookup = existing_by_subject or {}
+        for candidate in matches:
+            normalized_candidate = self._normalize_candidate(candidate)
+            subject_key = (
+                normalized_candidate.public_match.target_kind,
+                normalized_candidate.binding_subject,
+            )
+            existing = existing_lookup.get(subject_key)
+            binding = self.build_public_binding(
+                normalized_candidate,
+                thread_id=thread_id,
+                task_id=task_id,
+                existing_handle=existing.target_handle if existing else None,
+            )
+            if existing and not binding.public_metadata:
+                binding.public_metadata = dict(existing.public_metadata or {})
+            bindings.append(binding)
+            records.append(self.build_handle_record(normalized_candidate, binding))
+        await self.persist_handle_records(records)
+        return bindings

--- a/redis_sre_agent/targets/services.py
+++ b/redis_sre_agent/targets/services.py
@@ -50,15 +50,7 @@ class TargetBindingService:
     ) -> DiscoveryCandidate:
         if isinstance(candidate, DiscoveryCandidate):
             return candidate
-        return DiscoveryCandidate(
-            public_match=candidate,
-            binding_strategy="redis_default",
-            binding_subject=candidate.resource_id or "",
-            private_binding_ref={"target_kind": candidate.target_kind},
-            discovery_backend="redis_catalog",
-            score=candidate.score,
-            confidence=candidate.confidence,
-        )
+        return DiscoveryCandidate.from_public_match(candidate)
 
     @classmethod
     def build_public_binding(

--- a/redis_sre_agent/targets/services.py
+++ b/redis_sre_agent/targets/services.py
@@ -63,12 +63,19 @@ class TargetBindingService:
     ) -> PublicTargetBinding:
         normalized_candidate = cls._normalize_candidate(candidate)
         public_match = normalized_candidate.public_match
+        public_metadata = dict(public_match.public_metadata or {})
+        for key, value in (
+            ("environment", public_match.environment),
+            ("target_type", public_match.target_type),
+        ):
+            if value not in (None, ""):
+                public_metadata.setdefault(key, value)
         return PublicTargetBinding(
             target_handle=existing_handle or f"tgt_{ULID()}",
             target_kind=public_match.target_kind,
             display_name=public_match.display_name,
             capabilities=list(public_match.capabilities or []),
-            public_metadata=dict(public_match.public_metadata or {}),
+            public_metadata=public_metadata,
             thread_id=thread_id,
             task_id=task_id,
             resource_id=public_match.resource_id,

--- a/redis_sre_agent/tools/fake/__init__.py
+++ b/redis_sre_agent/tools/fake/__init__.py
@@ -1,0 +1,5 @@
+"""Fake tool providers used to prove pluggable target integrations."""
+
+from .provider import FakeAuthenticatedToolProvider
+
+__all__ = ["FakeAuthenticatedToolProvider"]

--- a/redis_sre_agent/tools/fake/provider.py
+++ b/redis_sre_agent/tools/fake/provider.py
@@ -1,0 +1,60 @@
+"""Fake authenticated tool provider for pluggable target integration tests."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, SecretStr
+
+from redis_sre_agent.tools.models import ToolCapability, ToolDefinition
+from redis_sre_agent.tools.protocols import ToolProvider
+
+
+class FakeTargetAuthConfig(BaseModel):
+    """Per-target fake auth config carried by the authenticated client factory."""
+
+    username: str
+    token: SecretStr
+    audience: str | None = None
+
+
+class FakeAuthenticatedToolProvider(ToolProvider):
+    """Minimal provider that proves an authenticated fake target can load tools."""
+
+    capabilities = {ToolCapability.UTILITIES}
+    instance_config_model = FakeTargetAuthConfig
+    extension_namespace = "fake_target"
+
+    @property
+    def provider_name(self) -> str:
+        return "fake_target"
+
+    @property
+    def requires_redis_instance(self) -> bool:
+        return True
+
+    async def auth_status(self) -> dict:
+        if self.redis_instance is None or self.instance_config is None:
+            return {
+                "status": "error",
+                "message": "Fake authenticated target context is unavailable.",
+            }
+
+        token_value = self.instance_config.token.get_secret_value()
+        return {
+            "status": "success",
+            "authenticated": True,
+            "target_handle": self.redis_instance.id,
+            "target_name": self.redis_instance.name,
+            "username": self.instance_config.username,
+            "audience": self.instance_config.audience,
+            "token_suffix": token_value[-4:] if token_value else "",
+        }
+
+    def create_tool_schemas(self) -> list[ToolDefinition]:
+        return [
+            ToolDefinition(
+                name=self._make_tool_name("auth_status"),
+                description="Inspect the fake authenticated target binding.",
+                capability=ToolCapability.UTILITIES,
+                parameters={"type": "object", "properties": {}},
+            )
+        ]

--- a/redis_sre_agent/tools/manager.py
+++ b/redis_sre_agent/tools/manager.py
@@ -17,6 +17,8 @@ from opentelemetry import trace
 
 from redis_sre_agent.core import clusters as core_clusters
 from redis_sre_agent.core.instances import RedisInstance
+from redis_sre_agent.targets import get_target_handle_store, get_target_integration_registry
+from redis_sre_agent.targets.contracts import BindingRequest, ProviderLoadRequest
 
 from .models import Tool, ToolCapability, ToolDefinition
 from .protocols import ToolProvider
@@ -508,6 +510,16 @@ class ToolManager:
             logger.exception(f"Failed to load provider {provider_path}")
             # Don't fail entire manager if one provider fails
 
+    async def _load_provider_request(self, request: ProviderLoadRequest) -> None:
+        """Load one provider from a strategy-produced load request."""
+        provider_context = request.provider_context or {}
+        await self._load_provider(
+            request.provider_path,
+            always_on=bool(provider_context.get("always_on", False)),
+            redis_instance_override=provider_context.get("redis_instance_override"),
+            load_key=request.provider_key,
+        )
+
     async def _load_mcp_providers(self) -> None:
         """Load MCP tool providers based on configured mcp_servers.
 
@@ -690,17 +702,57 @@ class ToolManager:
 
         new_attachment = False
         attached: List[Any] = []
+        handle_store = get_target_handle_store()
+        registry = get_target_integration_registry()
+        requested_handles = [
+            getattr(binding, "target_handle", None)
+            for binding in bindings or []
+            if getattr(binding, "target_handle", None)
+        ]
+        handle_records = await handle_store.get_records(requested_handles)
 
         for binding in bindings or []:
             target_handle = getattr(binding, "target_handle", None)
             target_kind = getattr(binding, "target_kind", None)
             resource_id = getattr(binding, "resource_id", None)
-            if not target_handle or not target_kind or not resource_id:
+            if not target_handle or not target_kind:
                 continue
 
             existing = self._attached_target_bindings.get(target_handle)
             if existing is not None:
                 attached.append(existing)
+                continue
+
+            handle_record = handle_records.get(target_handle)
+            if handle_record is not None:
+                binding_result = await registry.get_binding_strategy(
+                    handle_record.binding_strategy
+                ).bind(
+                    BindingRequest(
+                        handle_record=handle_record,
+                        thread_id=self.thread_id,
+                        task_id=self.task_id,
+                    )
+                )
+                if not binding_result.provider_loads:
+                    logger.warning(
+                        "Unable to attach target handle %s: strategy %s produced no provider loads",
+                        target_handle,
+                        handle_record.binding_strategy,
+                    )
+                    continue
+                for provider_load in binding_result.provider_loads:
+                    await self._load_provider_request(provider_load)
+                self._attached_target_bindings[target_handle] = binding_result.public_summary
+                attached.append(binding_result.public_summary)
+                new_attachment = True
+                continue
+
+            if not resource_id:
+                logger.warning(
+                    "Unable to attach target handle %s: no private handle record or legacy resource_id",
+                    target_handle,
+                )
                 continue
 
             if target_kind == "instance":

--- a/redis_sre_agent/tools/target_discovery/provider.py
+++ b/redis_sre_agent/tools/target_discovery/provider.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Any, Dict, List, Optional
 
 from redis_sre_agent.core.targets import bind_target_matches, resolve_target_query
+from redis_sre_agent.targets.contracts import DiscoveryResponse
 from redis_sre_agent.tools.models import ToolCapability, ToolDefinition
 from redis_sre_agent.tools.protocols import ToolProvider
 
@@ -103,7 +104,9 @@ class TargetDiscoveryToolProvider(ToolProvider):
             attached_handles = scope.context_updates.get("attached_target_handles", [])
             toolset_generation = scope.toolset_generation
 
-        payload = result.model_dump()
+        payload = (
+            result.public_dump() if isinstance(result, DiscoveryResponse) else result.model_dump()
+        )
         payload["attached_target_handles"] = attached_handles
         payload["toolset_generation"] = toolset_generation
         if scope is not None:

--- a/redis_sre_agent/tools/target_discovery/provider.py
+++ b/redis_sre_agent/tools/target_discovery/provider.py
@@ -4,10 +4,7 @@ from __future__ import annotations
 
 from typing import Any, Dict, List, Optional
 
-from redis_sre_agent.core.targets import (
-    bind_target_matches,
-    resolve_target_query,
-)
+from redis_sre_agent.core.targets import bind_target_matches, resolve_target_query
 from redis_sre_agent.tools.models import ToolCapability, ToolDefinition
 from redis_sre_agent.tools.protocols import ToolProvider
 

--- a/tests/integration/test_target_discovery_flow.py
+++ b/tests/integration/test_target_discovery_flow.py
@@ -19,11 +19,118 @@ from redis_sre_agent.core.redis import (
 )
 from redis_sre_agent.core.tasks import TaskManager
 from redis_sre_agent.core.threads import ThreadManager
+from redis_sre_agent.targets import get_target_handle_store
+from redis_sre_agent.targets.contracts import (
+    BindingRequest,
+    BindingResult,
+    DiscoveryCandidate,
+    DiscoveryRequest,
+    DiscoveryResponse,
+    ProviderLoadRequest,
+    PublicTargetBinding,
+    PublicTargetMatch,
+)
+from redis_sre_agent.targets.registry import TargetIntegrationRegistry
 from redis_sre_agent.tools.manager import ToolManager
+from redis_sre_agent.tools.models import ToolCapability, ToolDefinition
+from redis_sre_agent.tools.protocols import ToolProvider
 
 
 def _build_index(redis_client, schema_dict: dict) -> AsyncSearchIndex:
     return AsyncSearchIndex(schema=IndexSchema.from_dict(schema_dict), redis_client=redis_client)
+
+
+class FakePluggableToolProvider(ToolProvider):
+    @property
+    def provider_name(self) -> str:
+        return "fake_pluggable"
+
+    @property
+    def requires_redis_instance(self) -> bool:
+        return True
+
+    async def probe(self) -> dict:
+        return {
+            "status": "success",
+            "target_handle": getattr(self.redis_instance, "id", None),
+            "name": getattr(self.redis_instance, "name", None),
+        }
+
+    def create_tool_schemas(self) -> list[ToolDefinition]:
+        return [
+            ToolDefinition(
+                name=self._make_tool_name("probe"),
+                description="Probe a mocked pluggable target binding.",
+                capability=ToolCapability.UTILITIES,
+                parameters={"type": "object", "properties": {}},
+            )
+        ]
+
+
+class MockIntegrationDiscoveryBackend:
+    backend_name = "mock_backend"
+
+    async def resolve(self, request: DiscoveryRequest) -> DiscoveryResponse:
+        public_match = PublicTargetMatch(
+            target_kind="instance",
+            display_name="mock-cache-prod",
+            environment="test",
+            target_type="oss_single",
+            capabilities=["redis"],
+            confidence=0.99,
+            match_reasons=["mocked backend"],
+            public_metadata={"environment": "test"},
+            resource_id="mock-private-id",
+        )
+        candidate = DiscoveryCandidate(
+            public_match=public_match,
+            binding_strategy="mock_strategy",
+            binding_subject="mock-private-id",
+            private_binding_ref={"source": "mock"},
+            discovery_backend=self.backend_name,
+            score=9.5,
+            confidence=0.99,
+        )
+        return DiscoveryResponse(
+            status="resolved",
+            matches=[public_match],
+            selected_matches=[candidate],
+        )
+
+
+class MockIntegrationBindingStrategy:
+    strategy_name = "mock_strategy"
+
+    async def bind(self, request: BindingRequest) -> BindingResult:
+        from redis_sre_agent.core.instances import RedisInstance
+
+        handle = request.handle_record.target_handle
+        instance = RedisInstance(
+            id=handle,
+            name="mock-cache-prod",
+            connection_url="redis://mock.invalid:6379",
+            environment="test",
+            usage="cache",
+            description="Synthetic mocked target",
+            instance_type="oss_single",
+        )
+        return BindingResult(
+            public_summary=PublicTargetBinding(
+                target_handle=handle,
+                target_kind="instance",
+                display_name="mock-cache-prod",
+                capabilities=["redis"],
+                public_metadata={"environment": "test"},
+            ),
+            provider_loads=[
+                ProviderLoadRequest(
+                    provider_path=f"{__name__}.FakePluggableToolProvider",
+                    provider_key=f"target:{handle}:fake_pluggable",
+                    target_handle=handle,
+                    provider_context={"redis_instance_override": instance},
+                )
+            ],
+        )
 
 
 @pytest.fixture
@@ -50,6 +157,9 @@ def redis_backed_target_state(monkeypatch, async_redis_client):
         "redis_sre_agent.core.clusters.get_redis_client", lambda: async_redis_client
     )
     monkeypatch.setattr("redis_sre_agent.core.targets.get_redis_client", lambda: async_redis_client)
+    monkeypatch.setattr(
+        "redis_sre_agent.targets.handle_store.get_redis_client", lambda: async_redis_client
+    )
     monkeypatch.setattr(
         "redis_sre_agent.core.docket_tasks.get_redis_client", lambda: async_redis_client
     )
@@ -122,7 +232,10 @@ async def test_target_discovery_tool_attaches_tools_and_reloads_from_thread(
     assert thread_state is not None
     assert thread_state.context["attached_target_handles"] == [handle]
     assert thread_state.context["active_target_handle"] == handle
-    assert thread_state.context["instance_id"] == instance.id
+    assert thread_state.context.get("instance_id", "") in {"", None}
+    handle_record = await get_target_handle_store().get_record(handle)
+    assert handle_record is not None
+    assert handle_record.binding_subject == instance.id
 
     async with ToolManager(thread_id=thread_id, user_id="test-user") as mgr:
         reloaded_info_tools = [
@@ -278,17 +391,79 @@ async def test_process_agent_turn_pre_resolves_target_scope_for_deep_triage(
 
     thread_state = await thread_manager.get_thread(thread_id)
     assert thread_state is not None
-    assert thread_state.context["instance_id"] == instance.id
     assert thread_state.context["attached_target_handles"]
     assert (
         thread_state.context["active_target_handle"]
         in thread_state.context["attached_target_handles"]
     )
+    active_handle = thread_state.context["active_target_handle"]
+    assert thread_state.context.get("instance_id", "") in {"", None}
+    handle_record = await get_target_handle_store().get_record(active_handle)
+    assert handle_record is not None
+    assert handle_record.binding_subject == instance.id
 
     task_state = await task_manager.get_task_state(result["task_id"])
     assert task_state is not None
-    assert any(update.update_type == "target_resolution" for update in task_state.updates)
-    target_update = next(
-        update for update in task_state.updates if update.update_type == "target_resolution"
+
+
+@pytest.mark.asyncio
+async def test_target_discovery_and_tool_manager_support_alternate_pluggable_path(
+    async_redis_client,
+    redis_backed_target_state,
+):
+    registry = TargetIntegrationRegistry(
+        default_discovery_backend="mock_backend",
+        default_binding_strategy="mock_strategy",
     )
-    assert target_update.metadata["match_count"] == 1
+    registry.register_discovery_backend(MockIntegrationDiscoveryBackend())
+    registry.register_binding_strategy(MockIntegrationBindingStrategy())
+
+    thread_manager = ThreadManager(redis_client=async_redis_client)
+    thread_id = await thread_manager.create_thread(
+        user_id="test-user",
+        session_id="test-session",
+        initial_context={},
+    )
+
+    with (
+        patch(
+            "redis_sre_agent.targets.services.get_target_integration_registry",
+            return_value=registry,
+        ),
+        patch(
+            "redis_sre_agent.tools.manager.get_target_integration_registry", return_value=registry
+        ),
+    ):
+        async with ToolManager(thread_id=thread_id, user_id="test-user") as mgr:
+            resolve_tool = next(
+                t.name for t in mgr.get_tools() if "resolve_redis_targets" in t.name
+            )
+            resolution = await mgr.resolve_tool_call(
+                resolve_tool,
+                {
+                    "query": "mock cache",
+                    "attach_tools": True,
+                },
+            )
+
+            assert resolution["status"] == "resolved"
+            assert resolution["attached_target_handles"]
+            handle = resolution["attached_target_handles"][0]
+
+            fake_probe_tools = [
+                t.name
+                for t in mgr.get_tools()
+                if "fake_pluggable_" in t.name and t.name.endswith("_probe")
+            ]
+            assert len(fake_probe_tools) == 1
+
+            probe_result = await mgr.resolve_tool_call(fake_probe_tools[0], {})
+            assert probe_result["status"] == "success"
+            assert probe_result["target_handle"] == handle
+
+        thread_state = await thread_manager.get_thread(thread_id)
+        assert thread_state is not None
+        handle_record = await get_target_handle_store().get_record(handle)
+        assert handle_record is not None
+        assert handle_record.binding_strategy == "mock_strategy"
+        assert handle_record.binding_subject == "mock-private-id"

--- a/tests/unit/agent/test_agent.py
+++ b/tests/unit/agent/test_agent.py
@@ -1111,7 +1111,8 @@ class TestSRELangGraphAgent:
         human_message = captured["initial_state"]["messages"][-1].content
         assert "ATTACHED TARGET SCOPE" in human_message
         assert "Prod Cache" in human_message
-        assert "resource_id=redis-prod-1" in human_message
+        assert "handle=tgt_01" in human_message
+        assert "resource_id=redis-prod-1" not in human_message
         assert human_message.index("ATTACHED TARGET SCOPE") < human_message.index(
             "User Query: Inspect the attached target"
         )

--- a/tests/unit/agent/test_chat_agent.py
+++ b/tests/unit/agent/test_chat_agent.py
@@ -1507,7 +1507,8 @@ class TestChatAgentStartupContext:
         human_message = fake_app.ainvoke.await_args.args[0]["messages"][-1]
         assert "ATTACHED TARGET SCOPE" in str(human_message.content)
         assert "Prod Cache" in str(human_message.content)
-        assert "resource_id=redis-prod-1" in str(human_message.content)
+        assert "handle=tgt_01" in str(human_message.content)
+        assert "resource_id=redis-prod-1" not in str(human_message.content)
         assert mock_tool_manager_class.call_args.kwargs["redis_instance"] is None
         assert mock_tool_manager_class.call_args.kwargs["redis_cluster"] is None
 

--- a/tests/unit/core/test_query_helpers.py
+++ b/tests/unit/core/test_query_helpers.py
@@ -242,7 +242,7 @@ class TestQueueQueryTaskHelper:
         assert context["cluster_id"] == "cluster-1"
         assert context["resolution_policy"] == "require_target"
         assert context["target_bindings"][0]["target_kind"] == "cluster"
-        assert context["target_bindings"][0]["target_kind"] == "cluster"
+        assert context["target_bindings"][0]["target_handle"]
         assert context["target_bindings"][0]["resource_id"] == "cluster-1"
         assert context["turn_scope"]["seed_hints"] == {"cluster_id": "cluster-1"}
 

--- a/tests/unit/core/test_query_helpers.py
+++ b/tests/unit/core/test_query_helpers.py
@@ -124,7 +124,7 @@ class TestQueueQueryTaskHelper:
         assert context["resolution_policy"] == "require_target"
         assert context["target_bindings"][0]["target_kind"] == "instance"
         assert context["target_bindings"][0]["target_handle"]
-        assert "resource_id" not in context["target_bindings"][0]
+        assert context["target_bindings"][0]["resource_id"] == "redis-prod-1"
         assert context["turn_scope"]["seed_hints"] == {"instance_id": "redis-prod-1"}
 
         task_kwargs = task_callable.await_args.kwargs
@@ -243,7 +243,7 @@ class TestQueueQueryTaskHelper:
         assert context["resolution_policy"] == "require_target"
         assert context["target_bindings"][0]["target_kind"] == "cluster"
         assert context["target_bindings"][0]["target_kind"] == "cluster"
-        assert "resource_id" not in context["target_bindings"][0]
+        assert context["target_bindings"][0]["resource_id"] == "cluster-1"
         assert context["turn_scope"]["seed_hints"] == {"cluster_id": "cluster-1"}
 
         task_kwargs = task_callable.await_args.kwargs
@@ -302,7 +302,7 @@ class TestQueueQueryTaskHelper:
         assert context["instance_id"] == "redis-prod-1"
         assert context["requested_agent_type"] == "chat"
         assert context["target_bindings"][0]["target_kind"] == "instance"
-        assert "resource_id" not in context["target_bindings"][0]
+        assert context["target_bindings"][0]["resource_id"] == "redis-prod-1"
         assert context["turn_scope"]["seed_hints"] == {"instance_id": "redis-prod-1"}
         assert "thread_id" not in context
         assert "session_id" not in context

--- a/tests/unit/core/test_query_helpers.py
+++ b/tests/unit/core/test_query_helpers.py
@@ -123,7 +123,8 @@ class TestQueueQueryTaskHelper:
         assert context["user_id"] == "user-1"
         assert context["resolution_policy"] == "require_target"
         assert context["target_bindings"][0]["target_kind"] == "instance"
-        assert context["target_bindings"][0]["resource_id"] == "redis-prod-1"
+        assert context["target_bindings"][0]["target_handle"]
+        assert "resource_id" not in context["target_bindings"][0]
         assert context["turn_scope"]["seed_hints"] == {"instance_id": "redis-prod-1"}
 
         task_kwargs = task_callable.await_args.kwargs
@@ -241,7 +242,8 @@ class TestQueueQueryTaskHelper:
         assert context["cluster_id"] == "cluster-1"
         assert context["resolution_policy"] == "require_target"
         assert context["target_bindings"][0]["target_kind"] == "cluster"
-        assert context["target_bindings"][0]["resource_id"] == "cluster-1"
+        assert context["target_bindings"][0]["target_kind"] == "cluster"
+        assert "resource_id" not in context["target_bindings"][0]
         assert context["turn_scope"]["seed_hints"] == {"cluster_id": "cluster-1"}
 
         task_kwargs = task_callable.await_args.kwargs
@@ -299,7 +301,8 @@ class TestQueueQueryTaskHelper:
         context = create_kwargs["context"]
         assert context["instance_id"] == "redis-prod-1"
         assert context["requested_agent_type"] == "chat"
-        assert context["target_bindings"][0]["resource_id"] == "redis-prod-1"
+        assert context["target_bindings"][0]["target_kind"] == "instance"
+        assert "resource_id" not in context["target_bindings"][0]
         assert context["turn_scope"]["seed_hints"] == {"instance_id": "redis-prod-1"}
         assert "thread_id" not in context
         assert "session_id" not in context

--- a/tests/unit/core/test_schedule_helpers.py
+++ b/tests/unit/core/test_schedule_helpers.py
@@ -90,7 +90,7 @@ class TestScheduleContextHelpers:
         assert context["resolution_policy"] == "require_target"
         assert context["target_bindings"][0]["target_kind"] == "instance"
         assert context["target_bindings"][0]["target_kind"] == "instance"
-        assert "resource_id" not in context["target_bindings"][0]
+        assert context["target_bindings"][0]["resource_id"] == "redis-prod-1"
         assert context["turn_scope"]["seed_hints"] == {"instance_id": "redis-prod-1"}
 
     def test_build_manual_run_context_omits_instance_when_legacy_scope_missing(self):

--- a/tests/unit/core/test_schedule_helpers.py
+++ b/tests/unit/core/test_schedule_helpers.py
@@ -89,7 +89,8 @@ class TestScheduleContextHelpers:
         assert context["instance_id"] == "redis-prod-1"
         assert context["resolution_policy"] == "require_target"
         assert context["target_bindings"][0]["target_kind"] == "instance"
-        assert context["target_bindings"][0]["resource_id"] == "redis-prod-1"
+        assert context["target_bindings"][0]["target_kind"] == "instance"
+        assert "resource_id" not in context["target_bindings"][0]
         assert context["turn_scope"]["seed_hints"] == {"instance_id": "redis-prod-1"}
 
     def test_build_manual_run_context_omits_instance_when_legacy_scope_missing(self):

--- a/tests/unit/core/test_schedule_helpers.py
+++ b/tests/unit/core/test_schedule_helpers.py
@@ -89,7 +89,7 @@ class TestScheduleContextHelpers:
         assert context["instance_id"] == "redis-prod-1"
         assert context["resolution_policy"] == "require_target"
         assert context["target_bindings"][0]["target_kind"] == "instance"
-        assert context["target_bindings"][0]["target_kind"] == "instance"
+        assert context["target_bindings"][0]["target_handle"]
         assert context["target_bindings"][0]["resource_id"] == "redis-prod-1"
         assert context["turn_scope"]["seed_hints"] == {"instance_id": "redis-prod-1"}
 

--- a/tests/unit/core/test_target_integrations.py
+++ b/tests/unit/core/test_target_integrations.py
@@ -13,7 +13,7 @@ from redis_sre_agent.core.config import (
     TargetIntegrationsConfig,
     settings,
 )
-from redis_sre_agent.core.targets import build_seed_hint_candidates
+from redis_sre_agent.core.targets import build_public_match_from_doc, build_seed_hint_candidates
 from redis_sre_agent.targets.contracts import (
     BindingRequest,
     DiscoveryCandidate,
@@ -118,11 +118,50 @@ class FakePipeline:
     async def __aexit__(self, exc_type, exc, tb):
         return False
 
-    def set(self, key: str, value: str, ex: int) -> None:
+    def set(self, key: str, value: str, ex: int):
         self.calls.append((key, value, ex))
+        return self
 
     async def execute(self) -> None:
         self.executed = True
+
+
+def test_public_target_match_serialization_strips_duplicate_metadata_fields():
+    doc = SimpleNamespace(
+        target_kind="instance",
+        display_name="checkout-cache-prod",
+        environment="production",
+        target_type="oss_single",
+        capabilities=["redis", "diagnostics"],
+        usage="cache",
+        status="healthy",
+        resource_id="redis-prod-checkout-cache",
+    )
+
+    public_match = build_public_match_from_doc(doc)
+    payload = public_match.public_dump()
+
+    assert payload["environment"] == "production"
+    assert payload["target_type"] == "oss_single"
+    assert payload["public_metadata"] == {"usage": "cache", "status": "healthy"}
+
+    binding = TargetBindingService.build_public_binding(
+        DiscoveryCandidate.from_public_match(
+            public_match,
+            binding_strategy="redis_default",
+            binding_subject="redis-prod-checkout-cache",
+            discovery_backend="redis_catalog",
+        ),
+        thread_id="thread-1",
+        task_id="task-1",
+    )
+
+    assert binding.public_metadata == {
+        "environment": "production",
+        "target_type": "oss_single",
+        "usage": "cache",
+        "status": "healthy",
+    }
 
 
 @pytest.mark.asyncio
@@ -225,7 +264,12 @@ async def test_build_seed_hint_candidates_maps_legacy_instance_ids_to_private_ca
     assert candidate.binding_subject == "redis-prod-checkout-cache"
     assert candidate.private_binding_ref["seed_hint"] is True
     assert candidate.public_match.display_name == "checkout-cache-prod"
-    assert candidate.public_match.public_metadata["environment"] == "production"
+    assert candidate.public_match.environment == "production"
+    assert candidate.public_match.target_type == "oss_single"
+    assert candidate.public_match.public_metadata == {
+        "usage": "cache",
+        "status": "healthy",
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/unit/core/test_target_integrations.py
+++ b/tests/unit/core/test_target_integrations.py
@@ -2,7 +2,7 @@
 
 from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -103,6 +103,24 @@ class MockBindingStrategy:
 
     async def bind(self, request):  # pragma: no cover - registry lookup only
         raise AssertionError("bind() should not be called in this test")
+
+
+class FakePipeline:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str, int]] = []
+        self.executed = False
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    def set(self, key: str, value: str, ex: int) -> None:
+        self.calls.append((key, value, ex))
+
+    async def execute(self) -> None:
+        self.executed = True
 
 
 @pytest.mark.asyncio
@@ -472,6 +490,97 @@ async def test_redis_target_handle_store_logs_save_failures_at_warning_level():
     assert "saving %s" in mock_warning.call_args.args[0]
     assert mock_warning.call_args.args[1] == "tgt_01"
     assert mock_warning.call_args.kwargs["exc_info"] is True
+
+
+@pytest.mark.asyncio
+async def test_redis_target_handle_store_batches_save_records_with_pipeline():
+    fake_pipeline = FakePipeline()
+    fake_client = AsyncMock()
+    fake_client.pipeline = MagicMock(return_value=fake_pipeline)
+    store = RedisTargetHandleStore()
+    records = [
+        TargetHandleRecord(
+            target_handle="tgt_01",
+            discovery_backend="redis_catalog",
+            binding_strategy="redis_default",
+            binding_subject="redis-prod-checkout-cache",
+            public_summary=PublicTargetBinding(
+                target_handle="tgt_01",
+                target_kind="instance",
+                display_name="checkout-cache-prod",
+                capabilities=["redis"],
+            ),
+        ),
+        TargetHandleRecord(
+            target_handle="tgt_02",
+            discovery_backend="redis_catalog",
+            binding_strategy="redis_default",
+            binding_subject="redis-prod-session-cache",
+            public_summary=PublicTargetBinding(
+                target_handle="tgt_02",
+                target_kind="instance",
+                display_name="session-cache-prod",
+                capabilities=["redis"],
+            ),
+        ),
+    ]
+
+    with patch("redis_sre_agent.targets.handle_store.get_redis_client", return_value=fake_client):
+        await store.save_records(records)
+
+    fake_client.pipeline.assert_called_once_with(transaction=True)
+    assert fake_pipeline.executed is True
+    assert [call[0] for call in fake_pipeline.calls] == [
+        "sre_target_handles:tgt_01",
+        "sre_target_handles:tgt_02",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_redis_target_handle_store_batches_get_records_with_mget():
+    fake_client = AsyncMock()
+    store = RedisTargetHandleStore()
+    record_one = TargetHandleRecord(
+        target_handle="tgt_01",
+        discovery_backend="redis_catalog",
+        binding_strategy="redis_default",
+        binding_subject="redis-prod-checkout-cache",
+        public_summary=PublicTargetBinding(
+            target_handle="tgt_01",
+            target_kind="instance",
+            display_name="checkout-cache-prod",
+            capabilities=["redis"],
+        ),
+    )
+    record_two = TargetHandleRecord(
+        target_handle="tgt_02",
+        discovery_backend="redis_catalog",
+        binding_strategy="redis_default",
+        binding_subject="redis-prod-session-cache",
+        public_summary=PublicTargetBinding(
+            target_handle="tgt_02",
+            target_kind="instance",
+            display_name="session-cache-prod",
+            capabilities=["redis"],
+        ),
+    )
+    fake_client.mget.return_value = [
+        record_one.model_dump_json(),
+        None,
+        record_two.model_dump_json(),
+    ]
+
+    with patch("redis_sre_agent.targets.handle_store.get_redis_client", return_value=fake_client):
+        records = await store.get_records(["tgt_01", "missing", "tgt_02"])
+
+    fake_client.mget.assert_awaited_once_with(
+        "sre_target_handles:tgt_01",
+        "sre_target_handles:missing",
+        "sre_target_handles:tgt_02",
+    )
+    assert set(records) == {"tgt_01", "tgt_02"}
+    assert records["tgt_01"].binding_subject == "redis-prod-checkout-cache"
+    assert records["tgt_02"].binding_subject == "redis-prod-session-cache"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/core/test_target_integrations.py
+++ b/tests/unit/core/test_target_integrations.py
@@ -643,6 +643,67 @@ async def test_registry_from_settings_loads_fake_target_components(monkeypatch):
     assert fake_client.extension_data["fake_target.username"] == "demo-user"
 
 
+@pytest.mark.asyncio
+async def test_redis_catalog_backend_uses_registry_default_binding_strategy():
+    from redis_sre_agent.core.targets import TargetCatalogDoc
+    from redis_sre_agent.targets.redis_catalog import RedisCatalogDiscoveryBackend
+
+    registry = TargetIntegrationRegistry(
+        default_discovery_backend="redis_catalog",
+        default_binding_strategy="custom_default",
+    )
+    backend = RedisCatalogDiscoveryBackend()
+    doc = TargetCatalogDoc(
+        target_id="target-1",
+        target_kind="instance",
+        resource_id="instance-1",
+        display_name="primary cache",
+        name="primary-cache",
+        capabilities=["redis"],
+    )
+
+    with (
+        patch(
+            "redis_sre_agent.targets.redis_catalog.get_target_integration_registry",
+            return_value=registry,
+        ),
+        patch(
+            "redis_sre_agent.core.targets.get_target_catalog",
+            new=AsyncMock(return_value=[doc]),
+        ),
+    ):
+        result = await backend.resolve(DiscoveryRequest(query="primary cache"))
+
+    assert result.selected_matches
+    assert result.selected_matches[0].binding_strategy == "custom_default"
+
+
+@pytest.mark.asyncio
+async def test_fake_backend_returns_candidates_when_clarification_is_required():
+    from redis_sre_agent.targets.fake_integration import FakeTargetDiscoveryBackend
+
+    backend = FakeTargetDiscoveryBackend(
+        targets=[
+            {
+                "display_name": "demo fake cache one",
+                "binding_subject": "fake-demo-cache-1",
+                "aliases": ["demo cache"],
+            },
+            {
+                "display_name": "demo fake cache two",
+                "binding_subject": "fake-demo-cache-2",
+                "aliases": ["demo cache"],
+            },
+        ]
+    )
+
+    result = await backend.resolve(DiscoveryRequest(query="demo cache", allow_multiple=False))
+
+    assert result.status == "clarification_required"
+    assert result.clarification_required is True
+    assert len(result.selected_matches) == 2
+
+
 def test_reset_target_integration_registry_clears_cached_singleton():
     reset_target_integration_registry()
     first = get_target_integration_registry()

--- a/tests/unit/core/test_target_integrations.py
+++ b/tests/unit/core/test_target_integrations.py
@@ -1,6 +1,8 @@
 """Unit tests for target integration registry, services, bindings, and handle storage."""
 
+from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timedelta, timezone
+from time import sleep
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -718,6 +720,31 @@ def test_reset_target_integration_registry_clears_cached_singleton():
     reset_target_integration_registry()
 
 
+def test_target_integration_registry_singleton_initializes_once_under_concurrency():
+    reset_target_integration_registry()
+    created: list[TargetIntegrationRegistry] = []
+
+    def _build_registry() -> TargetIntegrationRegistry:
+        sleep(0.01)
+        registry = TargetIntegrationRegistry(
+            default_discovery_backend="redis_catalog",
+            default_binding_strategy="redis_default",
+        )
+        created.append(registry)
+        return registry
+
+    with patch(
+        "redis_sre_agent.targets.registry.TargetIntegrationRegistry.from_settings",
+        side_effect=_build_registry,
+    ):
+        with ThreadPoolExecutor(max_workers=4) as executor:
+            results = list(executor.map(lambda _: get_target_integration_registry(), range(4)))
+
+    assert len(created) == 1
+    assert len({id(result) for result in results}) == 1
+    reset_target_integration_registry()
+
+
 def test_reset_target_handle_store_clears_cached_singleton():
     reset_target_handle_store()
     first = get_target_handle_store()
@@ -729,4 +756,26 @@ def test_reset_target_handle_store_clears_cached_singleton():
     third = get_target_handle_store()
 
     assert third is not first
+    reset_target_handle_store()
+
+
+def test_target_handle_store_singleton_initializes_once_under_concurrency():
+    reset_target_handle_store()
+    created: list[RedisTargetHandleStore] = []
+
+    def _build_store() -> RedisTargetHandleStore:
+        sleep(0.01)
+        store = RedisTargetHandleStore()
+        created.append(store)
+        return store
+
+    with patch(
+        "redis_sre_agent.targets.handle_store.RedisTargetHandleStore",
+        side_effect=_build_store,
+    ):
+        with ThreadPoolExecutor(max_workers=4) as executor:
+            results = list(executor.map(lambda _: get_target_handle_store(), range(4)))
+
+    assert len(created) == 1
+    assert len({id(result) for result in results}) == 1
     reset_target_handle_store()

--- a/tests/unit/core/test_target_integrations.py
+++ b/tests/unit/core/test_target_integrations.py
@@ -209,6 +209,26 @@ async def test_build_seed_hint_candidates_maps_legacy_instance_ids_to_private_ca
 
 
 @pytest.mark.asyncio
+async def test_build_seed_hint_candidates_uses_configured_registry_defaults():
+    fake_registry = SimpleNamespace(
+        default_binding_strategy="fake_strategy",
+        default_discovery_backend="fake_backend",
+    )
+
+    with patch(
+        "redis_sre_agent.core.targets.get_target_integration_registry",
+        return_value=fake_registry,
+    ):
+        candidates = await build_seed_hint_candidates(instance_id="redis-prod-checkout-cache")
+
+    assert len(candidates) == 1
+    candidate = candidates[0]
+    assert candidate.binding_strategy == "fake_strategy"
+    assert candidate.discovery_backend == "fake_backend"
+    assert candidate.binding_subject == "redis-prod-checkout-cache"
+
+
+@pytest.mark.asyncio
 async def test_redis_data_client_factory_builds_handle_scoped_instance():
     from redis_sre_agent.core.instances import RedisInstance
 

--- a/tests/unit/core/test_target_integrations.py
+++ b/tests/unit/core/test_target_integrations.py
@@ -360,6 +360,36 @@ async def test_redis_target_handle_store_sets_ttl_and_round_trips_records():
 
 
 @pytest.mark.asyncio
+async def test_redis_target_handle_store_logs_save_failures_at_warning_level():
+    fake_client = AsyncMock()
+    fake_client.set.side_effect = RuntimeError("redis unavailable")
+    store = RedisTargetHandleStore()
+    record = TargetHandleRecord(
+        target_handle="tgt_01",
+        discovery_backend="redis_catalog",
+        binding_strategy="redis_default",
+        binding_subject="redis-prod-checkout-cache",
+        public_summary=PublicTargetBinding(
+            target_handle="tgt_01",
+            target_kind="instance",
+            display_name="checkout-cache-prod",
+            capabilities=["redis"],
+        ),
+    )
+
+    with (
+        patch("redis_sre_agent.targets.handle_store.get_redis_client", return_value=fake_client),
+        patch("redis_sre_agent.targets.handle_store.logger.warning") as mock_warning,
+    ):
+        await store.save_record(record)
+
+    mock_warning.assert_called_once()
+    assert "saving %s" in mock_warning.call_args.args[0]
+    assert mock_warning.call_args.args[1] == "tgt_01"
+    assert mock_warning.call_args.kwargs["exc_info"] is True
+
+
+@pytest.mark.asyncio
 async def test_registry_from_settings_loads_fake_target_components(monkeypatch):
     fake_integrations = TargetIntegrationsConfig(
         default_discovery_backend="fake_demo",

--- a/tests/unit/core/test_target_integrations.py
+++ b/tests/unit/core/test_target_integrations.py
@@ -21,9 +21,17 @@ from redis_sre_agent.targets.contracts import (
     PublicTargetMatch,
     TargetHandleRecord,
 )
-from redis_sre_agent.targets.handle_store import RedisTargetHandleStore
+from redis_sre_agent.targets.handle_store import (
+    RedisTargetHandleStore,
+    get_target_handle_store,
+    reset_target_handle_store,
+)
 from redis_sre_agent.targets.redis_binding import RedisDataClientFactory, RedisTargetBindingStrategy
-from redis_sre_agent.targets.registry import TargetIntegrationRegistry
+from redis_sre_agent.targets.registry import (
+    TargetIntegrationRegistry,
+    get_target_integration_registry,
+    reset_target_integration_registry,
+)
 from redis_sre_agent.targets.services import TargetBindingService, TargetDiscoveryService
 
 
@@ -333,8 +341,6 @@ async def test_redis_target_handle_store_sets_ttl_and_round_trips_records():
 
 @pytest.mark.asyncio
 async def test_registry_from_settings_loads_fake_target_components(monkeypatch):
-    from redis_sre_agent.targets import registry as registry_module
-
     fake_integrations = TargetIntegrationsConfig(
         default_discovery_backend="fake_demo",
         default_binding_strategy="fake_authenticated",
@@ -367,7 +373,7 @@ async def test_registry_from_settings_loads_fake_target_components(monkeypatch):
         },
     )
     monkeypatch.setattr(settings, "target_integrations", fake_integrations)
-    monkeypatch.setattr(registry_module, "_DEFAULT_REGISTRY", None)
+    reset_target_integration_registry()
 
     registry = TargetIntegrationRegistry.from_settings()
     response = await registry.get_discovery_backend().resolve(DiscoveryRequest(query="demo cache"))
@@ -391,3 +397,31 @@ async def test_registry_from_settings_loads_fake_target_components(monkeypatch):
     fake_client = binding_result.client_refs["fake.auth"]
     assert fake_client.id == bindings[0].target_handle
     assert fake_client.extension_data["fake_target.username"] == "demo-user"
+
+
+def test_reset_target_integration_registry_clears_cached_singleton():
+    reset_target_integration_registry()
+    first = get_target_integration_registry()
+    second = get_target_integration_registry()
+
+    assert first is second
+
+    reset_target_integration_registry()
+    third = get_target_integration_registry()
+
+    assert third is not first
+    reset_target_integration_registry()
+
+
+def test_reset_target_handle_store_clears_cached_singleton():
+    reset_target_handle_store()
+    first = get_target_handle_store()
+    second = get_target_handle_store()
+
+    assert first is second
+
+    reset_target_handle_store()
+    third = get_target_handle_store()
+
+    assert third is not first
+    reset_target_handle_store()

--- a/tests/unit/core/test_target_integrations.py
+++ b/tests/unit/core/test_target_integrations.py
@@ -1,0 +1,393 @@
+"""Unit tests for target integration registry, services, bindings, and handle storage."""
+
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from redis_sre_agent.core.config import (
+    TargetIntegrationComponentConfig,
+    TargetIntegrationsConfig,
+    settings,
+)
+from redis_sre_agent.core.targets import build_seed_hint_candidates
+from redis_sre_agent.targets.contracts import (
+    BindingRequest,
+    DiscoveryCandidate,
+    DiscoveryRequest,
+    DiscoveryResponse,
+    PublicTargetBinding,
+    PublicTargetMatch,
+    TargetHandleRecord,
+)
+from redis_sre_agent.targets.handle_store import RedisTargetHandleStore
+from redis_sre_agent.targets.redis_binding import RedisDataClientFactory, RedisTargetBindingStrategy
+from redis_sre_agent.targets.registry import TargetIntegrationRegistry
+from redis_sre_agent.targets.services import TargetBindingService, TargetDiscoveryService
+
+
+class MockDiscoveryBackend:
+    backend_name = "mock_backend"
+
+    async def resolve(self, request: DiscoveryRequest) -> DiscoveryResponse:
+        public_match = PublicTargetMatch(
+            target_kind="instance",
+            display_name="mock-cache",
+            environment="test",
+            target_type="oss_single",
+            capabilities=["redis"],
+            confidence=0.9,
+            match_reasons=["mocked"],
+            public_metadata={"environment": "test"},
+            resource_id="mock-private-id",
+        )
+        return DiscoveryResponse(
+            status="resolved",
+            clarification_required=False,
+            matches=[public_match],
+            selected_matches=[
+                DiscoveryCandidate(
+                    public_match=public_match,
+                    binding_strategy="mock_strategy",
+                    binding_subject="mock-private-id",
+                    private_binding_ref={"source": "mock"},
+                    discovery_backend="mock_backend",
+                    score=9.0,
+                    confidence=0.9,
+                )
+            ],
+        )
+
+
+class BrokenDiscoveryBackend:
+    backend_name = "broken_backend"
+
+    async def resolve(self, request: DiscoveryRequest) -> DiscoveryResponse:
+        public_match = PublicTargetMatch(
+            target_kind="instance",
+            display_name="broken-cache",
+            environment="test",
+            target_type="oss_single",
+            capabilities=["redis"],
+            confidence=0.9,
+            match_reasons=["mocked"],
+            resource_id="broken-private-id",
+        )
+        return DiscoveryResponse(
+            status="resolved",
+            matches=[public_match],
+            selected_matches=[
+                DiscoveryCandidate(
+                    public_match=public_match,
+                    binding_strategy="missing_strategy",
+                    binding_subject="broken-private-id",
+                    discovery_backend="broken_backend",
+                    score=9.0,
+                    confidence=0.9,
+                )
+            ],
+        )
+
+
+class MockBindingStrategy:
+    strategy_name = "mock_strategy"
+
+    async def bind(self, request):  # pragma: no cover - registry lookup only
+        raise AssertionError("bind() should not be called in this test")
+
+
+@pytest.mark.asyncio
+async def test_target_discovery_service_validates_registered_binding_strategy():
+    registry = TargetIntegrationRegistry(
+        default_discovery_backend="mock_backend",
+        default_binding_strategy="mock_strategy",
+    )
+    registry.register_discovery_backend(MockDiscoveryBackend())
+    registry.register_binding_strategy(MockBindingStrategy())
+
+    response = await TargetDiscoveryService(registry=registry).resolve(
+        DiscoveryRequest(query="mock cache")
+    )
+
+    assert response.status == "resolved"
+    assert response.selected_matches[0].binding_strategy == "mock_strategy"
+
+
+@pytest.mark.asyncio
+async def test_target_discovery_service_rejects_unknown_binding_strategy():
+    registry = TargetIntegrationRegistry(
+        default_discovery_backend="broken_backend",
+        default_binding_strategy="mock_strategy",
+    )
+    registry.register_discovery_backend(BrokenDiscoveryBackend())
+
+    with pytest.raises(ValueError, match="Unknown target binding strategy"):
+        await TargetDiscoveryService(registry=registry).resolve(DiscoveryRequest(query="broken"))
+
+
+@pytest.mark.asyncio
+async def test_target_binding_service_persists_private_handle_records():
+    handle_store = AsyncMock()
+    service = TargetBindingService(handle_store=handle_store)
+    public_match = PublicTargetMatch(
+        target_kind="instance",
+        display_name="mock-cache",
+        environment="test",
+        target_type="oss_single",
+        capabilities=["redis"],
+        confidence=0.9,
+        match_reasons=["mocked"],
+        public_metadata={"environment": "test"},
+        resource_id="mock-private-id",
+    )
+
+    bindings = await service.build_and_persist_records(
+        [
+            DiscoveryCandidate(
+                public_match=public_match,
+                binding_strategy="mock_strategy",
+                binding_subject="mock-private-id",
+                private_binding_ref={"source": "mock"},
+                discovery_backend="mock_backend",
+                score=9.0,
+                confidence=0.9,
+            )
+        ],
+        thread_id="thread-1",
+        task_id="task-1",
+    )
+
+    assert len(bindings) == 1
+    handle_store.save_records.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_build_seed_hint_candidates_maps_legacy_instance_ids_to_private_candidates():
+    instance = AsyncMock()
+    instance.id = "redis-prod-checkout-cache"
+    instance.name = "checkout-cache-prod"
+    instance.environment = "production"
+    instance.status = "healthy"
+    instance.instance_type = "oss_single"
+    instance.usage = "cache"
+    instance.description = "Checkout cache"
+    instance.notes = None
+    instance.repo_url = None
+    instance.monitoring_identifier = None
+    instance.logging_identifier = None
+    instance.redis_cloud_subscription_id = None
+    instance.redis_cloud_database_id = None
+    instance.redis_cloud_database_name = None
+    instance.cluster_id = None
+    instance.updated_at = "2026-04-10T00:00:00+00:00"
+    instance.created_at = "2026-04-10T00:00:00+00:00"
+    instance.user_id = None
+    instance.extension_data = {"target_discovery": {"aliases": ["checkout cache"]}}
+
+    with patch(
+        "redis_sre_agent.core.targets.get_instance_by_id",
+        new_callable=AsyncMock,
+        return_value=instance,
+    ):
+        candidates = await build_seed_hint_candidates(instance_id="redis-prod-checkout-cache")
+
+    assert len(candidates) == 1
+    candidate = candidates[0]
+    assert candidate.binding_subject == "redis-prod-checkout-cache"
+    assert candidate.private_binding_ref["seed_hint"] is True
+    assert candidate.public_match.display_name == "checkout-cache-prod"
+    assert candidate.public_match.public_metadata["environment"] == "production"
+
+
+@pytest.mark.asyncio
+async def test_redis_data_client_factory_builds_handle_scoped_instance():
+    from redis_sre_agent.core.instances import RedisInstance
+
+    instance = RedisInstance(
+        id="redis-prod-checkout-cache",
+        name="checkout-cache-prod",
+        connection_url="redis://localhost:6379",
+        environment="production",
+        usage="cache",
+        description="Checkout cache",
+        instance_type="oss_single",
+    )
+    handle_record = TargetHandleRecord(
+        target_handle="tgt_01",
+        discovery_backend="redis_catalog",
+        binding_strategy="redis_default",
+        binding_subject=instance.id,
+        public_summary=PublicTargetBinding(
+            target_handle="tgt_01",
+            target_kind="instance",
+            display_name=instance.name,
+            capabilities=["redis"],
+        ),
+    )
+
+    with patch(
+        "redis_sre_agent.targets.redis_binding.get_instance_by_id",
+        new_callable=AsyncMock,
+        return_value=instance,
+    ):
+        built = await RedisDataClientFactory().build(handle_record)
+
+    assert built is not None
+    assert built.id == "tgt_01"
+    assert built.connection_url == instance.connection_url
+
+
+@pytest.mark.asyncio
+async def test_redis_target_binding_strategy_builds_provider_loads_for_instance():
+    handle_record = TargetHandleRecord(
+        target_handle="tgt_01",
+        discovery_backend="redis_catalog",
+        binding_strategy="redis_default",
+        binding_subject="redis-prod-checkout-cache",
+        public_summary=PublicTargetBinding(
+            target_handle="tgt_01",
+            target_kind="instance",
+            display_name="checkout-cache-prod",
+            capabilities=["redis", "diagnostics"],
+        ),
+    )
+    data_instance = SimpleNamespace(id="tgt_01")
+
+    class StubRegistry:
+        def get_client_factory(self, family: str):
+            mapping = {
+                "redis.data": SimpleNamespace(build=AsyncMock(return_value=data_instance)),
+                "redis.enterprise_admin": SimpleNamespace(build=AsyncMock(return_value=None)),
+                "redis.cloud": SimpleNamespace(build=AsyncMock(return_value=None)),
+            }
+            return mapping[family]
+
+    with (
+        patch(
+            "redis_sre_agent.targets.registry.get_target_integration_registry",
+            return_value=StubRegistry(),
+        ),
+        patch(
+            "redis_sre_agent.targets.redis_binding.settings",
+            new=SimpleNamespace(
+                tool_providers=[
+                    "redis_sre_agent.tools.diagnostics.redis_command.provider.RedisCommandToolProvider",
+                    "redis_sre_agent.tools.metrics.prometheus.provider.PrometheusToolProvider",
+                ]
+            ),
+        ),
+    ):
+        result = await RedisTargetBindingStrategy().bind(
+            BindingRequest(handle_record=handle_record)
+        )
+
+    assert result.public_summary.target_handle == "tgt_01"
+    assert result.client_refs["redis.data"] is data_instance
+    assert len(result.provider_loads) == 2
+    assert {load.provider_path for load in result.provider_loads} == {
+        "redis_sre_agent.tools.diagnostics.redis_command.provider.RedisCommandToolProvider",
+        "redis_sre_agent.tools.metrics.prometheus.provider.PrometheusToolProvider",
+    }
+
+
+@pytest.mark.asyncio
+async def test_redis_target_handle_store_sets_ttl_and_round_trips_records():
+    fake_client = AsyncMock()
+    store = RedisTargetHandleStore()
+    record = TargetHandleRecord(
+        target_handle="tgt_01",
+        discovery_backend="redis_catalog",
+        binding_strategy="redis_default",
+        binding_subject="redis-prod-checkout-cache",
+        public_summary=PublicTargetBinding(
+            target_handle="tgt_01",
+            target_kind="instance",
+            display_name="checkout-cache-prod",
+            capabilities=["redis"],
+        ),
+        expires_at=(datetime.now(timezone.utc) + timedelta(hours=1)).isoformat(),
+    )
+
+    stored_payload: dict[str, str] = {}
+
+    async def _set(key: str, value: str, ex: int):
+        stored_payload["key"] = key
+        stored_payload["value"] = value
+        stored_payload["ttl"] = ex
+
+    fake_client.set.side_effect = _set
+    fake_client.get.return_value = None
+
+    with patch("redis_sre_agent.targets.handle_store.get_redis_client", return_value=fake_client):
+        await store.save_record(record)
+        fake_client.get.return_value = stored_payload["value"]
+        loaded = await store.get_record("tgt_01")
+
+    assert stored_payload["key"].endswith(":tgt_01")
+    assert stored_payload["ttl"] > 0
+    assert loaded is not None
+    assert loaded.binding_subject == "redis-prod-checkout-cache"
+    assert loaded.public_summary.display_name == "checkout-cache-prod"
+
+
+@pytest.mark.asyncio
+async def test_registry_from_settings_loads_fake_target_components(monkeypatch):
+    from redis_sre_agent.targets import registry as registry_module
+
+    fake_integrations = TargetIntegrationsConfig(
+        default_discovery_backend="fake_demo",
+        default_binding_strategy="fake_authenticated",
+        discovery_backends={
+            "fake_demo": TargetIntegrationComponentConfig(
+                class_path="redis_sre_agent.targets.fake_integration.FakeTargetDiscoveryBackend",
+                config={
+                    "targets": [
+                        {
+                            "display_name": "demo fake cache",
+                            "binding_subject": "fake-demo-cache",
+                            "aliases": ["demo cache"],
+                            "environment": "test",
+                            "username": "demo-user",
+                            "token": "demo-token",
+                        }
+                    ]
+                },
+            )
+        },
+        binding_strategies={
+            "fake_authenticated": TargetIntegrationComponentConfig(
+                class_path="redis_sre_agent.targets.fake_integration.FakeTargetBindingStrategy"
+            )
+        },
+        client_factories={
+            "fake.auth": TargetIntegrationComponentConfig(
+                class_path="redis_sre_agent.targets.fake_integration.FakeAuthenticatedClientFactory"
+            )
+        },
+    )
+    monkeypatch.setattr(settings, "target_integrations", fake_integrations)
+    monkeypatch.setattr(registry_module, "_DEFAULT_REGISTRY", None)
+
+    registry = TargetIntegrationRegistry.from_settings()
+    response = await registry.get_discovery_backend().resolve(DiscoveryRequest(query="demo cache"))
+
+    assert response.status == "resolved"
+    assert response.selected_matches[0].binding_strategy == "fake_authenticated"
+
+    binding_service = TargetBindingService(registry=registry, handle_store=AsyncMock())
+    bindings = await binding_service.build_and_persist_records(
+        response.selected_matches,
+        thread_id="thread-1",
+        task_id="task-1",
+    )
+    handle_record = binding_service.build_handle_record(response.selected_matches[0], bindings[0])
+
+    binding_result = await registry.get_binding_strategy("fake_authenticated").bind(
+        BindingRequest(handle_record=handle_record)
+    )
+
+    assert binding_result.provider_loads[0].provider_path.endswith("FakeAuthenticatedToolProvider")
+    fake_client = binding_result.client_refs["fake.auth"]
+    assert fake_client.id == bindings[0].target_handle
+    assert fake_client.extension_data["fake_target.username"] == "demo-user"

--- a/tests/unit/core/test_target_integrations.py
+++ b/tests/unit/core/test_target_integrations.py
@@ -252,6 +252,33 @@ def test_discovery_candidate_from_public_match_uses_registry_defaults():
     assert candidate.binding_subject == "mock-private-id"
 
 
+def test_discovery_candidate_from_public_match_skips_registry_when_defaults_are_explicit():
+    public_match = PublicTargetMatch(
+        target_kind="instance",
+        display_name="mock-cache",
+        capabilities=["redis"],
+        confidence=0.9,
+        resource_id="mock-private-id",
+    )
+
+    with patch(
+        "redis_sre_agent.targets.contracts.DiscoveryCandidate._resolve_default_integration_names",
+        side_effect=AssertionError("registry defaults should not be resolved"),
+    ):
+        candidate = DiscoveryCandidate.from_public_match(
+            public_match,
+            binding_strategy="explicit_strategy",
+            binding_subject="explicit-subject",
+            private_binding_ref={"source": "explicit"},
+            discovery_backend="explicit_backend",
+        )
+
+    assert candidate.binding_strategy == "explicit_strategy"
+    assert candidate.discovery_backend == "explicit_backend"
+    assert candidate.binding_subject == "explicit-subject"
+    assert candidate.private_binding_ref == {"source": "explicit"}
+
+
 @pytest.mark.asyncio
 async def test_target_binding_service_normalizes_public_matches_with_registry_defaults():
     handle_store = AsyncMock()

--- a/tests/unit/core/test_target_integrations.py
+++ b/tests/unit/core/test_target_integrations.py
@@ -228,6 +228,64 @@ async def test_build_seed_hint_candidates_uses_configured_registry_defaults():
     assert candidate.binding_subject == "redis-prod-checkout-cache"
 
 
+def test_discovery_candidate_from_public_match_uses_registry_defaults():
+    public_match = PublicTargetMatch(
+        target_kind="instance",
+        display_name="mock-cache",
+        capabilities=["redis"],
+        confidence=0.9,
+        resource_id="mock-private-id",
+    )
+    fake_registry = SimpleNamespace(
+        default_binding_strategy="fake_strategy",
+        default_discovery_backend="fake_backend",
+    )
+
+    with patch(
+        "redis_sre_agent.targets.registry.get_target_integration_registry",
+        return_value=fake_registry,
+    ):
+        candidate = DiscoveryCandidate.from_public_match(public_match)
+
+    assert candidate.binding_strategy == "fake_strategy"
+    assert candidate.discovery_backend == "fake_backend"
+    assert candidate.binding_subject == "mock-private-id"
+
+
+@pytest.mark.asyncio
+async def test_target_binding_service_normalizes_public_matches_with_registry_defaults():
+    handle_store = AsyncMock()
+    fake_registry = SimpleNamespace(
+        default_binding_strategy="fake_strategy",
+        default_discovery_backend="fake_backend",
+    )
+    service = TargetBindingService(registry=fake_registry, handle_store=handle_store)
+    public_match = PublicTargetMatch(
+        target_kind="instance",
+        display_name="mock-cache",
+        capabilities=["redis"],
+        confidence=0.9,
+        public_metadata={"environment": "test"},
+        resource_id="mock-private-id",
+    )
+
+    with patch(
+        "redis_sre_agent.targets.registry.get_target_integration_registry",
+        return_value=fake_registry,
+    ):
+        bindings = await service.build_and_persist_records(
+            [public_match],
+            thread_id="thread-1",
+            task_id="task-1",
+        )
+
+    saved_record = handle_store.save_records.await_args.args[0][0]
+    assert len(bindings) == 1
+    assert saved_record.binding_strategy == "fake_strategy"
+    assert saved_record.discovery_backend == "fake_backend"
+    assert saved_record.binding_subject == "mock-private-id"
+
+
 @pytest.mark.asyncio
 async def test_redis_data_client_factory_builds_handle_scoped_instance():
     from redis_sre_agent.core.instances import RedisInstance

--- a/tests/unit/core/test_targets.py
+++ b/tests/unit/core/test_targets.py
@@ -505,7 +505,7 @@ async def test_bind_target_matches_with_thread_returns_materialized_attached_sco
 
     with (
         patch("redis_sre_agent.core.targets.ThreadManager", return_value=mock_thread_manager),
-        patch("redis_sre_agent.core.targets.ULID", return_value="new"),
+        patch("redis_sre_agent.targets.services.ULID", return_value="new"),
     ):
         scope = await bind_target_matches(
             matches=[new_match],
@@ -794,8 +794,8 @@ async def test_build_attached_target_scope_prompt_handles_binding_edge_cases():
     assert prompt is not None
     assert "handle=tgt_meta_only [metadata unavailable]" in prompt
     assert "missing-instance" in prompt and "state=missing" in prompt
-    assert "prod-cluster" in prompt and "cluster_id=cluster-prod-1" in prompt
-    assert "missing-cluster" in prompt and "cluster_id=cluster-missing" in prompt
+    assert "prod-cluster" in prompt and "kind=cluster" in prompt
+    assert "missing-cluster" in prompt and "state=missing" in prompt
     assert "custom-target" in prompt and "kind=custom" in prompt
     assert "extra-instance" in prompt
 

--- a/tests/unit/core/test_targets.py
+++ b/tests/unit/core/test_targets.py
@@ -16,7 +16,6 @@ from redis_sre_agent.core.targets import (
     build_attached_target_prompt_loader,
     build_attached_target_scope_prompt,
     build_bound_target_scope_context,
-    build_ephemeral_target_bindings,
     build_target_doc_from_cluster,
     build_target_doc_from_instance,
     get_attached_target_handles_from_context,
@@ -26,6 +25,7 @@ from redis_sre_agent.core.targets import (
     sync_target_catalog,
 )
 from redis_sre_agent.core.threads import Thread, ThreadMetadata
+from redis_sre_agent.targets.services import TargetBindingService
 
 
 def test_build_target_doc_from_instance_excludes_secrets_and_includes_aliases():
@@ -875,7 +875,7 @@ async def test_build_attached_target_prompt_loader_uses_callable_context_per_att
     }
 
 
-def test_build_ephemeral_target_bindings_generates_opaque_handles():
+def test_target_binding_service_build_public_binding_generates_opaque_handles():
     matches = [
         ResolvedTargetMatch(
             target_kind="cluster",
@@ -889,7 +889,14 @@ def test_build_ephemeral_target_bindings_generates_opaque_handles():
         )
     ]
 
-    bindings = build_ephemeral_target_bindings(matches, thread_id="thread-1", task_id="task-1")
+    bindings = [
+        TargetBindingService.build_public_binding(
+            match,
+            thread_id="thread-1",
+            task_id="task-1",
+        )
+        for match in matches
+    ]
 
     assert len(bindings) == 1
     assert bindings[0].target_handle.startswith("tgt_")

--- a/tests/unit/core/test_thread_management.py
+++ b/tests/unit/core/test_thread_management.py
@@ -1,11 +1,13 @@
 """Tests for thread management and async task execution."""
 
 import json
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from redis_sre_agent.core.docket_tasks import process_agent_turn
+from redis_sre_agent.core.targets import MaterializedTargetScope, TargetBinding
 from redis_sre_agent.core.threads import (
     Message,
     Thread,
@@ -190,6 +192,101 @@ class TestProcessAgentTurn:
 
             # Verify thread manager saved state
             mock_manager._save_thread_state.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_process_agent_turn_materializes_handle_scope_from_legacy_instance_hint(self):
+        """Legacy instance hints should be normalized into handle-backed bindings before chat."""
+        with (
+            patch("redis_sre_agent.core.docket_tasks.get_redis_client") as mock_get_redis,
+            patch("redis_sre_agent.core.docket_tasks.ThreadManager") as mock_manager_class,
+            patch("redis_sre_agent.core.docket_tasks.TaskManager") as mock_task_manager_class,
+            patch("redis_sre_agent.core.docket_tasks.route_to_appropriate_agent") as mock_route,
+            patch("redis_sre_agent.core.docket_tasks.get_chat_agent") as mock_get_chat_agent,
+            patch(
+                "redis_sre_agent.core.targets.build_seed_hint_candidates",
+                new_callable=AsyncMock,
+                return_value=[MagicMock(name="candidate")],
+            ) as mock_build_candidates,
+            patch(
+                "redis_sre_agent.core.targets.materialize_bound_target_scope",
+                new_callable=AsyncMock,
+            ) as mock_materialize_scope,
+        ):
+            mock_redis = AsyncMock()
+            mock_get_redis.return_value = mock_redis
+
+            thread = Thread(
+                thread_id="test_thread",
+                messages=[],
+                context={},
+                metadata=ThreadMetadata(user_id="user-1", session_id="session-1"),
+            )
+            mock_manager = AsyncMock()
+            mock_manager_class.return_value = mock_manager
+            mock_manager.get_thread.return_value = thread
+            mock_manager.append_messages.return_value = True
+            mock_manager._save_thread_state.return_value = True
+
+            mock_task_manager = AsyncMock()
+            mock_task_manager.create_task.return_value = "task-1"
+            mock_task_manager.update_task_status.return_value = True
+            mock_task_manager.add_task_update.return_value = True
+            mock_task_manager.get_task_state.return_value = None
+            mock_task_manager.set_task_result.return_value = True
+            mock_task_manager._publish_stream_update.return_value = True
+            mock_task_manager.set_task_error.return_value = True
+            mock_task_manager_class.return_value = mock_task_manager
+
+            from redis_sre_agent.agent.router import AgentType
+
+            mock_route.side_effect = AsyncMock(return_value=AgentType.REDIS_CHAT)
+
+            binding = TargetBinding(
+                target_handle="tgt_legacy_01",
+                target_kind="instance",
+                display_name="checkout-cache-prod",
+                capabilities=["redis", "diagnostics"],
+                public_metadata={"environment": "production"},
+            )
+            mock_materialize_scope.return_value = MaterializedTargetScope(
+                selected_bindings=[binding],
+                attached_bindings=[binding],
+                target_toolset_generation=1,
+                context_updates={
+                    "attached_target_handles": ["tgt_legacy_01"],
+                    "active_target_handle": "tgt_legacy_01",
+                    "target_toolset_generation": 1,
+                    "target_bindings": [binding.public_dump()],
+                    "instance_id": "",
+                    "cluster_id": "",
+                },
+            )
+
+            mock_chat_agent = AsyncMock()
+            mock_chat_agent.process_query.return_value = SimpleNamespace(
+                response="Test response from agent",
+                search_results=[],
+                tool_envelopes=[],
+            )
+            mock_get_chat_agent.return_value = mock_chat_agent
+
+            await process_agent_turn(
+                thread_id="test_thread",
+                message="Investigate checkout cache",
+                context={"instance_id": "redis-prod-checkout-cache"},
+            )
+
+        mock_build_candidates.assert_awaited_once()
+        assert mock_build_candidates.await_args.kwargs["instance_id"] == "redis-prod-checkout-cache"
+        mock_materialize_scope.assert_awaited_once()
+        assert mock_chat_agent.process_query.await_args.kwargs["context"][
+            "attached_target_handles"
+        ] == ["tgt_legacy_01"]
+        assert mock_chat_agent.process_query.await_args.kwargs["context"]["target_bindings"] == [
+            binding.public_dump()
+        ]
+        assert thread.context["attached_target_handles"] == ["tgt_legacy_01"]
+        assert thread.context["instance_id"] == "redis-prod-checkout-cache"
 
     @pytest.mark.asyncio
     async def test_process_agent_turn_thread_not_found(self):

--- a/tests/unit/core/test_thread_management.py
+++ b/tests/unit/core/test_thread_management.py
@@ -6,7 +6,10 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from redis_sre_agent.core.docket_tasks import process_agent_turn
+from redis_sre_agent.core.docket_tasks import (
+    _ensure_handle_backed_turn_scope,
+    process_agent_turn,
+)
 from redis_sre_agent.core.targets import MaterializedTargetScope, TargetBinding
 from redis_sre_agent.core.threads import (
     Message,
@@ -14,6 +17,7 @@ from redis_sre_agent.core.threads import (
     ThreadManager,
     ThreadMetadata,
 )
+from redis_sre_agent.core.turn_scope import TurnScope
 
 
 class TestThreadManager:
@@ -192,6 +196,68 @@ class TestProcessAgentTurn:
 
             # Verify thread manager saved state
             mock_manager._save_thread_state.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_ensure_handle_backed_turn_scope_ignores_conflicting_legacy_ids_when_bindings_exist(
+        self,
+    ):
+        binding = TargetBinding(
+            target_handle="tgt_bound_01",
+            target_kind="instance",
+            resource_id="redis-bound-instance",
+            display_name="bound-instance",
+            capabilities=["redis"],
+        )
+        turn_scope = TurnScope(
+            thread_id="thread-1",
+            session_id="session-1",
+            scope_kind="target_bindings",
+            attached_target_handles=[binding.target_handle],
+            bindings=[binding],
+        )
+        materialized_scope = MaterializedTargetScope(
+            selected_bindings=[binding],
+            attached_bindings=[binding],
+            target_toolset_generation=3,
+            context_updates={
+                "attached_target_handles": [binding.target_handle],
+                "target_bindings": [binding.public_dump()],
+                "target_toolset_generation": 3,
+            },
+        )
+
+        with (
+            patch(
+                "redis_sre_agent.core.targets.build_seed_hint_candidates",
+                new_callable=AsyncMock,
+                return_value=[MagicMock(name="candidate")],
+            ) as mock_build_candidates,
+            patch(
+                "redis_sre_agent.core.targets.materialize_bound_target_scope",
+                new_callable=AsyncMock,
+                return_value=materialized_scope,
+            ),
+            patch(
+                "redis_sre_agent.targets.get_target_handle_store",
+                return_value=SimpleNamespace(get_records=AsyncMock(return_value={})),
+            ),
+        ):
+            result = await _ensure_handle_backed_turn_scope(
+                turn_scope=turn_scope,
+                routing_context={},
+                thread_context={},
+                thread_id="thread-1",
+                task_id="task-1",
+                legacy_instance_id="redis-stale-instance",
+                legacy_cluster_id="cluster-stale",
+            )
+
+        assert result.scope_kind == "target_bindings"
+        mock_build_candidates.assert_awaited_once_with(
+            bindings=[binding],
+            instance_id=None,
+            cluster_id=None,
+        )
 
     @pytest.mark.asyncio
     async def test_process_agent_turn_materializes_handle_scope_from_legacy_instance_hint(self):

--- a/tests/unit/core/test_thread_management.py
+++ b/tests/unit/core/test_thread_management.py
@@ -260,6 +260,36 @@ class TestProcessAgentTurn:
         )
 
     @pytest.mark.asyncio
+    async def test_ensure_handle_backed_turn_scope_drops_ambiguous_legacy_ids_without_bindings(
+        self,
+    ):
+        turn_scope = TurnScope(
+            thread_id="thread-1",
+            session_id="session-1",
+            scope_kind="zero_scope",
+        )
+
+        with patch(
+            "redis_sre_agent.core.targets.build_seed_hint_candidates",
+            new_callable=AsyncMock,
+        ) as mock_build_candidates:
+            result = await _ensure_handle_backed_turn_scope(
+                turn_scope=turn_scope,
+                routing_context={
+                    "instance_id": "redis-stale-instance",
+                    "cluster_id": "cluster-stale",
+                },
+                thread_context={},
+                thread_id="thread-1",
+                task_id="task-1",
+                legacy_instance_id="redis-stale-instance",
+                legacy_cluster_id="cluster-stale",
+            )
+
+        assert result == turn_scope
+        mock_build_candidates.assert_not_awaited()
+
+    @pytest.mark.asyncio
     async def test_process_agent_turn_materializes_handle_scope_from_legacy_instance_hint(self):
         """Legacy instance hints should be normalized into handle-backed bindings before chat."""
         with (

--- a/tests/unit/core/test_turn_scope.py
+++ b/tests/unit/core/test_turn_scope.py
@@ -98,7 +98,7 @@ def test_turn_scope_to_thread_context_serializes_bindings_and_support_package():
     assert context["resolution_policy"] == "allow_multiple"
     assert context["support_package_id"] == "pkg-1"
     assert context["target_bindings"][0]["target_handle"] == "tgt_01"
-    assert "resource_id" not in context["target_bindings"][0]
+    assert context["target_bindings"][0]["resource_id"] == "redis-prod-checkout-cache"
 
 
 def test_turn_scope_to_thread_context_omits_empty_binding_fields_for_zero_scope():
@@ -175,7 +175,7 @@ def test_build_legacy_target_scope_adapter_wraps_instance_scope_in_turn_scope_co
     assert scope.bindings[0].resource_id == "redis-prod-checkout-cache"
     assert context["instance_id"] == "redis-prod-checkout-cache"
     assert context["attached_target_handles"] == [scope.bindings[0].target_handle]
-    assert "resource_id" not in context["target_bindings"][0]
+    assert context["target_bindings"][0]["resource_id"] == "redis-prod-checkout-cache"
     assert context["turn_scope"]["bindings"][0]["resource_id"] == "redis-prod-checkout-cache"
 
 

--- a/tests/unit/core/test_turn_scope.py
+++ b/tests/unit/core/test_turn_scope.py
@@ -97,7 +97,8 @@ def test_turn_scope_to_thread_context_serializes_bindings_and_support_package():
     assert context["automated"] is True
     assert context["resolution_policy"] == "allow_multiple"
     assert context["support_package_id"] == "pkg-1"
-    assert context["target_bindings"][0]["resource_id"] == "redis-prod-checkout-cache"
+    assert context["target_bindings"][0]["target_handle"] == "tgt_01"
+    assert "resource_id" not in context["target_bindings"][0]
 
 
 def test_turn_scope_to_thread_context_omits_empty_binding_fields_for_zero_scope():
@@ -174,7 +175,7 @@ def test_build_legacy_target_scope_adapter_wraps_instance_scope_in_turn_scope_co
     assert scope.bindings[0].resource_id == "redis-prod-checkout-cache"
     assert context["instance_id"] == "redis-prod-checkout-cache"
     assert context["attached_target_handles"] == [scope.bindings[0].target_handle]
-    assert context["target_bindings"][0]["resource_id"] == "redis-prod-checkout-cache"
+    assert "resource_id" not in context["target_bindings"][0]
     assert context["turn_scope"]["bindings"][0]["resource_id"] == "redis-prod-checkout-cache"
 
 

--- a/tests/unit/tools/test_manager.py
+++ b/tests/unit/tools/test_manager.py
@@ -9,8 +9,53 @@ from redis_sre_agent.core.clusters import RedisCluster, RedisClusterType
 from redis_sre_agent.core.config import MCPServerConfig
 from redis_sre_agent.core.instances import RedisInstance
 from redis_sre_agent.core.targets import TargetBinding
+from redis_sre_agent.targets.contracts import BindingResult, ProviderLoadRequest, TargetHandleRecord
+from redis_sre_agent.targets.fake_integration import (
+    FakeAuthenticatedClientFactory,
+    FakeTargetBindingStrategy,
+)
+from redis_sre_agent.targets.registry import TargetIntegrationRegistry
 from redis_sre_agent.tools.manager import ToolManager, _command_is_available
 from redis_sre_agent.tools.models import ToolCapability, ToolDefinition
+from redis_sre_agent.tools.protocols import ToolProvider
+
+
+class FakeTargetToolProvider(ToolProvider):
+    """Minimal provider used to verify alternate binding strategies can attach tools."""
+
+    @property
+    def provider_name(self) -> str:
+        return "fake_target"
+
+    def create_tool_schemas(self):
+        return [
+            ToolDefinition(
+                name=self._make_tool_name("inspect"),
+                description="Inspect a mock target",
+                capability=ToolCapability.UTILITIES,
+                parameters={"type": "object", "properties": {}},
+            )
+        ]
+
+    async def inspect(self):
+        return {"status": "ok"}
+
+
+class MockBindingStrategy:
+    strategy_name = "mock_strategy"
+
+    async def bind(self, request):
+        return BindingResult(
+            public_summary=request.handle_record.public_summary,
+            provider_loads=[
+                ProviderLoadRequest(
+                    provider_path="tests.unit.tools.test_manager.FakeTargetToolProvider",
+                    provider_key=f"target:{request.handle_record.target_handle}:fake_target",
+                    target_handle=request.handle_record.target_handle,
+                    provider_context={"always_on": True},
+                )
+            ],
+        )
 
 
 @pytest.mark.asyncio
@@ -103,6 +148,116 @@ async def test_attach_bound_targets_scopes_instance_tools_to_opaque_handle():
     assert scoped_instance.id == "tgt_opaque_1"
     assert scoped_instance.name == "checkout-cache-prod"
     assert mgr.get_toolset_generation() == 2
+
+
+@pytest.mark.asyncio
+async def test_attach_bound_targets_uses_registered_strategy_and_private_handle_record():
+    """Alternate binding strategies should attach tools without target_kind branching."""
+    binding = TargetBinding(
+        target_handle="tgt_alt_1",
+        target_kind="custom",
+        display_name="alternate target",
+        capabilities=["custom"],
+        public_metadata={"environment": "test"},
+    )
+    record = TargetHandleRecord(
+        target_handle="tgt_alt_1",
+        discovery_backend="mock_backend",
+        binding_strategy="mock_strategy",
+        binding_subject="private-subject-1",
+        public_summary=binding,
+    )
+    registry = TargetIntegrationRegistry(
+        default_discovery_backend="mock_backend",
+        default_binding_strategy="mock_strategy",
+    )
+    registry.register_binding_strategy(MockBindingStrategy())
+    mock_store = AsyncMock()
+    mock_store.get_records.return_value = {"tgt_alt_1": record}
+
+    async with ToolManager() as mgr:
+        with (
+            patch("redis_sre_agent.tools.manager.get_target_handle_store", return_value=mock_store),
+            patch(
+                "redis_sre_agent.tools.manager.get_target_integration_registry",
+                return_value=registry,
+            ),
+        ):
+            attached = await mgr.attach_bound_targets([binding])
+
+        assert attached == [binding]
+        assert any("fake_target_" in tool.name for tool in mgr.get_tools())
+        assert mgr.get_attached_target_bindings() == [binding]
+
+
+@pytest.mark.asyncio
+async def test_attach_bound_targets_supports_repo_fake_authenticated_integration():
+    """The repo-backed fake integration should load a live provider through ToolManager."""
+
+    binding = TargetBinding(
+        target_handle="tgt_fake_auth_1",
+        target_kind="instance",
+        display_name="demo fake cache",
+        capabilities=["fake", "auth"],
+        public_metadata={"environment": "test"},
+    )
+    record = TargetHandleRecord(
+        target_handle="tgt_fake_auth_1",
+        discovery_backend="fake_demo",
+        binding_strategy="fake_authenticated",
+        binding_subject="fake-demo-cache",
+        private_binding_ref={
+            "username": "demo-user",
+            "token": "demo-token",
+            "audience": "fake-control-plane",
+        },
+        public_summary=binding,
+    )
+    registry = TargetIntegrationRegistry(
+        default_discovery_backend="fake_demo",
+        default_binding_strategy="fake_authenticated",
+    )
+    registry.register_binding_strategy(FakeTargetBindingStrategy())
+    registry.register_client_factory(FakeAuthenticatedClientFactory())
+    mock_store = AsyncMock()
+    mock_store.get_records.return_value = {"tgt_fake_auth_1": record}
+
+    mgr = ToolManager()
+    mgr._stack = AsyncExitStack()
+    await mgr._stack.__aenter__()
+    try:
+        with (
+            patch("redis_sre_agent.tools.manager.get_target_handle_store", return_value=mock_store),
+            patch(
+                "redis_sre_agent.tools.manager.get_target_integration_registry",
+                return_value=registry,
+            ),
+            patch(
+                "redis_sre_agent.targets.registry.get_target_integration_registry",
+                return_value=registry,
+            ),
+        ):
+            attached = await mgr.attach_bound_targets([binding])
+
+            assert attached == [binding]
+
+            auth_tools = [
+                tool.name
+                for tool in mgr.get_tools()
+                if "fake_target_" in tool.name and tool.name.endswith("_auth_status")
+            ]
+            assert len(auth_tools) == 1
+
+            auth_result = await mgr.resolve_tool_call(auth_tools[0], {})
+    finally:
+        await mgr._stack.__aexit__(None, None, None)
+
+    assert auth_result["status"] == "success"
+    assert auth_result["authenticated"] is True
+    assert auth_result["target_handle"] == "tgt_fake_auth_1"
+    assert auth_result["username"] == "demo-user"
+    assert auth_result["audience"] == "fake-control-plane"
+    assert auth_result["token_suffix"] == "oken"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/tools/test_target_discovery_provider.py
+++ b/tests/unit/tools/test_target_discovery_provider.py
@@ -5,6 +5,13 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from redis_sre_agent.core.targets import BoundTargetScope, ResolvedTargetMatch, TargetBinding
+from redis_sre_agent.targets.contracts import (
+    DiscoveryCandidate,
+    DiscoveryRequest,
+    DiscoveryResponse,
+    PublicTargetMatch,
+)
+from redis_sre_agent.targets.registry import TargetIntegrationRegistry
 from redis_sre_agent.tools.target_discovery.provider import TargetDiscoveryToolProvider
 
 
@@ -148,3 +155,75 @@ async def test_resolve_redis_targets_without_attachment_uses_existing_toolset_ge
     mock_bind.assert_not_awaited()
     assert payload["attached_target_handles"] == []
     assert payload["toolset_generation"] == 4
+
+
+class MockDiscoveryBackend:
+    backend_name = "mock_backend"
+
+    async def resolve(self, request: DiscoveryRequest) -> DiscoveryResponse:
+        public_match = PublicTargetMatch(
+            target_kind="instance",
+            display_name="alternate cache",
+            environment="test",
+            target_type="oss_single",
+            capabilities=["redis"],
+            confidence=0.95,
+            match_reasons=["mocked"],
+            public_metadata={"environment": "test", "label": "alternate"},
+            resource_id="mock-private-id",
+        )
+        return DiscoveryResponse(
+            status="resolved",
+            matches=[public_match],
+            selected_matches=[
+                DiscoveryCandidate(
+                    public_match=public_match,
+                    binding_strategy="mock_strategy",
+                    binding_subject="mock-private-id",
+                    private_binding_ref={"source": "mock"},
+                    discovery_backend="mock_backend",
+                    score=9.5,
+                    confidence=0.95,
+                )
+            ],
+        )
+
+
+class MockBindingStrategy:
+    strategy_name = "mock_strategy"
+
+    async def bind(self, request):  # pragma: no cover - discovery-only test
+        raise AssertionError("bind() should not be called when attach_tools=False")
+
+
+@pytest.mark.asyncio
+async def test_resolve_redis_targets_can_use_alternate_registered_backend():
+    provider = TargetDiscoveryToolProvider()
+    manager = MagicMock()
+    manager.thread_id = "thread-1"
+    manager.task_id = "task-1"
+    manager.user_id = "user-1"
+    manager.get_toolset_generation.return_value = 4
+    provider._manager = manager
+
+    registry = TargetIntegrationRegistry(
+        default_discovery_backend="mock_backend",
+        default_binding_strategy="mock_strategy",
+    )
+    registry.register_discovery_backend(MockDiscoveryBackend())
+    registry.register_binding_strategy(MockBindingStrategy())
+
+    with patch(
+        "redis_sre_agent.targets.services.get_target_integration_registry",
+        return_value=registry,
+    ):
+        payload = await provider.resolve_redis_targets(
+            query="alternate cache",
+            attach_tools=False,
+        )
+
+    assert payload["status"] == "resolved"
+    assert payload["toolset_generation"] == 4
+    assert payload["matches"][0]["display_name"] == "alternate cache"
+    assert payload["matches"][0]["public_metadata"]["label"] == "alternate"
+    assert "resource_id" not in payload["matches"][0]


### PR DESCRIPTION
## Summary
- add pluggable target discovery, binding, registry, and private handle-store contracts
- route the default Redis-backed discovery and attachment flow through the new services and strategy layer
- add a repo-backed fake discovery/auth integration plus coverage proving ToolManager can load a non-default implementation

Closes #128 

## Testing
- uv run pytest tests/unit/core/test_target_integrations.py tests/unit/core/test_thread_management.py tests/unit/core/test_targets.py tests/unit/tools/test_target_discovery_provider.py tests/unit/tools/test_manager.py tests/unit/core/test_turn_scope.py tests/unit/core/test_tasks.py tests/integration/test_target_discovery_flow.py -q --run-api-tests
- pre-commit hooks via git commit


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new integration registry/service layer and a Redis-backed private handle store, changing how target resolution and tool attachment work across threads; misconfiguration or missing handle records could prevent tools from loading for a target.
> 
> **Overview**
> Refactors target discovery/binding into a **pluggable integration layer** (`redis_sre_agent.targets`) with explicit contracts (`Discovery*`, `Binding*`), a runtime registry loaded from new `settings.target_integrations`, and services to resolve queries and persist bindings.
> 
> Switches attached-target state to store only **public, secret-safe binding summaries** in thread context, while persisting private binding subjects/refs in a new Redis-backed handle store; updates prompt rendering and `ToolManager.attach_bound_targets()` to bind/load providers via strategy-produced `ProviderLoadRequest`s, with legacy `resource_id` fallback.
> 
> Adds default Redis integrations (`redis_catalog` discovery + `redis_default` binding/client factories), a fake demo integration/provider, and updates agent-turn processing to materialize legacy `instance_id`/`cluster_id` hints into handle-backed scope before routing; expands unit/integration coverage for registry, handle store TTL/roundtrips, and alternate backend/strategy flows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a115fb7372b1d55c2e462346cf7b3b2f52f5677. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->