### PR TITLE
Publish UI image for air-gapped deployments

### DIFF
--- a/.env.airgap.example
+++ b/.env.airgap.example
@@ -75,7 +75,9 @@ GITHUB_PERSONAL_ACCESS_TOKEN=
 # =============================================================================
 # Override if using custom registry
 SRE_AGENT_IMAGE=redis-sre-agent:airgap
-# SRE_UI_IMAGE=redis-sre-agent-ui:airgap
+SRE_UI_IMAGE=redis-sre-agent-ui:airgap
+# Backend upstream consumed by the production UI nginx proxy
+SRE_UI_API_UPSTREAM=http://sre-agent:8000
 
 # Port mappings
 API_PORT=8080

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -103,6 +103,62 @@ jobs:
       - name: Image digest
         run: echo ${{ steps.meta.outputs.digest }}
 
+  publish-ui:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU (for cross-arch builds)
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata for UI image
+        id: meta-ui
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            redislabs/redis-sre-agent-ui
+            ghcr.io/${{ github.repository_owner }}/redis-sre-agent-ui
+          tags: |
+            type=raw,value=${{ github.event.inputs.tag }}
+            type=raw,value=latest,enable=${{ github.event.inputs.push_latest }}
+            type=sha,prefix={{branch}}-
+
+      - name: Build and push UI Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./ui
+          file: ./ui/Dockerfile
+          target: production
+          push: true
+          tags: ${{ steps.meta-ui.outputs.tags }}
+          labels: ${{ steps.meta-ui.outputs.labels }}
+          cache-from: type=registry,ref=redislabs/redis-sre-agent-ui:buildcache
+          cache-to: type=registry,ref=redislabs/redis-sre-agent-ui:buildcache,mode=max
+          platforms: linux/amd64,linux/arm64
+
+      - name: UI image digest
+        run: echo ${{ steps.meta-ui.outputs.digest }}
+
   publish-airgap:
     runs-on: ubuntu-latest
     if: ${{ github.event.inputs.build_airgap == 'true' }}
@@ -192,3 +248,58 @@ jobs:
 
       - name: Air-gap image digest
         run: echo ${{ steps.meta-airgap.outputs.digest }}
+
+  publish-ui-airgap:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.inputs.build_airgap == 'true' }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU (for cross-arch builds)
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata for air-gap UI image
+        id: meta-ui-airgap
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            redislabs/redis-sre-agent-ui
+            ghcr.io/${{ github.repository_owner }}/redis-sre-agent-ui
+          tags: |
+            type=raw,value=${{ github.event.inputs.tag }}-airgap
+            type=raw,value=airgap,enable=${{ github.event.inputs.push_latest }}
+
+      - name: Build and push air-gap UI Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./ui
+          file: ./ui/Dockerfile
+          target: production
+          push: true
+          tags: ${{ steps.meta-ui-airgap.outputs.tags }}
+          labels: ${{ steps.meta-ui-airgap.outputs.labels }}
+          cache-from: type=registry,ref=redislabs/redis-sre-agent-ui:buildcache
+          platforms: linux/amd64,linux/arm64
+
+      - name: Air-gap UI image digest
+        run: echo ${{ steps.meta-ui-airgap.outputs.digest }}

--- a/docker-compose.airgap.yml
+++ b/docker-compose.airgap.yml
@@ -92,13 +92,16 @@ services:
         condition: service_healthy
 
   # Optional: SRE Agent UI
-  # Uncomment if you have the UI image available
-  # sre-ui:
-  #   image: ${SRE_UI_IMAGE:-redis-sre-agent-ui:airgap}
-  #   ports:
-  #     - "${UI_PORT:-3002}:80"
-  #   environment:
-  #     - VITE_API_URL=http://sre-agent:8000
-  #   depends_on:
-  #     sre-agent:
-  #       condition: service_healthy
+  # Enable with: docker compose --profile ui -f docker-compose.airgap.yml up -d
+  sre-ui:
+    image: ${SRE_UI_IMAGE:-redis-sre-agent-ui:airgap}
+    ports:
+      - "${UI_PORT:-3002}:80"
+    environment:
+      - SRE_UI_API_UPSTREAM=${SRE_UI_API_UPSTREAM:-http://sre-agent:8000}
+    depends_on:
+      sre-agent:
+        condition: service_healthy
+    restart: unless-stopped
+    profiles:
+      - ui

--- a/docs/operations/airgap-deployment.md
+++ b/docs/operations/airgap-deployment.md
@@ -11,7 +11,7 @@ The air-gapped deployment uses:
 - **Pre-bundled embedding models** - HuggingFace sentence-transformers included in image
 - **External Redis** - Customer provides Redis with RediSearch module
 - **Internal LLM proxy** - Customer provides OpenAI-compatible API endpoint
-- **No runtime downloads** - Everything needed is in the Docker image
+- **No runtime downloads** - Everything needed is in the published Docker images
 
 ## Prerequisites
 
@@ -29,37 +29,49 @@ The air-gapped deployment uses:
 | Prometheus | Metrics server | For `prometheus_query_metrics` tool |
 | Loki | Log aggregation | For `loki_query_logs` tool |
 
-## Getting the Air-Gap Image
+## Getting the Air-Gap Images
 
 ### Option 1: Mirror from Docker Hub (Recommended)
 
-The air-gap image is published to Docker Hub. Mirror it to your internal
+The air-gap images are published to Docker Hub. Mirror them to your internal
 registry (Artifactory, Harbor, etc.):
 
 ```bash
 # On a machine with internet access
 docker pull redislabs/redis-sre-agent:airgap
+docker pull redislabs/redis-sre-agent-ui:airgap
 
 # Tag for your internal registry
 docker tag redislabs/redis-sre-agent:airgap your-artifactory.internal.com/redis-sre-agent:airgap
+docker tag redislabs/redis-sre-agent-ui:airgap your-artifactory.internal.com/redis-sre-agent-ui:airgap
 
 # Push to internal registry
 docker push your-artifactory.internal.com/redis-sre-agent:airgap
+docker push your-artifactory.internal.com/redis-sre-agent-ui:airgap
 ```
 
 Then in your air-gapped environment, pull from your internal registry:
 
 ```bash
 docker pull your-artifactory.internal.com/redis-sre-agent:airgap
+docker pull your-artifactory.internal.com/redis-sre-agent-ui:airgap
 ```
 
-**Available tags:**
+**Available agent tags:**
 
 | Tag | Description |
 |-----|-------------|
 | `airgap` | Latest air-gap image with bundled HuggingFace models |
 | `v1.0.0-airgap` | Versioned air-gap image (example) |
 | `latest` | Standard image (requires internet for model downloads) |
+
+**Available UI tags:**
+
+| Tag | Description |
+|-----|-------------|
+| `airgap` | Latest UI image for no-internet deployments |
+| `v1.0.0-airgap` | Versioned air-gap UI image (example) |
+| `latest` | Latest standard UI image |
 
 ### Option 2: Build from Source
 
@@ -70,19 +82,21 @@ If you cannot use the published image, build it yourself:
 git clone https://github.com/redis-applied-ai/redis-sre-agent.git
 cd redis-sre-agent
 
-# Build the air-gap bundle (builds Docker image + creates bundle)
+# Build the air-gap bundle (builds Docker images + creates bundle)
 ./scripts/build-airgap.sh --output ./airgap-bundle
 ```
 
 The build script:
 
-1. **Builds the Docker image** from `Dockerfile.airgap` with pre-bundled HuggingFace models
-2. **Exports the image** to a portable tarball
-3. **Creates a complete bundle** with configuration files
+1. **Builds the agent Docker image** from `Dockerfile.airgap` with pre-bundled HuggingFace models
+2. **Builds the UI Docker image** from `ui/Dockerfile` using the production nginx target
+3. **Exports the images** to portable tarballs
+4. **Creates a complete bundle** with configuration files
 
 Bundle contents:
 
 - `redis-sre-agent-airgap.tar.gz` (Docker image ~4GB with models and KB artifacts)
+- `redis-sre-agent-ui-airgap.tar.gz` (optional UI image served by nginx)
 - `docker-compose.airgap.yml`
 - `.env.example`
 - `config.yaml`
@@ -99,8 +113,14 @@ Bundle contents:
 # Custom image tag
 ./scripts/build-airgap.sh --tag myregistry/sre-agent:v1.0
 
+# Custom UI image tag
+./scripts/build-airgap.sh --ui-tag myregistry/sre-agent-ui:v1.0-airgap
+
 # Skip knowledge base artifacts
 ./scripts/build-airgap.sh --skip-artifacts
+
+# Skip building the UI image
+./scripts/build-airgap.sh --skip-ui-image
 
 # Push to internal registry
 ./scripts/build-airgap.sh --push myregistry.internal.com
@@ -108,16 +128,18 @@ Bundle contents:
 
 ## Deployment
 
-### 1. Get the Image
+### 1. Get the Images
 
 **If using mirrored image (Option 1):**
 
 ```bash
 # Pull from your internal registry
 docker pull your-artifactory.internal.com/redis-sre-agent:airgap
+docker pull your-artifactory.internal.com/redis-sre-agent-ui:airgap
 
 # Or for Podman
 podman pull your-artifactory.internal.com/redis-sre-agent:airgap
+podman pull your-artifactory.internal.com/redis-sre-agent-ui:airgap
 ```
 
 **If using build bundle (Option 2):**
@@ -125,6 +147,7 @@ podman pull your-artifactory.internal.com/redis-sre-agent:airgap
 ```bash
 # Transfer airgap-bundle/ to air-gapped environment, then:
 docker load < redis-sre-agent-airgap.tar.gz
+docker load < redis-sre-agent-ui-airgap.tar.gz
 
 # Verify
 docker images | grep redis-sre-agent
@@ -171,9 +194,15 @@ VECTOR_DIM=384
 # Optional: Monitoring
 TOOLS_PROMETHEUS_URL=http://your-prometheus:9090
 TOOLS_LOKI_URL=http://your-loki:3100
+
+# Optional: Published UI image and backend upstream
+SRE_UI_IMAGE=your-artifactory.internal.com/redis-sre-agent-ui:airgap
+SRE_UI_API_UPSTREAM=http://sre-agent:8000
 ```
 
 ### 4. Start Services
+
+Start the API and worker:
 
 ```bash
 docker compose -f docker-compose.airgap.yml up -d
@@ -182,6 +211,17 @@ docker compose -f docker-compose.airgap.yml up -d
 For Podman:
 ```bash
 podman-compose -f docker-compose.airgap.yml up -d
+```
+
+To include the UI image, enable the `ui` profile:
+
+```bash
+docker compose --profile ui -f docker-compose.airgap.yml up -d
+```
+
+For Podman:
+```bash
+podman-compose --profile ui -f docker-compose.airgap.yml up -d
 ```
 
 ### 5. Initialize Knowledge Base

--- a/docs/operations/docker-deployment.md
+++ b/docs/operations/docker-deployment.md
@@ -194,12 +194,16 @@ For production deployments:
 
 Pre-built images are available on Docker Hub:
 
-| Tag | Description |
+| Image | Description |
 |-----|-------------|
-| `redislabs/redis-sre-agent:latest` | Latest standard image |
-| `redislabs/redis-sre-agent:airgap` | Air-gap image with bundled models |
-| `redislabs/redis-sre-agent:v1.0.0` | Versioned release (example) |
-| `redislabs/redis-sre-agent:v1.0.0-airgap` | Versioned air-gap release |
+| `redislabs/redis-sre-agent:latest` | Latest standard API/worker image |
+| `redislabs/redis-sre-agent:airgap` | Air-gap API/worker image with bundled models |
+| `redislabs/redis-sre-agent:v1.0.0` | Versioned API/worker release (example) |
+| `redislabs/redis-sre-agent:v1.0.0-airgap` | Versioned air-gap API/worker release |
+| `redislabs/redis-sre-agent-ui:latest` | Latest production UI image |
+| `redislabs/redis-sre-agent-ui:airgap` | Air-gap-compatible production UI image |
+| `redislabs/redis-sre-agent-ui:v1.0.0` | Versioned UI release (example) |
+| `redislabs/redis-sre-agent-ui:v1.0.0-airgap` | Versioned air-gap UI release |
 
 Example production overrides:
 

--- a/scripts/build-airgap.sh
+++ b/scripts/build-airgap.sh
@@ -130,6 +130,17 @@ cp .env.airgap.example "$OUTPUT_DIR/.env.example"
 cp config.airgap.yaml "$OUTPUT_DIR/config.yaml"
 success "Configuration templates copied"
 
+CONFIGURE_STEP_NUMBER=2
+START_CORE_STEP_NUMBER=3
+START_UI_STEP_NUMBER=4
+
+if [ "$SKIP_UI_IMAGE" = false ]; then
+    LOAD_UI_STEP_NUMBER=2
+    CONFIGURE_STEP_NUMBER=3
+    START_CORE_STEP_NUMBER=4
+    START_UI_STEP_NUMBER=5
+fi
+
 cat > "$OUTPUT_DIR/README.md" <<EOF
 # Redis SRE Agent - Air-Gapped Deployment Bundle
 
@@ -162,32 +173,39 @@ cat >> "$OUTPUT_DIR/README.md" <<'EOF'
 EOF
 
 if [ "$SKIP_UI_IMAGE" = false ]; then
+    printf '\n%s\n' "${LOAD_UI_STEP_NUMBER}. Load the UI image (optional):" >> "$OUTPUT_DIR/README.md"
     cat >> "$OUTPUT_DIR/README.md" <<'EOF'
-
-2. Load the UI image (optional):
    ```bash
    docker load < redis-sre-agent-ui-airgap.tar.gz
    ```
 EOF
 fi
 
+printf '\n%s\n' "${CONFIGURE_STEP_NUMBER}. Configure environment:" >> "$OUTPUT_DIR/README.md"
 cat >> "$OUTPUT_DIR/README.md" <<'EOF'
-
-3. Configure environment:
    ```bash
    cp .env.example .env
    # Edit .env with your internal URLs
    ```
+EOF
 
-4. Start core services:
+printf '\n%s\n' "${START_CORE_STEP_NUMBER}. Start core services:" >> "$OUTPUT_DIR/README.md"
+cat >> "$OUTPUT_DIR/README.md" <<'EOF'
    ```bash
    docker compose -f docker-compose.airgap.yml up -d
    ```
+EOF
 
-5. Start with the published UI image:
+if [ "$SKIP_UI_IMAGE" = false ]; then
+    printf '\n%s\n' "${START_UI_STEP_NUMBER}. Start with the published UI image:" >> "$OUTPUT_DIR/README.md"
+    cat >> "$OUTPUT_DIR/README.md" <<'EOF'
    ```bash
    docker compose --profile ui -f docker-compose.airgap.yml up -d
    ```
+EOF
+fi
+
+cat >> "$OUTPUT_DIR/README.md" <<'EOF'
 
 ## Requirements
 
@@ -202,8 +220,16 @@ See `.env.example` for all configuration options.
 Key settings:
 - `REDIS_URL` - Your internal Redis instance
 - `OPENAI_BASE_URL` - Your internal LLM proxy
+EOF
+
+if [ "$SKIP_UI_IMAGE" = false ]; then
+    cat >> "$OUTPUT_DIR/README.md" <<'EOF'
 - `SRE_UI_IMAGE` - Published UI image tag to mirror internally
 - `SRE_UI_API_UPSTREAM` - Backend URL proxied by the UI container
+EOF
+fi
+
+cat >> "$OUTPUT_DIR/README.md" <<'EOF'
 - `EMBEDDING_PROVIDER=local` - Uses bundled embedding model
 EOF
 

--- a/scripts/build-airgap.sh
+++ b/scripts/build-airgap.sh
@@ -141,7 +141,7 @@ if [ "$SKIP_UI_IMAGE" = false ]; then
     START_UI_STEP_NUMBER=5
 fi
 
-cat > "$OUTPUT_DIR/README.md" <<EOF
+cat > "$OUTPUT_DIR/README.md" <<'EOF'
 # Redis SRE Agent - Air-Gapped Deployment Bundle
 
 This bundle contains everything needed to deploy Redis SRE Agent in an
@@ -149,7 +149,7 @@ air-gapped environment without internet access.
 
 ## Contents
 
-- \`redis-sre-agent-airgap.tar.gz\` - Docker image with pre-bundled models
+- `redis-sre-agent-airgap.tar.gz` - Docker image with pre-bundled models
 EOF
 
 if [ "$SKIP_UI_IMAGE" = false ]; then

--- a/scripts/build-airgap.sh
+++ b/scripts/build-airgap.sh
@@ -2,7 +2,7 @@
 # build-airgap.sh - Build air-gapped deployment bundle for Redis SRE Agent
 #
 # This script creates a complete bundle for air-gapped deployment:
-# - Docker image with pre-bundled embedding models
+# - Docker images for the API/worker and optional UI
 # - Pre-built knowledge base artifacts
 # - Configuration templates
 # - Documentation
@@ -11,16 +11,17 @@
 #   ./scripts/build-airgap.sh [OPTIONS]
 #
 # Options:
-#   --tag TAG           Image tag (default: redis-sre-agent:airgap)
-#   --output DIR        Output directory (default: ./airgap-bundle)
-#   --skip-artifacts    Skip building knowledge base artifacts
-#   --skip-image        Skip building Docker image
-#   --push REGISTRY     Push to registry after build
-#   --help              Show this help message
+#   --tag TAG            Agent image tag (default: redis-sre-agent:airgap)
+#   --ui-tag TAG         UI image tag (default: redis-sre-agent-ui:airgap)
+#   --output DIR         Output directory (default: ./airgap-bundle)
+#   --skip-artifacts     Skip building knowledge base artifacts
+#   --skip-image         Skip building the agent Docker image
+#   --skip-ui-image      Skip building the UI Docker image
+#   --push REGISTRY      Push built images to REGISTRY after build
+#   --help               Show this help message
 
 set -euo pipefail
 
-# Colors for output
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 BLUE='\033[0;34m'
@@ -32,20 +33,22 @@ success() { echo -e "${GREEN}[SUCCESS]${NC} $1"; }
 warning() { echo -e "${YELLOW}[WARNING]${NC} $1"; }
 error() { echo -e "${RED}[ERROR]${NC} $1"; exit 1; }
 
-# Default values
 IMAGE_TAG="redis-sre-agent:airgap"
+UI_IMAGE_TAG="redis-sre-agent-ui:airgap"
 OUTPUT_DIR="./airgap-bundle"
 SKIP_ARTIFACTS=false
 SKIP_IMAGE=false
+SKIP_UI_IMAGE=false
 PUSH_REGISTRY=""
 
-# Parse arguments
 while [[ $# -gt 0 ]]; do
     case $1 in
         --tag) IMAGE_TAG="$2"; shift 2 ;;
+        --ui-tag) UI_IMAGE_TAG="$2"; shift 2 ;;
         --output) OUTPUT_DIR="$2"; shift 2 ;;
         --skip-artifacts) SKIP_ARTIFACTS=true; shift ;;
         --skip-image) SKIP_IMAGE=true; shift ;;
+        --skip-ui-image) SKIP_UI_IMAGE=true; shift ;;
         --push) PUSH_REGISTRY="$2"; shift 2 ;;
         --help)
             head -25 "$0" | tail -20
@@ -56,13 +59,12 @@ while [[ $# -gt 0 ]]; do
 done
 
 log "Building air-gapped deployment bundle"
-log "  Image tag: $IMAGE_TAG"
+log "  Agent image tag: $IMAGE_TAG"
+log "  UI image tag: $UI_IMAGE_TAG"
 log "  Output: $OUTPUT_DIR"
 
-# Create output directory
 mkdir -p "$OUTPUT_DIR"
 
-# Build knowledge base artifacts (if not skipped)
 if [ "$SKIP_ARTIFACTS" = false ]; then
     log "Building knowledge base artifacts..."
     if [ -d "source_documents" ] && [ "$(ls -A source_documents 2>/dev/null)" ]; then
@@ -71,7 +73,6 @@ if [ "$SKIP_ARTIFACTS" = false ]; then
             --prepare-only \
             --artifacts-path ./artifacts || warning "Artifact build failed, continuing..."
 
-        # Copy artifacts to bundle
         if [ -d "artifacts" ]; then
             cp -r artifacts "$OUTPUT_DIR/"
             success "Knowledge base artifacts copied"
@@ -83,39 +84,53 @@ else
     log "Skipping artifact build (--skip-artifacts)"
 fi
 
-# Build Docker image (if not skipped)
 if [ "$SKIP_IMAGE" = false ]; then
-    log "Building Docker image: $IMAGE_TAG"
+    log "Building agent Docker image: $IMAGE_TAG"
     docker build -f Dockerfile.airgap -t "$IMAGE_TAG" .
     success "Docker image built: $IMAGE_TAG"
 
-    # Export image to tarball
-    log "Exporting image to tarball..."
+    log "Exporting agent image to tarball..."
     docker save "$IMAGE_TAG" | gzip > "$OUTPUT_DIR/redis-sre-agent-airgap.tar.gz"
-    success "Image exported: $OUTPUT_DIR/redis-sre-agent-airgap.tar.gz"
+    success "Agent image exported: $OUTPUT_DIR/redis-sre-agent-airgap.tar.gz"
 
-    # Push to registry if specified
     if [ -n "$PUSH_REGISTRY" ]; then
         FULL_TAG="$PUSH_REGISTRY/$IMAGE_TAG"
-        log "Pushing to registry: $FULL_TAG"
+        log "Pushing agent image to registry: $FULL_TAG"
         docker tag "$IMAGE_TAG" "$FULL_TAG"
         docker push "$FULL_TAG"
-        success "Pushed to: $FULL_TAG"
+        success "Pushed agent image to: $FULL_TAG"
     fi
 else
-    log "Skipping image build (--skip-image)"
+    log "Skipping agent image build (--skip-image)"
 fi
 
-# Copy configuration templates
+if [ "$SKIP_UI_IMAGE" = false ]; then
+    log "Building UI Docker image: $UI_IMAGE_TAG"
+    docker build -f ui/Dockerfile --target production -t "$UI_IMAGE_TAG" ./ui
+    success "UI Docker image built: $UI_IMAGE_TAG"
+
+    log "Exporting UI image to tarball..."
+    docker save "$UI_IMAGE_TAG" | gzip > "$OUTPUT_DIR/redis-sre-agent-ui-airgap.tar.gz"
+    success "UI image exported: $OUTPUT_DIR/redis-sre-agent-ui-airgap.tar.gz"
+
+    if [ -n "$PUSH_REGISTRY" ]; then
+        FULL_UI_TAG="$PUSH_REGISTRY/$UI_IMAGE_TAG"
+        log "Pushing UI image to registry: $FULL_UI_TAG"
+        docker tag "$UI_IMAGE_TAG" "$FULL_UI_TAG"
+        docker push "$FULL_UI_TAG"
+        success "Pushed UI image to: $FULL_UI_TAG"
+    fi
+else
+    log "Skipping UI image build (--skip-ui-image)"
+fi
+
 log "Copying configuration templates..."
 cp docker-compose.airgap.yml "$OUTPUT_DIR/"
 cp .env.airgap.example "$OUTPUT_DIR/.env.example"
 cp config.airgap.yaml "$OUTPUT_DIR/config.yaml"
-
 success "Configuration templates copied"
 
-# Create README for the bundle
-cat > "$OUTPUT_DIR/README.md" << 'EOF'
+cat > "$OUTPUT_DIR/README.md" <<EOF
 # Redis SRE Agent - Air-Gapped Deployment Bundle
 
 This bundle contains everything needed to deploy Redis SRE Agent in an
@@ -123,28 +138,55 @@ air-gapped environment without internet access.
 
 ## Contents
 
-- `redis-sre-agent-airgap.tar.gz` - Docker image with pre-bundled models
-- `docker-compose.airgap.yml` - Minimal compose file
+- \`redis-sre-agent-airgap.tar.gz\` - Docker image with pre-bundled models
+EOF
+
+if [ "$SKIP_UI_IMAGE" = false ]; then
+    cat >> "$OUTPUT_DIR/README.md" <<'EOF'
+- `redis-sre-agent-ui-airgap.tar.gz` - Optional UI image served by nginx
+EOF
+fi
+
+cat >> "$OUTPUT_DIR/README.md" <<'EOF'
+- `docker-compose.airgap.yml` - Minimal compose file with optional `ui` profile
 - `.env.example` - Configuration template
 - `config.yaml` - Agent configuration (MCP servers disabled)
 - `artifacts/` - Pre-built knowledge base (if available)
 
 ## Quick Start
 
-1. Load the Docker image:
+1. Load the agent Docker image:
    ```bash
    docker load < redis-sre-agent-airgap.tar.gz
    ```
+EOF
 
-2. Configure environment:
+if [ "$SKIP_UI_IMAGE" = false ]; then
+    cat >> "$OUTPUT_DIR/README.md" <<'EOF'
+
+2. Load the UI image (optional):
+   ```bash
+   docker load < redis-sre-agent-ui-airgap.tar.gz
+   ```
+EOF
+fi
+
+cat >> "$OUTPUT_DIR/README.md" <<'EOF'
+
+3. Configure environment:
    ```bash
    cp .env.example .env
    # Edit .env with your internal URLs
    ```
 
-3. Start services:
+4. Start core services:
    ```bash
-   docker-compose -f docker-compose.airgap.yml up -d
+   docker compose -f docker-compose.airgap.yml up -d
+   ```
+
+5. Start with the published UI image:
+   ```bash
+   docker compose --profile ui -f docker-compose.airgap.yml up -d
    ```
 
 ## Requirements
@@ -160,12 +202,13 @@ See `.env.example` for all configuration options.
 Key settings:
 - `REDIS_URL` - Your internal Redis instance
 - `OPENAI_BASE_URL` - Your internal LLM proxy
+- `SRE_UI_IMAGE` - Published UI image tag to mirror internally
+- `SRE_UI_API_UPSTREAM` - Backend URL proxied by the UI container
 - `EMBEDDING_PROVIDER=local` - Uses bundled embedding model
 EOF
 
 success "Bundle README created"
 
-# Print summary
 echo
 success "Air-gapped bundle created: $OUTPUT_DIR"
 echo
@@ -174,6 +217,14 @@ ls -la "$OUTPUT_DIR"
 echo
 log "Next steps:"
 echo "  1. Transfer $OUTPUT_DIR to air-gapped environment"
-echo "  2. Load image: docker load < redis-sre-agent-airgap.tar.gz"
-echo "  3. Configure: cp .env.example .env && edit .env"
-echo "  4. Start: docker-compose -f docker-compose.airgap.yml up -d"
+echo "  2. Load agent image: docker load < redis-sre-agent-airgap.tar.gz"
+if [ "$SKIP_UI_IMAGE" = false ]; then
+    echo "  3. Load UI image (optional): docker load < redis-sre-agent-ui-airgap.tar.gz"
+    echo "  4. Configure: cp .env.example .env && edit .env"
+    echo "  5. Start core services: docker compose -f docker-compose.airgap.yml up -d"
+    echo "  6. Start with UI: docker compose --profile ui -f docker-compose.airgap.yml up -d"
+else
+    echo "  3. Configure: cp .env.example .env && edit .env"
+    echo "  4. Start core services: docker compose -f docker-compose.airgap.yml up -d"
+    echo "  5. Start with UI later by mirroring a published redis-sre-agent-ui image"
+fi

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -54,11 +54,21 @@ FROM nginx:alpine AS production
 # Copy built assets from build stage
 COPY --from=build /app/dist /usr/share/nginx/html
 
-# Copy nginx configuration
-COPY nginx.conf /etc/nginx/conf.d/default.conf
+# Copy nginx configuration template. The nginx base image will render this
+# with a constrained envsubst invocation so air-gapped deployments can
+# override the backend upstream without rebuilding the image.
+COPY nginx.conf /etc/nginx/templates/default.conf.template
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 
 # Expose port
 EXPOSE 80
+
+# Allow callers to override the upstream at container start.
+ENV SRE_UI_API_UPSTREAM=http://sre-agent:8000
+
+# Render the nginx template, then delegate to the upstream nginx entrypoint.
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
 
 # Start nginx
 CMD ["nginx", "-g", "daemon off;"]

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -54,10 +54,9 @@ FROM nginx:alpine AS production
 # Copy built assets from build stage
 COPY --from=build /app/dist /usr/share/nginx/html
 
-# Copy nginx configuration template. The nginx base image will render this
-# with a constrained envsubst invocation so air-gapped deployments can
-# override the backend upstream without rebuilding the image.
-COPY nginx.conf /etc/nginx/templates/default.conf.template
+# Copy the nginx configuration template outside the base image's default
+# envsubst scan path so our custom entrypoint is the only renderer.
+COPY nginx.conf /etc/nginx/sre/default.conf.template
 COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 

--- a/ui/README.md
+++ b/ui/README.md
@@ -107,9 +107,17 @@ COPY dist/ /usr/share/nginx/html/
 EXPOSE 80
 ```
 
+The production Docker image in this repo already includes nginx proxying for
+`/api/`, `/health`, and `/metrics`. Override the backend target at runtime with:
+
+```bash
+SRE_UI_API_UPSTREAM=http://sre-agent:8000
+```
+
 ### Environment Configuration
 
-The UI automatically detects the correct API endpoint, but you can override it:
+For development or custom builds, the UI automatically detects the correct API
+endpoint, but you can override it:
 
 ```bash
 # Copy the example environment file
@@ -120,6 +128,8 @@ VITE_API_BASE_URL=http://your-custom-host:8080
 ```
 
 **Note**: In most cases, you don't need to set `VITE_API_BASE_URL` as the UI will automatically use the correct host.
+For the published production container, prefer `SRE_UI_API_UPSTREAM` instead of
+`VITE_API_BASE_URL`.
 
 ## Contributing
 

--- a/ui/docker-entrypoint.sh
+++ b/ui/docker-entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -eu
+
+: "${SRE_UI_API_UPSTREAM:=http://sre-agent:8000}"
+export SRE_UI_API_UPSTREAM
+
+envsubst '$SRE_UI_API_UPSTREAM' \
+  < /etc/nginx/templates/default.conf.template \
+  > /etc/nginx/conf.d/default.conf
+
+exec /docker-entrypoint.sh "$@"

--- a/ui/docker-entrypoint.sh
+++ b/ui/docker-entrypoint.sh
@@ -5,7 +5,7 @@ set -eu
 export SRE_UI_API_UPSTREAM
 
 envsubst '$SRE_UI_API_UPSTREAM' \
-  < /etc/nginx/templates/default.conf.template \
+  < /etc/nginx/sre/default.conf.template \
   > /etc/nginx/conf.d/default.conf
 
 exec /docker-entrypoint.sh "$@"

--- a/ui/nginx.conf
+++ b/ui/nginx.conf
@@ -8,7 +8,7 @@ server {
     gzip on;
     gzip_vary on;
     gzip_min_length 1024;
-    gzip_proxied expired no-cache no-store private must-revalidate auth;
+    gzip_proxied expired no-cache no-store private auth;
     gzip_types
         text/plain
         text/css

--- a/ui/nginx.conf
+++ b/ui/nginx.conf
@@ -25,7 +25,7 @@ server {
 
     # Proxy API requests to the backend
     location /api/ {
-        proxy_pass http://sre-agent:8000;
+        proxy_pass ${SRE_UI_API_UPSTREAM};
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -41,7 +41,7 @@ server {
 
     # Proxy health check requests
     location /health {
-        proxy_pass http://sre-agent:8000;
+        proxy_pass ${SRE_UI_API_UPSTREAM};
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -50,7 +50,7 @@ server {
 
     # Proxy metrics requests
     location /metrics {
-        proxy_pass http://sre-agent:8000;
+        proxy_pass ${SRE_UI_API_UPSTREAM};
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
## Summary
- publish a real `redis-sre-agent-ui` image in GitHub Actions, including `-airgap` tags
- extend the air-gap bundle script to export and optionally push a UI image alongside the agent image
- make the production UI image runtime-configurable for backend proxying and wire the air-gap compose/env/docs to the published UI artifact

## Validation
- `bash -n scripts/build-airgap.sh`
- `docker build -f ui/Dockerfile --target production -t redis-sre-agent-ui:test ./ui`
- `docker run --rm -e SRE_UI_API_UPSTREAM=http://backend.internal:9000 redis-sre-agent-ui:test sh -lc "grep -n 'proxy_pass' /etc/nginx/conf.d/default.conf"`
- `REDIS_URL=redis://example:6379/0 OPENAI_BASE_URL=https://llm.internal/v1 OPENAI_API_KEY=dummy docker compose -f docker-compose.airgap.yml --profile ui config`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes CI image publishing and air-gapped packaging/compose defaults; mistakes could break releases or UI routing, but it doesn’t touch core API/business logic.
> 
> **Overview**
> Adds first-class publishing of `redis-sre-agent-ui` images (standard and `-airgap` tags) in the GitHub Actions Docker publish workflow.
> 
> Extends `scripts/build-airgap.sh` to build/export (and optionally push) a UI image alongside the agent image, updates the air-gap bundle README generation accordingly, and wires the air-gap `.env`/`docker-compose.airgap.yml` to optionally run the UI via a `ui` profile.
> 
> Makes the production UI container runtime-configurable for backend proxying via `SRE_UI_API_UPSTREAM` by templating `ui/nginx.conf` and rendering it in a new `ui/docker-entrypoint.sh`; docs are updated to reflect the new UI artifact and configuration knobs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e04e0bdc9a0385852ff6311b1e8c39d56caa7b1a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->