### PR TITLE
Fix pipeline scrape stalls and progress visibility

### DIFF
--- a/redis_sre_agent/core/docket_tasks.py
+++ b/redis_sre_agent/core/docket_tasks.py
@@ -696,7 +696,7 @@ async def process_runbook_operation(
 async def scheduler_task(
     global_limit="scheduler",  # Need a sentinel value for concurrency limit argument
     perpetual: Perpetual = Perpetual(every=timedelta(seconds=30), automatic=True),
-    concurrency: ConcurrencyLimit = ConcurrencyLimit("sentinel", max_concurrent=1),
+    concurrency: ConcurrencyLimit = ConcurrencyLimit("global_limit", max_concurrent=1),
     retry: Retry = Retry(attempts=3, delay=timedelta(seconds=5)),
 ) -> Dict[str, Any]:
     """

--- a/redis_sre_agent/core/pipeline_execution_helpers.py
+++ b/redis_sre_agent/core/pipeline_execution_helpers.py
@@ -79,6 +79,19 @@ def _get_pipeline_task_callable() -> Any:
     return process_pipeline_operation
 
 
+def _build_progress_callback(progress_emitter: Any) -> Any:
+    """Wrap a task emitter so orchestrator callbacks share one interface."""
+
+    async def _progress_callback(
+        message: str,
+        update_type: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        await _emit_progress(progress_emitter, message, update_type, metadata)
+
+    return _progress_callback
+
+
 async def run_pipeline_operation_helper(
     operation: str,
     *,
@@ -96,6 +109,7 @@ async def run_pipeline_operation_helper(
     progress_emitter: Any = None,
 ) -> Dict[str, Any]:
     """Execute a pipeline operation and return a structured result."""
+    progress_callback = _build_progress_callback(progress_emitter)
     await _emit_progress(
         progress_emitter,
         f"Starting pipeline {operation}",
@@ -109,7 +123,9 @@ async def run_pipeline_operation_helper(
             _build_scrape_config(latest_only=latest_only, docs_path=docs_path),
             scrapers=scrapers,
         )
-        result = await orchestrator.run_scraping_pipeline(scrapers)
+        result = await orchestrator.run_scraping_pipeline(
+            scrapers, progress_callback=progress_callback
+        )
         await _emit_progress(
             progress_emitter,
             f"Completed pipeline {operation}",
@@ -123,7 +139,9 @@ async def run_pipeline_operation_helper(
             artifacts_path,
             {"ingestion": {"latest_only": latest_only}},
         )
-        result = await orchestrator.run_ingestion_pipeline(batch_date)
+        result = await orchestrator.run_ingestion_pipeline(
+            batch_date, progress_callback=progress_callback
+        )
         await _emit_progress(
             progress_emitter,
             f"Completed pipeline {operation}",
@@ -136,7 +154,7 @@ async def run_pipeline_operation_helper(
         config = _build_scrape_config(latest_only=latest_only, docs_path=docs_path)
         config["ingestion"] = {"latest_only": latest_only}
         orchestrator = PipelineOrchestrator(artifacts_path, config, scrapers=scrapers)
-        result = await orchestrator.run_full_pipeline(scrapers)
+        result = await orchestrator.run_full_pipeline(scrapers, progress_callback=progress_callback)
         await _emit_progress(
             progress_emitter,
             f"Completed pipeline {operation}",

--- a/redis_sre_agent/pipelines/orchestrator.py
+++ b/redis_sre_agent/pipelines/orchestrator.py
@@ -3,7 +3,7 @@
 import logging
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Awaitable, Callable, Dict, List, Optional
 
 from .ingestion.processor import IngestionPipeline
 from .scraper.base import ArtifactStorage
@@ -28,6 +28,8 @@ class PipelineOrchestrator:
         "redis_cloud_api": RedisCloudAPIScraper,
         "runbook_generator": RunbookGenerator,
     }
+
+    ProgressCallback = Callable[[str, str, Optional[Dict[str, Any]]], Awaitable[None]]
 
     def __init__(
         self,
@@ -59,7 +61,22 @@ class PipelineOrchestrator:
             self.storage, self.config.get("ingestion", {}), knowledge_settings
         )
 
-    async def run_scraping_pipeline(self, scrapers: Optional[List[str]] = None) -> Dict[str, Any]:
+    async def _emit_progress(
+        self,
+        progress_callback: Optional[ProgressCallback],
+        message: str,
+        update_type: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """Emit pipeline progress when a callback is provided."""
+        if progress_callback is not None:
+            await progress_callback(message, update_type, metadata or {})
+
+    async def run_scraping_pipeline(
+        self,
+        scrapers: Optional[List[str]] = None,
+        progress_callback: Optional[ProgressCallback] = None,
+    ) -> Dict[str, Any]:
         """Run the complete scraping pipeline."""
         logger.info("Starting scraping pipeline")
 
@@ -86,6 +103,13 @@ class PipelineOrchestrator:
 
                 logger.info(f"Running scraper: {scraper_name}")
                 scraper = self.scrapers[scraper_name]
+                scraper.progress_callback = progress_callback
+                await self._emit_progress(
+                    progress_callback,
+                    f"Starting scraper {scraper_name}",
+                    "pipeline_scraper_start",
+                    {"scraper": scraper_name, "batch_date": self.storage.current_date},
+                )
 
                 try:
                     scraper_result = await scraper.run_scraping_job()
@@ -97,6 +121,16 @@ class PipelineOrchestrator:
                     logger.info(
                         f"Scraper {scraper_name} completed: {scraper_result['documents_scraped']} documents"
                     )
+                    await self._emit_progress(
+                        progress_callback,
+                        f"Completed scraper {scraper_name}",
+                        "pipeline_scraper_complete",
+                        {
+                            "scraper": scraper_name,
+                            "documents_scraped": scraper_result.get("documents_scraped", 0),
+                            "batch_date": self.storage.current_date,
+                        },
+                    )
 
                 except Exception as e:
                     logger.error(f"Scraper {scraper_name} failed: {e}")
@@ -104,6 +138,12 @@ class PipelineOrchestrator:
                         "error": str(e),
                         "documents_scraped": 0,
                     }
+                    await self._emit_progress(
+                        progress_callback,
+                        f"Scraper {scraper_name} failed: {e}",
+                        "pipeline_scraper_error",
+                        {"scraper": scraper_name, "batch_date": self.storage.current_date},
+                    )
 
             # Save batch manifest
             if all_documents:
@@ -126,23 +166,43 @@ class PipelineOrchestrator:
 
         return pipeline_results
 
-    async def run_ingestion_pipeline(self, batch_date: Optional[str] = None) -> Dict[str, Any]:
+    async def run_ingestion_pipeline(
+        self,
+        batch_date: Optional[str] = None,
+        progress_callback: Optional[ProgressCallback] = None,
+    ) -> Dict[str, Any]:
         """Run the ingestion pipeline for a specific batch."""
         target_batch = batch_date or self.storage.current_date
 
         logger.info(f"Starting ingestion pipeline for batch: {target_batch}")
+        await self._emit_progress(
+            progress_callback,
+            f"Starting ingestion for batch {target_batch}",
+            "pipeline_stage",
+            {"stage": "ingestion", "batch_date": target_batch},
+        )
 
         try:
             ingestion_results = await self.ingestion.ingest_batch(target_batch)
 
             logger.info(f"Ingestion pipeline completed for batch {target_batch}")
+            await self._emit_progress(
+                progress_callback,
+                f"Completed ingestion for batch {target_batch}",
+                "pipeline_stage_complete",
+                {"stage": "ingestion", "batch_date": target_batch},
+            )
             return ingestion_results
 
         except Exception as e:
             logger.error(f"Ingestion pipeline failed for batch {target_batch}: {e}")
             raise
 
-    async def run_full_pipeline(self, scrapers: Optional[List[str]] = None) -> Dict[str, Any]:
+    async def run_full_pipeline(
+        self,
+        scrapers: Optional[List[str]] = None,
+        progress_callback: Optional[ProgressCallback] = None,
+    ) -> Dict[str, Any]:
         """Run complete pipeline: scraping + ingestion."""
         logger.info("Starting full pipeline (scraping + ingestion)")
 
@@ -156,14 +216,24 @@ class PipelineOrchestrator:
         try:
             # Stage 1: Scraping
             logger.info("Stage 1: Running scraping pipeline")
-            scraping_results = await self.run_scraping_pipeline(scrapers)
+            await self._emit_progress(
+                progress_callback,
+                "Stage 1/2: scraping documents",
+                "pipeline_stage",
+                {"stage": "scraping", "batch_date": self.storage.current_date},
+            )
+            scraping_results = await self.run_scraping_pipeline(
+                scrapers, progress_callback=progress_callback
+            )
             full_results["scraping"] = scraping_results
 
             # Only proceed to ingestion if scraping was successful and found documents
             if scraping_results["success"] and scraping_results["total_documents"] > 0:
                 # Stage 2: Ingestion
                 logger.info("Stage 2: Running ingestion pipeline")
-                ingestion_results = await self.run_ingestion_pipeline()
+                ingestion_results = await self.run_ingestion_pipeline(
+                    progress_callback=progress_callback
+                )
                 full_results["ingestion"] = ingestion_results
 
                 full_results["success"] = ingestion_results["success"]

--- a/redis_sre_agent/pipelines/scraper/base.py
+++ b/redis_sre_agent/pipelines/scraper/base.py
@@ -7,7 +7,7 @@ from abc import ABC, abstractmethod
 from datetime import datetime, timezone
 from enum import Enum
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Awaitable, Callable, Dict, List, Optional, Union
 
 logger = logging.getLogger(__name__)
 
@@ -229,6 +229,9 @@ class BaseScraper(ABC):
         self.config = config or {}
         self.scraped_documents: List[ScrapedDocument] = []
         self.logger = logging.getLogger(f"{__name__}.{self.__class__.__name__}")
+        self.progress_callback: Optional[
+            Callable[[str, str, Optional[Dict[str, Any]]], Awaitable[None]]
+        ] = None
 
     @abstractmethod
     async def scrape(self) -> List[ScrapedDocument]:
@@ -281,6 +284,16 @@ class BaseScraper(ABC):
         except Exception as e:
             self.logger.error(f"Scraping job failed for {self.get_source_name()}: {e}")
             raise
+
+    async def emit_progress(
+        self,
+        message: str,
+        update_type: str = "scraper_progress",
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """Emit scraper progress when the orchestrator provides a callback."""
+        if self.progress_callback is not None:
+            await self.progress_callback(message, update_type, metadata or {})
 
     def _clean_content(self, content: str) -> str:
         """Clean and normalize content text."""

--- a/redis_sre_agent/pipelines/scraper/redis_docs.py
+++ b/redis_sre_agent/pipelines/scraper/redis_docs.py
@@ -457,14 +457,14 @@ class RedisDocsScraper(BaseScraper):
             href = link["href"]
 
             # Convert relative URLs to absolute
-            full_url = self._normalize_url(urljoin(base_url, href))
-            parsed = urlparse(full_url)
+            raw_full_url = urljoin(base_url, href)
+            parsed = urlparse(raw_full_url)
 
             # Only include links from the same domain
             if parsed.netloc == base_domain:
                 # Exclude non-documentation links
                 if any(
-                    exclude in full_url
+                    exclude in raw_full_url
                     for exclude in [
                         "#",
                         "javascript:",
@@ -485,6 +485,8 @@ class RedisDocsScraper(BaseScraper):
                     ]
                 ):
                     continue
+
+                full_url = self._normalize_url(raw_full_url)
 
                 # latest-only: skip versioned URLs
                 if self.config.get("latest_only") and self._is_versioned_url(full_url):

--- a/redis_sre_agent/pipelines/scraper/redis_docs.py
+++ b/redis_sre_agent/pipelines/scraper/redis_docs.py
@@ -2,8 +2,8 @@
 
 import asyncio
 import logging
-from typing import Any, Dict, List, Optional
-from urllib.parse import urljoin, urlparse
+from typing import Any, Dict, List, Optional, Set
+from urllib.parse import urljoin, urlparse, urlunparse
 
 import aiohttp
 from bs4 import BeautifulSoup
@@ -38,6 +38,9 @@ class RedisDocsScraper(BaseScraper):
         }
 
         self.session: Optional[aiohttp.ClientSession] = None
+        self._visited_urls: Set[str] = set()
+        self._pages_scraped = 0
+        self._progress_interval = max(1, int(self.config.get("progress_interval", 10)))
 
     def _is_versioned_url(self, url: str) -> bool:
         """Return True if URL path contains a version segment like /7.4/ or /6.2/."""
@@ -81,6 +84,8 @@ class RedisDocsScraper(BaseScraper):
     async def scrape(self) -> List[ScrapedDocument]:
         """Scrape Redis OSS and Enterprise documentation."""
         documents = []
+        self._visited_urls = set()
+        self._pages_scraped = 0
 
         async with aiohttp.ClientSession(
             timeout=aiohttp.ClientTimeout(total=self.config["timeout"])
@@ -99,6 +104,21 @@ class RedisDocsScraper(BaseScraper):
 
         self.logger.info(f"Scraped {len(documents)} Redis documentation pages")
         return documents
+
+    def _normalize_url(self, url: str) -> str:
+        """Normalize documentation URLs so revisits collapse to a single page."""
+        parsed = urlparse(url)
+        normalized_path = parsed.path.rstrip("/") or "/"
+        return urlunparse(
+            (
+                parsed.scheme,
+                parsed.netloc,
+                normalized_path,
+                parsed.params,
+                "",
+                "",
+            )
+        )
 
     async def _scrape_oss_docs(self) -> List[ScrapedDocument]:
         """Scrape Redis OSS documentation."""
@@ -250,27 +270,50 @@ class RedisDocsScraper(BaseScraper):
         if current_depth >= max_depth:
             return []
 
+        normalized_url = self._normalize_url(section_url)
+
+        if normalized_url in self._visited_urls:
+            return []
+
+        if self._pages_scraped >= self.config["max_pages"]:
+            return []
+
         documents = []
 
         try:
             # Respect latest-only: skip versioned URLs outright
-            if self.config.get("latest_only") and self._is_versioned_url(section_url):
+            if self.config.get("latest_only") and self._is_versioned_url(normalized_url):
                 return []
 
+            self._visited_urls.add(normalized_url)
+            self._pages_scraped += 1
+
+            if self._pages_scraped == 1 or self._pages_scraped % self._progress_interval == 0:
+                await self.emit_progress(
+                    f"Scraped {self._pages_scraped} Redis docs pages",
+                    "pipeline_scrape_progress",
+                    {
+                        "pages_scraped": self._pages_scraped,
+                        "max_pages": self.config["max_pages"],
+                        "current_url": normalized_url,
+                        "current_depth": current_depth,
+                    },
+                )
+
             # Get section page
-            async with self.session.get(section_url) as response:
+            async with self.session.get(normalized_url) as response:
                 if response.status != 200:
-                    self.logger.warning(f"HTTP {response.status} for {section_url}")
+                    self.logger.warning(f"HTTP {response.status} for {normalized_url}")
                     return []
 
                 html = await response.text()
                 soup = BeautifulSoup(html, "html.parser")
 
             # Extract main content
-            main_content = await self._extract_page_content(soup, section_url)
+            main_content = await self._extract_page_content(soup, normalized_url)
             if main_content:
                 # Extract version from URL and add to metadata
-                version = self._extract_version_from_url(section_url)
+                version = self._extract_version_from_url(normalized_url)
                 metadata = {
                     **main_content["metadata"],
                     "version": version,
@@ -278,7 +321,7 @@ class RedisDocsScraper(BaseScraper):
                 doc = ScrapedDocument(
                     title=main_content["title"],
                     content=main_content["content"],
-                    source_url=section_url,
+                    source_url=normalized_url,
                     category=category,
                     doc_type=doc_type,
                     severity=severity,
@@ -288,9 +331,14 @@ class RedisDocsScraper(BaseScraper):
 
             # Find links to sub-pages (if not at max depth)
             if current_depth < max_depth - 1:
-                links = await self._find_documentation_links(soup, section_url)
+                links = await self._find_documentation_links(soup, normalized_url)
+                filtered_links = [
+                    link_url
+                    for link_url in links
+                    if self._normalize_url(link_url) not in self._visited_urls
+                ]
 
-                for link_url in links[:50]:  # Increased limit for comprehensive scraping
+                for link_url in filtered_links[:50]:  # Increased limit for comprehensive scraping
                     try:
                         subdocs = await self._scrape_section(
                             link_url, category, doc_type, severity, max_depth, current_depth + 1
@@ -305,7 +353,7 @@ class RedisDocsScraper(BaseScraper):
                         continue
 
         except Exception as e:
-            self.logger.error(f"Failed to scrape section {section_url}: {e}")
+            self.logger.error(f"Failed to scrape section {normalized_url}: {e}")
 
         return documents
 
@@ -409,7 +457,7 @@ class RedisDocsScraper(BaseScraper):
             href = link["href"]
 
             # Convert relative URLs to absolute
-            full_url = urljoin(base_url, href)
+            full_url = self._normalize_url(urljoin(base_url, href))
             parsed = urlparse(full_url)
 
             # Only include links from the same domain

--- a/tests/unit/core/test_pipeline_execution_helpers.py
+++ b/tests/unit/core/test_pipeline_execution_helpers.py
@@ -1,6 +1,6 @@
 """Tests for task-backed pipeline execution helpers."""
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -47,7 +47,9 @@ class TestRunPipelineOperationHelper:
             },
             scrapers=["redis_docs"],
         )
-        mock_orchestrator.run_scraping_pipeline.assert_awaited_once_with(["redis_docs"])
+        mock_orchestrator.run_scraping_pipeline.assert_awaited_once_with(
+            ["redis_docs"], progress_callback=ANY
+        )
         assert emitter.emit.await_count == 2
 
     @pytest.mark.asyncio
@@ -75,7 +77,9 @@ class TestRunPipelineOperationHelper:
             "/tmp/artifacts",
             {"ingestion": {"latest_only": True}},
         )
-        mock_orchestrator.run_ingestion_pipeline.assert_awaited_once_with("2026-03-25")
+        mock_orchestrator.run_ingestion_pipeline.assert_awaited_once_with(
+            "2026-03-25", progress_callback=ANY
+        )
 
     @pytest.mark.asyncio
     async def test_run_full_operation(self):
@@ -107,7 +111,9 @@ class TestRunPipelineOperationHelper:
             },
             scrapers=["redis_docs_local"],
         )
-        mock_orchestrator.run_full_pipeline.assert_awaited_once_with(["redis_docs_local"])
+        mock_orchestrator.run_full_pipeline.assert_awaited_once_with(
+            ["redis_docs_local"], progress_callback=ANY
+        )
 
     @pytest.mark.asyncio
     async def test_run_cleanup_operation(self):

--- a/tests/unit/pipelines/orchestrator/test_pipeline_orchestrator.py
+++ b/tests/unit/pipelines/orchestrator/test_pipeline_orchestrator.py
@@ -187,6 +187,34 @@ class TestPipelineOrchestrator:
         assert result["scrapers_run"] == ["redis_docs"]
 
     @pytest.mark.asyncio
+    async def test_run_scraping_pipeline_emits_progress(self, orchestrator):
+        """Scraping pipeline should report scraper start and completion events."""
+        mock_result = {"documents_scraped": 1, "success": True}
+        sample_doc = [
+            ScrapedDocument(
+                title="Test",
+                content="Content",
+                source_url="https://test.com",
+                category=DocumentCategory.OSS,
+                doc_type=DocumentType.DOCUMENTATION,
+                severity=SeverityLevel.MEDIUM,
+            )
+        ]
+        progress_callback = AsyncMock()
+
+        orchestrator.scrapers["redis_docs"].run_scraping_job = AsyncMock(return_value=mock_result)
+        orchestrator.scrapers["redis_docs"].scraped_documents = sample_doc
+
+        with patch.object(orchestrator.storage, "save_batch_manifest") as mock_save:
+            mock_save.return_value = Path("/test/manifest.json")
+            await orchestrator.run_scraping_pipeline(
+                scrapers=["redis_docs"], progress_callback=progress_callback
+            )
+
+        progress_types = [call.args[1] for call in progress_callback.await_args_list]
+        assert progress_types == ["pipeline_scraper_start", "pipeline_scraper_complete"]
+
+    @pytest.mark.asyncio
     async def test_run_ingestion_pipeline_success(self, orchestrator, tmp_path):
         """Test successful ingestion pipeline execution."""
         batch_date = "2025-01-20"
@@ -269,6 +297,25 @@ class TestPipelineOrchestrator:
 
         mock_scrape.assert_called_once()
         mock_ingest.assert_not_called()  # Should not call ingestion
+
+    @pytest.mark.asyncio
+    async def test_run_full_pipeline_emits_stage_progress(self, orchestrator):
+        """Full pipeline should emit stage progress for scraping and ingestion."""
+        scraping_result = {"success": True, "total_documents": 2, "batch_date": "2025-01-20"}
+        ingestion_result = {"success": True, "documents_processed": 2, "chunks_indexed": 4}
+        progress_callback = AsyncMock()
+
+        with patch.object(orchestrator, "run_scraping_pipeline") as mock_scrape:
+            mock_scrape.return_value = scraping_result
+
+            with patch.object(orchestrator, "run_ingestion_pipeline") as mock_ingest:
+                mock_ingest.return_value = ingestion_result
+                await orchestrator.run_full_pipeline(progress_callback=progress_callback)
+
+        progress_types = [call.args[1] for call in progress_callback.await_args_list]
+        assert "pipeline_stage" in progress_types
+        mock_scrape.assert_awaited_once_with(None, progress_callback=progress_callback)
+        mock_ingest.assert_awaited_once_with(progress_callback=progress_callback)
 
     @pytest.mark.asyncio
     async def test_get_pipeline_status(self, orchestrator):

--- a/tests/unit/pipelines/scraper/test_redis_docs.py
+++ b/tests/unit/pipelines/scraper/test_redis_docs.py
@@ -1,0 +1,138 @@
+"""Tests for the Redis documentation scraper."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from redis_sre_agent.pipelines.scraper.base import (
+    ArtifactStorage,
+    DocumentCategory,
+    DocumentType,
+    SeverityLevel,
+)
+from redis_sre_agent.pipelines.scraper.redis_docs import RedisDocsScraper
+
+
+class _FakeResponse:
+    def __init__(self, url: str):
+        self.url = url
+        self.status = 200
+
+    async def text(self) -> str:
+        return "<html><body>redis docs</body></html>"
+
+
+class _FakeRequestContext:
+    def __init__(self, url: str, requested_urls: list[str]):
+        self._response = _FakeResponse(url)
+        self._requested_urls = requested_urls
+        self._url = url
+
+    async def __aenter__(self) -> _FakeResponse:
+        self._requested_urls.append(self._url)
+        return self._response
+
+    async def __aexit__(self, exc_type, exc, tb) -> bool:
+        return False
+
+
+class _FakeSession:
+    def __init__(self):
+        self.requested_urls: list[str] = []
+
+    def get(self, url: str) -> _FakeRequestContext:
+        return _FakeRequestContext(url, self.requested_urls)
+
+
+@pytest.mark.asyncio
+async def test_scrape_section_skips_revisited_urls(tmp_path):
+    """Recursive traversal should fetch each normalized URL at most once."""
+    scraper = RedisDocsScraper(ArtifactStorage(tmp_path), {"max_pages": 20})
+    scraper.session = _FakeSession()
+
+    graph = {
+        "https://redis.io/docs": [
+            "https://redis.io/docs/a/",
+            "https://redis.io/docs/b/",
+        ],
+        "https://redis.io/docs/a": [
+            "https://redis.io/docs/b/",
+            "https://redis.io/docs/c/",
+        ],
+        "https://redis.io/docs/b": [
+            "https://redis.io/docs/c/",
+        ],
+        "https://redis.io/docs/c": [],
+    }
+
+    async def fake_extract(_soup, url):
+        return {
+            "title": f"Doc for {url}",
+            "content": "x" * 200,
+            "metadata": {},
+        }
+
+    async def fake_links(_soup, base_url):
+        return graph[base_url]
+
+    with (
+        patch.object(scraper, "_extract_page_content", side_effect=fake_extract),
+        patch.object(scraper, "_find_documentation_links", side_effect=fake_links),
+        patch("redis_sre_agent.pipelines.scraper.redis_docs.asyncio.sleep", new=AsyncMock()),
+    ):
+        docs = await scraper._scrape_section(
+            "https://redis.io/docs/",
+            DocumentCategory.OSS,
+            DocumentType.DOCUMENTATION,
+            SeverityLevel.MEDIUM,
+            max_depth=4,
+        )
+
+    assert len(scraper.session.requested_urls) == 4
+    assert scraper.session.requested_urls == [
+        "https://redis.io/docs",
+        "https://redis.io/docs/a",
+        "https://redis.io/docs/b",
+        "https://redis.io/docs/c",
+    ]
+    assert len(docs) == 4
+
+
+@pytest.mark.asyncio
+async def test_scrape_section_honors_max_pages_budget(tmp_path):
+    """Traversal should stop once the configured page budget is exhausted."""
+    scraper = RedisDocsScraper(ArtifactStorage(tmp_path), {"max_pages": 2})
+    scraper.session = _FakeSession()
+
+    async def fake_extract(_soup, url):
+        return {
+            "title": f"Doc for {url}",
+            "content": "x" * 200,
+            "metadata": {},
+        }
+
+    async def fake_links(_soup, _base_url):
+        return [
+            "https://redis.io/docs/a/",
+            "https://redis.io/docs/b/",
+        ]
+
+    with (
+        patch.object(scraper, "_extract_page_content", side_effect=fake_extract),
+        patch.object(scraper, "_find_documentation_links", side_effect=fake_links),
+        patch("redis_sre_agent.pipelines.scraper.redis_docs.asyncio.sleep", new=AsyncMock()),
+    ):
+        docs = await scraper._scrape_section(
+            "https://redis.io/docs/",
+            DocumentCategory.OSS,
+            DocumentType.DOCUMENTATION,
+            SeverityLevel.MEDIUM,
+            max_depth=4,
+        )
+
+    assert len(scraper.session.requested_urls) == 2
+    assert scraper.session.requested_urls == [
+        "https://redis.io/docs",
+        "https://redis.io/docs/a",
+    ]
+    assert len(docs) == 2

--- a/tests/unit/pipelines/scraper/test_redis_docs.py
+++ b/tests/unit/pipelines/scraper/test_redis_docs.py
@@ -3,6 +3,7 @@
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from bs4 import BeautifulSoup
 
 from redis_sre_agent.pipelines.scraper.base import (
     ArtifactStorage,
@@ -136,3 +137,22 @@ async def test_scrape_section_honors_max_pages_budget(tmp_path):
         "https://redis.io/docs/a",
     ]
     assert len(docs) == 2
+
+
+@pytest.mark.asyncio
+async def test_find_documentation_links_excludes_search_queries_before_normalizing(tmp_path):
+    """Search query URLs should still be filtered even though dedupe normalizes URLs."""
+    scraper = RedisDocsScraper(ArtifactStorage(tmp_path))
+    soup = BeautifulSoup(
+        """
+        <html><body>
+            <a href="/docs/?search=vector">Search results</a>
+            <a href="/search/query-engine/">Valid search docs</a>
+        </body></html>
+        """,
+        "html.parser",
+    )
+
+    links = await scraper._find_documentation_links(soup, "https://redis.io/docs/")
+
+    assert links == ["https://redis.io/search/query-engine"]


### PR DESCRIPTION
## Summary
- stop `redis_docs` from revisiting the same normalized URLs and enforce the configured page budget during recursive scraping
- emit scraper and stage progress through the pipeline task path so long compose-based scrapes no longer look hung
- add regression coverage for revisit dedupe and page-budget enforcement, and fix the scheduler concurrency binding that was spamming worker logs

## Testing
- `make test`
- `uv run pytest tests/unit/pipelines/scraper/test_redis_docs.py tests/unit/pipelines/orchestrator/test_pipeline_orchestrator.py tests/unit/core/test_pipeline_execution_helpers.py`
- `uv run pytest tests/unit/core/test_tasks.py -k scheduler_task`
- compose-backed helper verification inside `sre-agent` showing `pipeline_scrape_progress` at 1, 10, 20, 30, 40, and 50 pages

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core scraping traversal and orchestrator execution paths; bugs could change scrape coverage or pipeline completion behavior, though changes are guarded by tests and mostly additive progress reporting.
> 
> **Overview**
> Improves long-running pipeline task visibility by threading a unified `progress_callback` from task emitters through `run_pipeline_operation_helper` into `PipelineOrchestrator`, emitting stage and per-scraper start/complete/error updates.
> 
> Fixes Redis docs scraping stalls by normalizing URLs, deduping revisits during recursive traversal, enforcing the configured `max_pages` budget, and emitting periodic scrape progress updates.
> 
> Also corrects the `scheduler_task` concurrency limit key binding (to reduce duplicate scheduling/log spam) and adds unit tests covering the new progress events plus the Redis docs dedupe/max-page behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb8ad62329b2b2a6ff08fcfc237e7ebe1cd3c818. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->