### PR TITLE
Fix runtime triage regressions

### DIFF
--- a/redis_sre_agent/agent/chat_agent.py
+++ b/redis_sre_agent/agent/chat_agent.py
@@ -59,6 +59,16 @@ logger = logging.getLogger(__name__)
 tracer = trace.get_tracer(__name__)
 
 
+def _format_exception_message(exc: Exception) -> str:
+    message = str(exc).strip()
+    if message:
+        return message
+
+    if exc.args:
+        return f"{type(exc).__name__}: {exc.args!r}"
+    return type(exc).__name__
+
+
 CHAT_SYSTEM_PROMPT = """You are a Redis SRE agent with access to tools for investigating Redis deployments.
 
 ## Your Approach - ITERATIVE INVESTIGATION
@@ -855,7 +865,7 @@ User Query: {query}"""
 
             try:
                 await emitter.emit("Chat agent processing your question...", "agent_start")
-                with open_graph_checkpointer(durable=bool(task_id)) as checkpointer:
+                async with open_graph_checkpointer(durable=bool(task_id)) as checkpointer:
                     app = workflow.compile(checkpointer=checkpointer)
                     final_state = await app.ainvoke(initial_state, config=thread_config)
                     await persist_checkpoint_metadata(
@@ -896,8 +906,9 @@ User Query: {query}"""
             except GraphInterrupt:
                 raise
             except Exception as e:
-                logger.exception(f"Chat agent error: {e}")
-                return AgentResponse(response=f"Error processing query: {e}")
+                error_message = _format_exception_message(e)
+                logger.exception("Chat agent error: %s", error_message)
+                return AgentResponse(response=f"Error processing query: {error_message}")
 
     async def resume_query(
         self,
@@ -959,7 +970,7 @@ User Query: {query}"""
             thread_config = build_graph_config(graph_thread_id=graph_thread_id)
 
             try:
-                with open_graph_checkpointer(durable=True) as checkpointer:
+                async with open_graph_checkpointer(durable=True) as checkpointer:
                     app = workflow.compile(checkpointer=checkpointer)
                     final_state = await app.ainvoke(
                         Command(resume=resume_payload or {}),
@@ -997,8 +1008,9 @@ User Query: {query}"""
             except GraphInterrupt:
                 raise
             except Exception as e:
-                logger.exception(f"Chat agent resume error: {e}")
-                return AgentResponse(response=f"Error resuming query: {e}")
+                error_message = _format_exception_message(e)
+                logger.exception("Chat agent resume error: %s", error_message)
+                return AgentResponse(response=f"Error resuming query: {error_message}")
 
 
 # Singleton cache keyed by instance name

--- a/redis_sre_agent/agent/checkpointing.py
+++ b/redis_sre_agent/agent/checkpointing.py
@@ -4,11 +4,11 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from contextlib import ExitStack, contextmanager
-from typing import Any, Dict, Iterator, Optional
+from contextlib import AsyncExitStack, asynccontextmanager
+from typing import Any, AsyncIterator, Dict, Optional
 
 from langgraph.checkpoint.memory import InMemorySaver
-from langgraph.checkpoint.redis import RedisSaver
+from langgraph.checkpoint.redis import AsyncRedisSaver
 
 from redis_sre_agent import __version__
 from redis_sre_agent.core.approvals import ApprovalManager, GraphResumeState, PendingApprovalSummary
@@ -86,15 +86,17 @@ async def resolve_checkpoint_lookup_thread_id(session_id: str) -> str:
         return session_id
 
 
-@contextmanager
-def open_graph_checkpointer(*, durable: bool = True) -> Iterator[Any]:
+@asynccontextmanager
+async def open_graph_checkpointer(*, durable: bool = True) -> AsyncIterator[Any]:
     """Open a Redis-backed LangGraph checkpointer for the current repo config."""
     redis_url = settings.redis_url.get_secret_value()
-    stack = ExitStack()
+    stack = AsyncExitStack()
     try:
-        checkpointer = stack.enter_context(RedisSaver.from_conn_string(redis_url=redis_url))
+        checkpointer = await stack.enter_async_context(
+            AsyncRedisSaver.from_conn_string(redis_url=redis_url)
+        )
     except Exception as exc:
-        stack.close()
+        await stack.aclose()
         logger.error(
             "Redis checkpoint connection failed; durable resume is unavailable: %s",
             exc,
@@ -106,13 +108,9 @@ def open_graph_checkpointer(*, durable: bool = True) -> Iterator[Any]:
         return
 
     try:
-        try:
-            checkpointer.setup()
-        except Exception as exc:
-            logger.warning("Redis checkpoint setup failed: %s", exc)
         yield checkpointer
     finally:
-        stack.close()
+        await stack.aclose()
 
 
 async def persist_checkpoint_metadata(
@@ -121,7 +119,7 @@ async def persist_checkpoint_metadata(
     thread_id: Optional[str],
     graph_thread_id: str,
     graph_type: str,
-    checkpointer: RedisSaver,
+    checkpointer: Any,
     config: Dict[str, Any],
     graph_version: str = __version__,
 ) -> None:

--- a/redis_sre_agent/agent/checkpointing.py
+++ b/redis_sre_agent/agent/checkpointing.py
@@ -95,6 +95,7 @@ async def open_graph_checkpointer(*, durable: bool = True) -> AsyncIterator[Any]
         checkpointer = await stack.enter_async_context(
             AsyncRedisSaver.from_conn_string(redis_url=redis_url)
         )
+        await checkpointer.asetup()
     except Exception as exc:
         await stack.aclose()
         logger.error(

--- a/redis_sre_agent/agent/langgraph_agent.py
+++ b/redis_sre_agent/agent/langgraph_agent.py
@@ -2422,7 +2422,7 @@ For now, I can still perform basic Redis diagnostics using the database connecti
             )
 
             try:
-                with open_graph_checkpointer(durable=bool(task_id)) as checkpointer:
+                async with open_graph_checkpointer(durable=bool(task_id)) as checkpointer:
                     self.app = self.workflow.compile(checkpointer=checkpointer)
                     final_state = await self.app.ainvoke(initial_state, config=thread_config)
                     await persist_checkpoint_metadata(
@@ -2492,7 +2492,7 @@ For now, I can still perform basic Redis diagnostics using the database connecti
             )
 
             if hasattr(self, "workflow"):
-                with open_graph_checkpointer(durable=False) as checkpointer:
+                async with open_graph_checkpointer(durable=False) as checkpointer:
                     app = self.workflow.compile(checkpointer=checkpointer)
                     current_state = await app.aget_state(config=thread_config)
             else:
@@ -2536,7 +2536,7 @@ For now, I can still perform basic Redis diagnostics using the database connecti
                 recursion_limit=recursion_limit,
             )
             if hasattr(self, "workflow"):
-                with open_graph_checkpointer(durable=False) as checkpointer:
+                async with open_graph_checkpointer(durable=False) as checkpointer:
                     app = self.workflow.compile(checkpointer=checkpointer)
                     current_state = await app.aget_state(config=thread_config)
             else:
@@ -2853,7 +2853,7 @@ For now, I can still perform basic Redis diagnostics using the database connecti
                     recursion_limit=self.settings.recursion_limit,
                 )
 
-                with open_graph_checkpointer(durable=True) as checkpointer:
+                async with open_graph_checkpointer(durable=True) as checkpointer:
                     self.app = self.workflow.compile(checkpointer=checkpointer)
                     final_state = await self.app.ainvoke(
                         Command(resume=resume_payload or {}),

--- a/redis_sre_agent/tools/manager.py
+++ b/redis_sre_agent/tools/manager.py
@@ -108,6 +108,21 @@ def _command_is_available(command: Optional[str]) -> bool:
     return shutil.which(cmd) is not None
 
 
+def _missing_local_mcp_arg_path(args: Optional[List[str]]) -> Optional[str]:
+    """Return the first direct local-path argument that does not exist."""
+    for raw_arg in args or []:
+        arg = (raw_arg or "").strip()
+        if not arg or arg.startswith("-") or any(ch.isspace() for ch in arg):
+            continue
+        if "/" not in arg and not arg.startswith(".") and not arg.startswith("~"):
+            continue
+
+        candidate = Path(arg).expanduser()
+        if not candidate.exists():
+            return str(candidate)
+    return None
+
+
 class ToolManager:
     """Manages tool provider lifecycle and routing.
 
@@ -617,6 +632,16 @@ class ToolManager:
                         "Configure a valid command or URL transport instead.",
                         server_name,
                         server_config.command,
+                    )
+                    continue
+
+                missing_arg_path = _missing_local_mcp_arg_path(server_config.args)
+                if missing_arg_path:
+                    logger.warning(
+                        "Skipping MCP provider '%s': local entrypoint '%s' does not exist. "
+                        "Configure a valid artifact path or URL transport instead.",
+                        server_name,
+                        missing_arg_path,
                     )
                     continue
 

--- a/redis_sre_agent/tools/manager.py
+++ b/redis_sre_agent/tools/manager.py
@@ -114,10 +114,14 @@ def _missing_local_mcp_arg_path(args: Optional[List[str]]) -> Optional[str]:
         arg = (raw_arg or "").strip()
         if not arg or arg.startswith("-") or any(ch.isspace() for ch in arg):
             continue
-        if "/" not in arg and not arg.startswith(".") and not arg.startswith("~"):
+        if arg.startswith("file://"):
+            candidate = Path(arg.removeprefix("file://")).expanduser()
+        elif arg.startswith(("/", "./", "../", "~")):
+            candidate = Path(arg).expanduser()
+        elif "/" in arg and Path(arg).suffix in {".js", ".mjs", ".cjs", ".ts", ".py", ".sh"}:
+            candidate = Path(arg).expanduser()
+        else:
             continue
-
-        candidate = Path(arg).expanduser()
         if not candidate.exists():
             return str(candidate)
     return None

--- a/redis_sre_agent/tools/manager.py
+++ b/redis_sre_agent/tools/manager.py
@@ -116,6 +116,8 @@ def _missing_local_mcp_arg_path(args: Optional[List[str]]) -> Optional[str]:
             continue
         if arg.startswith("file://"):
             candidate = Path(arg.removeprefix("file://")).expanduser()
+        elif "://" in arg:
+            continue
         elif arg.startswith(("/", "./", "../", "~")):
             candidate = Path(arg).expanduser()
         elif "/" in arg and Path(arg).suffix in {".js", ".mjs", ".cjs", ".ts", ".py", ".sh"}:

--- a/redis_sre_agent/tools/target_discovery/provider.py
+++ b/redis_sre_agent/tools/target_discovery/provider.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 from typing import Any, Dict, List, Optional
 
 from redis_sre_agent.core.targets import (
@@ -16,6 +17,12 @@ from redis_sre_agent.tools.protocols import ToolProvider
 
 class TargetDiscoveryToolProvider(ToolProvider):
     """Resolve safe Redis targets from natural-language metadata queries."""
+
+    def __init__(self, redis_instance=None, config=None):
+        super().__init__(redis_instance=redis_instance, config=config)
+        # Target discovery is always-on and not instance-scoped, so its tool
+        # names must stay stable across provider instances and processes.
+        self._instance_hash = hashlib.sha256(self.provider_name.encode()).hexdigest()[:6]
 
     @property
     def provider_name(self) -> str:

--- a/tests/unit/agent/test_agent.py
+++ b/tests/unit/agent/test_agent.py
@@ -1,7 +1,7 @@
 """Unit tests for SRE LangGraph Agent."""
 
 import asyncio
-from contextlib import contextmanager
+from contextlib import asynccontextmanager
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -370,8 +370,8 @@ class TestSRELangGraphAgent:
         captured: dict[str, object] = {}
         fake_checkpointer = MagicMock()
 
-        @contextmanager
-        def fake_open_graph_checkpointer(**_kwargs):
+        @asynccontextmanager
+        async def fake_open_graph_checkpointer(**_kwargs):
             yield fake_checkpointer
 
         class _FakeApp:
@@ -447,8 +447,8 @@ class TestSRELangGraphAgent:
                 }
             )
 
-            @contextmanager
-            def fake_open_graph_checkpointer(**_kwargs):
+            @asynccontextmanager
+            async def fake_open_graph_checkpointer(**_kwargs):
                 yield fake_checkpointer
 
             class _FakeApp:
@@ -487,8 +487,8 @@ class TestSRELangGraphAgent:
         mock_tool_mgr_ctx.__aexit__ = AsyncMock(return_value=None)
         fake_checkpointer = MagicMock()
 
-        @contextmanager
-        def fake_open_graph_checkpointer(**_kwargs):
+        @asynccontextmanager
+        async def fake_open_graph_checkpointer(**_kwargs):
             yield fake_checkpointer
 
         class _FakeApp:

--- a/tests/unit/agent/test_chat_agent.py
+++ b/tests/unit/agent/test_chat_agent.py
@@ -1,6 +1,6 @@
 """Unit tests for the lightweight Chat Agent."""
 
-from contextlib import contextmanager
+from contextlib import asynccontextmanager
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -1007,8 +1007,8 @@ class TestChatAgentStartupContext:
         captured: dict[str, object] = {}
         fake_checkpointer = MagicMock()
 
-        @contextmanager
-        def fake_open_graph_checkpointer(**_kwargs):
+        @asynccontextmanager
+        async def fake_open_graph_checkpointer(**_kwargs):
             yield fake_checkpointer
 
         class _FakeApp:
@@ -1213,6 +1213,132 @@ class TestChatAgentStartupContext:
 
         assert response.response == "I couldn't process that query. Please try rephrasing."
         prepared_memory.persist_response_fail_open.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    @patch("redis_sre_agent.agent.chat_agent.create_llm")
+    @patch("redis_sre_agent.agent.chat_agent.create_mini_llm")
+    async def test_process_query_surfaces_blank_exception_types(
+        self, mock_create_mini_llm, mock_create_llm
+    ):
+        mock_llm = MagicMock()
+        mock_llm.bind_tools.return_value = mock_llm
+        mock_create_llm.return_value = mock_llm
+        mock_create_mini_llm.return_value = mock_llm
+
+        agent = ChatAgent()
+
+        prepared_memory = PreparedAgentTurnMemory(
+            memory_service=MagicMock(),
+            memory_context=TurnMemoryContext(
+                system_prompt=None,
+                user_working_memory=None,
+                asset_working_memory=None,
+            ),
+            session_id="test-session",
+            user_id=None,
+            query="Who runs AOP?",
+            instance_id=None,
+            cluster_id=None,
+            emitter=None,
+        )
+        prepared_memory.persist_response_fail_open = AsyncMock()
+
+        mock_tool_manager = MagicMock()
+        mock_tool_manager.__aenter__.return_value = mock_tool_manager
+        mock_tool_manager.__aexit__.return_value = None
+        mock_tool_manager.get_tools.return_value = []
+        mock_tool_manager.get_toolset_generation.return_value = 1
+        fake_checkpointer = MagicMock()
+
+        @asynccontextmanager
+        async def fake_open_graph_checkpointer(**_kwargs):
+            yield fake_checkpointer
+
+        class _FailingApp:
+            async def ainvoke(self, *_args, **_kwargs):
+                raise NotImplementedError
+
+        fake_workflow = MagicMock()
+        fake_workflow.compile.return_value = _FailingApp()
+
+        with (
+            patch(
+                "redis_sre_agent.agent.chat_agent.prepare_agent_turn_memory",
+                AsyncMock(return_value=prepared_memory),
+            ),
+            patch(
+                "redis_sre_agent.agent.chat_agent.ToolManager",
+                return_value=mock_tool_manager,
+            ),
+            patch(
+                "redis_sre_agent.agent.chat_agent.build_startup_knowledge_context",
+                new=AsyncMock(return_value=""),
+            ),
+            patch(
+                "redis_sre_agent.agent.chat_agent.open_graph_checkpointer",
+                side_effect=fake_open_graph_checkpointer,
+            ),
+            patch.object(agent, "_build_workflow", return_value=fake_workflow),
+        ):
+            response = await agent.process_query(
+                query="Who runs AOP?",
+                session_id="test-session",
+                user_id=None,
+            )
+
+        assert response.response == "Error processing query: NotImplementedError"
+        prepared_memory.persist_response_fail_open.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    @patch("redis_sre_agent.agent.chat_agent.create_llm")
+    @patch("redis_sre_agent.agent.chat_agent.create_mini_llm")
+    async def test_resume_query_surfaces_blank_exception_types(
+        self, mock_create_mini_llm, mock_create_llm
+    ):
+        mock_llm = MagicMock()
+        mock_llm.bind_tools.return_value = mock_llm
+        mock_create_llm.return_value = mock_llm
+        mock_create_mini_llm.return_value = mock_llm
+
+        agent = ChatAgent()
+
+        mock_tool_manager = MagicMock()
+        mock_tool_manager.__aenter__.return_value = mock_tool_manager
+        mock_tool_manager.__aexit__.return_value = None
+        mock_tool_manager.get_tools.return_value = []
+        mock_tool_manager.get_toolset_generation.return_value = 1
+        fake_checkpointer = MagicMock()
+
+        @asynccontextmanager
+        async def fake_open_graph_checkpointer(**_kwargs):
+            yield fake_checkpointer
+
+        class _FailingApp:
+            async def ainvoke(self, *_args, **_kwargs):
+                raise NotImplementedError
+
+        fake_workflow = MagicMock()
+        fake_workflow.compile.return_value = _FailingApp()
+
+        with (
+            patch(
+                "redis_sre_agent.agent.chat_agent.ToolManager",
+                return_value=mock_tool_manager,
+            ),
+            patch(
+                "redis_sre_agent.agent.chat_agent.open_graph_checkpointer",
+                side_effect=fake_open_graph_checkpointer,
+            ),
+            patch.object(agent, "_build_workflow", return_value=fake_workflow),
+        ):
+            response = await agent.resume_query(
+                session_id="session-1",
+                user_id="user-1",
+                context={"task_id": "task-123"},
+                resume_payload={"decision": "approved"},
+            )
+
+        assert response.response == "Error resuming query: NotImplementedError"
 
     @pytest.mark.asyncio
     @patch("redis_sre_agent.agent.chat_agent.build_startup_knowledge_context")

--- a/tests/unit/agent/test_checkpointing.py
+++ b/tests/unit/agent/test_checkpointing.py
@@ -41,6 +41,7 @@ def test_build_graph_config_sets_namespace_and_recursion_limit():
 @pytest.mark.asyncio
 async def test_open_graph_checkpointer_uses_async_redis_saver():
     fake_checkpointer = MagicMock()
+    fake_checkpointer.asetup = AsyncMock()
 
     @asynccontextmanager
     async def fake_from_conn_string(**_kwargs):
@@ -52,6 +53,7 @@ async def test_open_graph_checkpointer_uses_async_redis_saver():
     ):
         async with open_graph_checkpointer() as checkpointer:
             assert checkpointer is fake_checkpointer
+    fake_checkpointer.asetup.assert_awaited_once()
 
 
 @pytest.mark.asyncio
@@ -83,6 +85,7 @@ async def test_open_graph_checkpointer_uses_memory_saver_for_non_durable_paths()
 @pytest.mark.asyncio
 async def test_open_graph_checkpointer_does_not_swallow_body_exceptions():
     fake_checkpointer = MagicMock()
+    fake_checkpointer.asetup = AsyncMock()
 
     @asynccontextmanager
     async def fake_from_conn_string(**_kwargs):

--- a/tests/unit/agent/test_checkpointing.py
+++ b/tests/unit/agent/test_checkpointing.py
@@ -1,6 +1,6 @@
 """Tests for shared graph checkpoint helpers."""
 
-from contextlib import contextmanager
+from contextlib import asynccontextmanager
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -38,60 +38,62 @@ def test_build_graph_config_sets_namespace_and_recursion_limit():
     assert config["recursion_limit"] == 25
 
 
-def test_open_graph_checkpointer_uses_redis_saver_setup():
+@pytest.mark.asyncio
+async def test_open_graph_checkpointer_uses_async_redis_saver():
     fake_checkpointer = MagicMock()
 
-    @contextmanager
-    def fake_from_conn_string(**_kwargs):
+    @asynccontextmanager
+    async def fake_from_conn_string(**_kwargs):
         yield fake_checkpointer
 
     with patch(
-        "redis_sre_agent.agent.checkpointing.RedisSaver.from_conn_string",
+        "redis_sre_agent.agent.checkpointing.AsyncRedisSaver.from_conn_string",
         side_effect=fake_from_conn_string,
     ):
-        with open_graph_checkpointer() as checkpointer:
+        async with open_graph_checkpointer() as checkpointer:
             assert checkpointer is fake_checkpointer
 
-    fake_checkpointer.setup.assert_called_once_with()
 
-
-def test_open_graph_checkpointer_raises_on_connection_error():
+@pytest.mark.asyncio
+async def test_open_graph_checkpointer_raises_on_connection_error():
     with patch(
-        "redis_sre_agent.agent.checkpointing.RedisSaver.from_conn_string",
+        "redis_sre_agent.agent.checkpointing.AsyncRedisSaver.from_conn_string",
         side_effect=RuntimeError("connection refused"),
     ):
         with pytest.raises(RuntimeError, match="Redis-backed graph checkpoint unavailable"):
-            with open_graph_checkpointer():
+            async with open_graph_checkpointer():
                 pass
 
 
-def test_open_graph_checkpointer_uses_memory_saver_for_non_durable_paths():
+@pytest.mark.asyncio
+async def test_open_graph_checkpointer_uses_memory_saver_for_non_durable_paths():
     fake_memory_saver = MagicMock()
 
     with (
         patch(
-            "redis_sre_agent.agent.checkpointing.RedisSaver.from_conn_string",
+            "redis_sre_agent.agent.checkpointing.AsyncRedisSaver.from_conn_string",
             side_effect=RuntimeError("connection refused"),
         ),
         patch("redis_sre_agent.agent.checkpointing.InMemorySaver", return_value=fake_memory_saver),
     ):
-        with open_graph_checkpointer(durable=False) as checkpointer:
+        async with open_graph_checkpointer(durable=False) as checkpointer:
             assert checkpointer is fake_memory_saver
 
 
-def test_open_graph_checkpointer_does_not_swallow_body_exceptions():
+@pytest.mark.asyncio
+async def test_open_graph_checkpointer_does_not_swallow_body_exceptions():
     fake_checkpointer = MagicMock()
 
-    @contextmanager
-    def fake_from_conn_string(**_kwargs):
+    @asynccontextmanager
+    async def fake_from_conn_string(**_kwargs):
         yield fake_checkpointer
 
     with patch(
-        "redis_sre_agent.agent.checkpointing.RedisSaver.from_conn_string",
+        "redis_sre_agent.agent.checkpointing.AsyncRedisSaver.from_conn_string",
         side_effect=fake_from_conn_string,
     ):
         with pytest.raises(RuntimeError, match="resume failed"):
-            with open_graph_checkpointer():
+            async with open_graph_checkpointer():
                 raise RuntimeError("resume failed")
 
 

--- a/tests/unit/evaluation/test_runtime.py
+++ b/tests/unit/evaluation/test_runtime.py
@@ -1,5 +1,5 @@
 import json
-from contextlib import contextmanager
+from contextlib import asynccontextmanager
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -942,8 +942,8 @@ async def test_run_full_turn_scenario_uses_production_turn_path_for_attached_sco
     fake_checkpointer = MagicMock()
     fake_checkpointer.get_tuple.return_value = None
 
-    @contextmanager
-    def fake_open_graph_checkpointer(**_kwargs):
+    @asynccontextmanager
+    async def fake_open_graph_checkpointer(**_kwargs):
         yield fake_checkpointer
 
     with (

--- a/tests/unit/tools/test_manager.py
+++ b/tests/unit/tools/test_manager.py
@@ -937,6 +937,10 @@ class TestToolManagerMcpConfigValidation:
         missing = _missing_local_mcp_arg_path(["vendor/re-analyzer-mcp/dist/src/index.js"])
         assert missing == "vendor/re-analyzer-mcp/dist/src/index.js"
 
+    def test_missing_local_mcp_arg_path_ignores_script_urls(self):
+        """Remote script URLs should not be mistaken for missing local files."""
+        assert _missing_local_mcp_arg_path(["https://example.com/server.ts"]) is None
+
     @pytest.mark.asyncio
     async def test_load_mcp_providers_skips_missing_command(self, caplog):
         """Missing MCP command should be skipped without raising or stack traces."""

--- a/tests/unit/tools/test_manager.py
+++ b/tests/unit/tools/test_manager.py
@@ -924,6 +924,19 @@ class TestToolManagerMcpConfigValidation:
             is None
         )
 
+    def test_missing_local_mcp_arg_path_ignores_docker_images_and_packages(self):
+        """Docker image refs and npm packages are not direct local entrypoints."""
+        assert (
+            _missing_local_mcp_arg_path(["run", "-i", "--rm", "ghcr.io/github/github-mcp-server"])
+            is None
+        )
+        assert _missing_local_mcp_arg_path(["-y", "@modelcontextprotocol/server-memory"]) is None
+
+    def test_missing_local_mcp_arg_path_detects_relative_script_entrypoints(self):
+        """Relative script paths with file extensions should still be validated."""
+        missing = _missing_local_mcp_arg_path(["vendor/re-analyzer-mcp/dist/src/index.js"])
+        assert missing == "vendor/re-analyzer-mcp/dist/src/index.js"
+
     @pytest.mark.asyncio
     async def test_load_mcp_providers_skips_missing_command(self, caplog):
         """Missing MCP command should be skipped without raising or stack traces."""

--- a/tests/unit/tools/test_manager.py
+++ b/tests/unit/tools/test_manager.py
@@ -30,7 +30,11 @@ from redis_sre_agent.targets.fake_integration import (
     FakeTargetBindingStrategy,
 )
 from redis_sre_agent.targets.registry import TargetIntegrationRegistry
-from redis_sre_agent.tools.manager import ToolManager, _command_is_available
+from redis_sre_agent.tools.manager import (
+    ToolManager,
+    _command_is_available,
+    _missing_local_mcp_arg_path,
+)
 from redis_sre_agent.tools.manager import settings as manager_settings
 from redis_sre_agent.tools.models import (
     Tool,
@@ -906,6 +910,20 @@ class TestToolManagerMcpConfigValidation:
         """Absolute/relative command paths should return False when missing."""
         assert _command_is_available("/definitely/not/a/real/command") is False
 
+    def test_missing_local_mcp_arg_path_detects_direct_script_paths(self):
+        """Direct script entrypoints should be validated before provider startup."""
+        missing = _missing_local_mcp_arg_path(["/definitely/not/a/real/index.js"])
+        assert missing == "/definitely/not/a/real/index.js"
+
+    def test_missing_local_mcp_arg_path_ignores_shell_command_strings(self):
+        """Shell command payloads should not be mistaken for direct file args."""
+        assert (
+            _missing_local_mcp_arg_path(
+                ["-lc", "cd /work/re-analyzer && exec node /work/re-analyzer/dist/index.js"]
+            )
+            is None
+        )
+
     @pytest.mark.asyncio
     async def test_load_mcp_providers_skips_missing_command(self, caplog):
         """Missing MCP command should be skipped without raising or stack traces."""
@@ -921,6 +939,31 @@ class TestToolManagerMcpConfigValidation:
 
             assert "mcp:github" not in mgr._loaded_provider_keys
             assert "Skipping MCP provider 'github'" in caplog.text
+        finally:
+            await mgr._stack.__aexit__(None, None, None)
+
+    @pytest.mark.asyncio
+    async def test_load_mcp_providers_skips_missing_local_entrypoint(self, caplog):
+        """Missing direct script entrypoints should be skipped before subprocess launch."""
+        mgr = ToolManager()
+        mgr._stack = AsyncExitStack()
+        await mgr._stack.__aenter__()
+        try:
+            with (
+                patch("redis_sre_agent.core.config.settings") as mock_settings,
+                patch("redis_sre_agent.tools.manager._command_is_available", return_value=True),
+            ):
+                mock_settings.mcp_servers = {
+                    "re_analyzer": MCPServerConfig(
+                        command="node",
+                        args=["/definitely/not/a/real/index.js"],
+                    )
+                }
+                await mgr._load_mcp_providers()
+
+            assert "mcp:re_analyzer" not in mgr._loaded_provider_keys
+            assert "Skipping MCP provider 're_analyzer'" in caplog.text
+            assert "/definitely/not/a/real/index.js" in caplog.text
         finally:
             await mgr._stack.__aexit__(None, None, None)
 

--- a/tests/unit/tools/test_target_discovery_provider.py
+++ b/tests/unit/tools/test_target_discovery_provider.py
@@ -15,6 +15,18 @@ from redis_sre_agent.targets.registry import TargetIntegrationRegistry
 from redis_sre_agent.tools.target_discovery.provider import TargetDiscoveryToolProvider
 
 
+def test_target_discovery_tool_names_are_stable_across_provider_instances():
+    provider_a = TargetDiscoveryToolProvider()
+    provider_b = TargetDiscoveryToolProvider()
+
+    tool_names_a = [tool.metadata.name for tool in provider_a.tools()]
+    tool_names_b = [tool.metadata.name for tool in provider_b.tools()]
+
+    assert tool_names_a == tool_names_b
+    assert any(name.endswith("list_known_redis_targets") for name in tool_names_a)
+    assert any(name.endswith("resolve_redis_targets") for name in tool_names_a)
+
+
 @pytest.mark.asyncio
 async def test_resolve_redis_targets_uses_shared_binding_contract():
     provider = TargetDiscoveryToolProvider()


### PR DESCRIPTION
## Summary
- switch async graph execution to an async Redis checkpointer
- stabilize target discovery tool names across provider instances
- surface non-empty chat errors and fail fast on missing local MCP entrypoints

## Testing
- `./.venv/bin/pytest tests/unit/agent/test_checkpointing.py tests/unit/agent/test_chat_agent.py tests/unit/agent/test_agent.py tests/unit/evaluation/test_runtime.py tests/unit/tools/test_target_discovery_provider.py tests/unit/tools/test_manager.py -q`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Switches LangGraph checkpointing to `AsyncRedisSaver` and updates all call sites/tests to use `async with`, which can impact pause/resume behavior and Redis resource lifecycle. Also changes tool naming/validation logic that could affect tool routing and provider loading at runtime.
> 
> **Overview**
> Fixes runtime regressions around graph execution by converting `open_graph_checkpointer` to an async context manager backed by `AsyncRedisSaver` (with `asetup()`), and updating both the chat and triage agents (and tests) to use `async with` for checkpointed runs/resumes.
> 
> Improves runtime robustness by formatting blank/opaque exceptions into user-visible error strings in `ChatAgent`, adding MCP provider guardrails to skip configs with missing local entrypoint args, and stabilizing target-discovery tool names across provider instances via a deterministic provider hash.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4c6fb69fd08bcb8786ec0475a28fe1c3320a4ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->