### PR TITLE
Record startup skill grounding provenance

### DIFF
--- a/redis_sre_agent/agent/knowledge_context.py
+++ b/redis_sre_agent/agent/knowledge_context.py
@@ -17,6 +17,9 @@ logger = logging.getLogger(__name__)
 PINNED_CONTEXT_TOOL_KEY = "knowledge.pinned_context"
 PINNED_CONTEXT_RETRIEVAL_KIND = "pinned_context"
 PINNED_CONTEXT_RETRIEVAL_LABEL = "Pinned context"
+STARTUP_SKILLS_TOOL_KEY = "knowledge.startup_skills_check"
+STARTUP_SKILLS_RETRIEVAL_KIND = "startup_skills"
+STARTUP_SKILLS_RETRIEVAL_LABEL = "Startup skills"
 
 
 class StartupKnowledgeContext(str):
@@ -191,6 +194,55 @@ def _build_internal_pinned_context_envelope(
     }
 
 
+def _build_internal_startup_skills_envelope(
+    skills: List[Dict[str, Any]],
+    *,
+    query: str,
+    version: Optional[str],
+    skills_limit: int,
+) -> Optional[Dict[str, Any]]:
+    """Build an internal knowledge envelope for startup skill discovery."""
+    if not skills:
+        return None
+
+    results: List[Dict[str, Any]] = []
+    for skill in skills:
+        title = str(skill.get("name", "")).strip() or str(skill.get("title", "")).strip()
+        document_hash = str(skill.get("document_hash", "")).strip()
+        results.append(
+            {
+                "id": document_hash or title,
+                "title": title or document_hash or "Skill",
+                "source": str(skill.get("source", "")).strip(),
+                "document_hash": document_hash,
+                "doc_type": "skill",
+                "summary": str(skill.get("summary", "")).strip(),
+                "retrieval_kind": STARTUP_SKILLS_RETRIEVAL_KIND,
+                "retrieval_label": STARTUP_SKILLS_RETRIEVAL_LABEL,
+            }
+        )
+
+    return {
+        "tool_key": STARTUP_SKILLS_TOOL_KEY,
+        "name": "skills_check",
+        "description": "Internal startup skill discovery recorded during grounding.",
+        "args": {
+            "query": query,
+            "limit": skills_limit,
+            "offset": 0,
+            "version": version,
+        },
+        "status": "success",
+        "data": {
+            "results": results,
+            "results_count": len(results),
+            "retrieval_kind": STARTUP_SKILLS_RETRIEVAL_KIND,
+            "retrieval_label": STARTUP_SKILLS_RETRIEVAL_LABEL,
+        },
+        "summary": f"Loaded {len(results)} startup skill{'s' if len(results) != 1 else ''} into grounding context.",
+    }
+
+
 async def build_startup_knowledge_context(
     query: str,
     version: Optional[str] = "latest",
@@ -270,6 +322,14 @@ async def build_startup_knowledge_context(
     skills_lines = _skills_toc_lines(skills_result.get("skills") or [])
     if skills_lines:
         sections.append("\n".join(skills_lines))
+        skills_envelope = _build_internal_startup_skills_envelope(
+            skills_result.get("skills") or [],
+            query=query,
+            version=version,
+            skills_limit=skills_limit,
+        )
+        if skills_envelope:
+            internal_tool_envelopes.append(skills_envelope)
 
     tool_lines = _tool_instruction_lines_for_categories(available_tools)
     if tool_lines:

--- a/tests/unit/agent/test_knowledge_context.py
+++ b/tests/unit/agent/test_knowledge_context.py
@@ -1,10 +1,16 @@
 """Tests for startup knowledge context assembly."""
 
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from redis_sre_agent.agent.knowledge_context import build_startup_knowledge_context
+from redis_sre_agent.agent.knowledge_context import (
+    _build_internal_pinned_context_envelope,
+    _build_internal_startup_skills_envelope,
+    build_startup_knowledge_context,
+    merge_internal_tool_envelopes,
+)
 from redis_sre_agent.evaluation.injection import eval_runtime_overrides
 from redis_sre_agent.tools.models import Tool, ToolCapability, ToolDefinition, ToolMetadata
 
@@ -151,6 +157,69 @@ async def test_startup_context_extracts_capability_from_tool_definition():
 
 
 @pytest.mark.asyncio
+async def test_startup_context_extracts_capability_from_tool_metadata_only():
+    with (
+        patch(
+            "redis_sre_agent.agent.knowledge_context.get_pinned_documents_helper",
+            new=AsyncMock(return_value={"pinned_documents": []}),
+        ),
+        patch(
+            "redis_sre_agent.agent.knowledge_context.skills_check_helper",
+            new=AsyncMock(return_value={"skills": []}),
+        ),
+    ):
+        metadata_only_tool = SimpleNamespace(
+            metadata=SimpleNamespace(capability=ToolCapability.LOGS),
+            definition=SimpleNamespace(capability=None),
+            capability=None,
+        )
+        ignored_tool = SimpleNamespace(metadata=SimpleNamespace(), definition=None, capability=None)
+        context = await build_startup_knowledge_context(
+            query="memory issue",
+            version="latest",
+            available_tools=[metadata_only_tool, ignored_tool],
+        )
+
+    assert "Available tool categories: logs." in context
+
+
+def test_merge_internal_tool_envelopes_deduplicates_dict_entries():
+    existing = [{"tool_key": "knowledge.pinned_context"}]
+    new = [
+        {"tool_key": "knowledge.pinned_context"},
+        {"tool_key": "knowledge.startup_skills_check"},
+    ]
+
+    merged = merge_internal_tool_envelopes(existing, new)
+
+    assert merged == [
+        {"tool_key": "knowledge.pinned_context"},
+        {"tool_key": "knowledge.startup_skills_check"},
+    ]
+
+
+def test_internal_envelope_builders_return_none_for_empty_inputs():
+    assert (
+        _build_internal_pinned_context_envelope(
+            [],
+            version="latest",
+            pinned_limit=20,
+            pinned_content_char_budget=12000,
+        )
+        is None
+    )
+    assert (
+        _build_internal_startup_skills_envelope(
+            [],
+            query="memory issue",
+            version="latest",
+            skills_limit=20,
+        )
+        is None
+    )
+
+
+@pytest.mark.asyncio
 async def test_startup_context_carries_internal_pinned_context_envelope():
     with (
         patch(
@@ -187,6 +256,107 @@ async def test_startup_context_carries_internal_pinned_context_envelope():
     assert envelope["data"]["retrieval_kind"] == "pinned_context"
     assert envelope["data"]["results"][0]["title"] == "Pinned Runbook"
     assert envelope["data"]["results"][0]["retrieval_kind"] == "pinned_context"
+
+
+@pytest.mark.asyncio
+async def test_startup_context_carries_internal_skill_discovery_envelope():
+    with (
+        patch(
+            "redis_sre_agent.agent.knowledge_context.get_pinned_documents_helper",
+            new=AsyncMock(return_value={"pinned_documents": []}),
+        ),
+        patch(
+            "redis_sre_agent.agent.knowledge_context.skills_check_helper",
+            new=AsyncMock(
+                return_value={
+                    "skills": [
+                        {
+                            "name": "Iterative Memory Check",
+                            "document_hash": "iterative-memory-check",
+                            "summary": "Check INFO memory before remediation.",
+                            "source": "fixture://skills/iterative-memory-check.md",
+                        },
+                        {
+                            "name": "Failover Investigation Skill",
+                            "document_hash": "failover-investigation-skill",
+                            "summary": "Verify replica health before role changes.",
+                            "source": "fixture://skills/failover-investigation-skill.md",
+                        },
+                    ]
+                }
+            ),
+        ),
+    ):
+        context = await build_startup_knowledge_context(query="memory issue", version="latest")
+
+    envelopes = getattr(context, "internal_tool_envelopes", [])
+    assert len(envelopes) == 1
+    envelope = envelopes[0]
+    assert envelope["tool_key"] == "knowledge.startup_skills_check"
+    assert envelope["name"] == "skills_check"
+    assert envelope["args"] == {
+        "query": "memory issue",
+        "limit": 20,
+        "offset": 0,
+        "version": "latest",
+    }
+    assert envelope["data"]["retrieval_kind"] == "startup_skills"
+    assert envelope["data"]["results"][0]["title"] == "Iterative Memory Check"
+    assert envelope["data"]["results"][0]["document_hash"] == "iterative-memory-check"
+    assert envelope["data"]["results"][0]["retrieval_label"] == "Startup skills"
+
+
+@pytest.mark.asyncio
+async def test_startup_context_continues_when_pinned_document_load_fails():
+    with (
+        patch(
+            "redis_sre_agent.agent.knowledge_context.get_pinned_documents_helper",
+            new=AsyncMock(side_effect=RuntimeError("pinned backend unavailable")),
+        ),
+        patch(
+            "redis_sre_agent.agent.knowledge_context.skills_check_helper",
+            new=AsyncMock(
+                return_value={
+                    "skills": [
+                        {"name": "Iterative Memory Check", "summary": "Use INFO memory first."}
+                    ]
+                }
+            ),
+        ),
+    ):
+        context = await build_startup_knowledge_context(query="memory issue", version="latest")
+
+    assert "Pinned documents:" not in context
+    assert "Iterative Memory Check: Use INFO memory first." in context
+
+
+@pytest.mark.asyncio
+async def test_startup_context_continues_when_skills_check_fails():
+    with (
+        patch(
+            "redis_sre_agent.agent.knowledge_context.get_pinned_documents_helper",
+            new=AsyncMock(
+                return_value={
+                    "pinned_documents": [
+                        {
+                            "name": "Pinned Runbook",
+                            "priority": "high",
+                            "doc_type": "runbook",
+                            "full_content": "Use evidence-first triage.",
+                        }
+                    ]
+                }
+            ),
+        ),
+        patch(
+            "redis_sre_agent.agent.knowledge_context.skills_check_helper",
+            new=AsyncMock(side_effect=RuntimeError("skills index unavailable")),
+        ),
+    ):
+        context = await build_startup_knowledge_context(query="memory issue", version="latest")
+
+    assert "Pinned Runbook" in context
+    assert "Skills you know:" not in context
 
 
 @pytest.mark.asyncio

--- a/tests/unit/evaluation/test_knowledge_scenarios.py
+++ b/tests/unit/evaluation/test_knowledge_scenarios.py
@@ -130,6 +130,16 @@ async def test_startup_only_scenario_materializes_pinned_doc_and_skill_context()
 
     assert "iterative-diagnostics-runbook" in startup_context
     assert "iterative-memory-check" in startup_context
+    skill_envelopes = [
+        envelope
+        for envelope in getattr(startup_context, "internal_tool_envelopes", [])
+        if envelope.get("tool_key") == "knowledge.startup_skills_check"
+    ]
+    assert len(skill_envelopes) == 1
+    assert skill_envelopes[0]["data"]["results_count"] >= 1
+    assert {result["document_hash"] for result in skill_envelopes[0]["data"]["results"]} >= {
+        "iterative-memory-check"
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/unit/evaluation/test_prompt_scenarios.py
+++ b/tests/unit/evaluation/test_prompt_scenarios.py
@@ -234,10 +234,24 @@ async def test_knowledge_agent_prompt_scenario_materializes_startup_context():
         for marker in ("handoff-to-full-sre-agent", "no-live-access-response")
     )
 
-    envelopes = getattr(startup_context, "internal_tool_envelopes", [])
-    assert len(envelopes) == 1
-    assert {result["document_hash"] for result in envelopes[0]["data"]["results"]} >= {
-        "no-live-instance-claims"
+    envelopes = {
+        envelope["tool_key"]: envelope
+        for envelope in getattr(startup_context, "internal_tool_envelopes", [])
+    }
+    assert set(envelopes) == {
+        "knowledge.pinned_context",
+        "knowledge.startup_skills_check",
+    }
+    assert {
+        result["document_hash"]
+        for result in envelopes["knowledge.pinned_context"]["data"]["results"]
+    } >= {"no-live-instance-claims"}
+    assert {
+        result["document_hash"]
+        for result in envelopes["knowledge.startup_skills_check"]["data"]["results"]
+    } >= {
+        "handoff-to-full-sre-agent",
+        "iterative-memory-check",
     }
 
 

--- a/tests/unit/evaluation/test_retrieval_scenarios.py
+++ b/tests/unit/evaluation/test_retrieval_scenarios.py
@@ -161,6 +161,25 @@ async def test_skills_retrieval_scenario_matches_prompt_and_redis_doc_skills():
 
 
 @pytest.mark.asyncio
+async def test_skills_retrieval_scenario_supports_discover_then_fetch_flow():
+    scenario = load_eval_scenario(scenario_manifest_path("retrieval", "skills-core"))
+    backend = build_fixture_knowledge_backend(scenario)
+
+    discovered = await backend.skills_check(
+        query="Redis Enterprise maintenance failover checklist",
+        version="latest",
+    )
+    discovered_by_name = {skill["name"]: skill for skill in discovered["skills"]}
+    selected_skill = discovered_by_name["redis-enterprise-maintenance-checklist"]
+    fetched = await backend.get_skill(skill_name=selected_skill["name"], version="latest")
+
+    assert "redis-enterprise-maintenance-checklist" in discovered_by_name
+    assert selected_skill["document_hash"] == "redis-enterprise-maintenance-checklist"
+    assert fetched["skill_name"] == selected_skill["name"]
+    assert "replica health" in fetched["full_content"]
+
+
+@pytest.mark.asyncio
 async def test_support_ticket_retrieval_scenario_supports_exact_and_semantic_lookup():
     scenario = load_eval_scenario(scenario_manifest_path("retrieval", "support-ticket-exact-match"))
     backend = build_fixture_knowledge_backend(scenario)

--- a/tests/unit/evaluation/test_scenario_corpus.py
+++ b/tests/unit/evaluation/test_scenario_corpus.py
@@ -91,9 +91,22 @@ async def test_startup_only_knowledge_scenario_materializes_pinned_doc_and_skill
     assert "maintenance-mode-overview" in startup_context
     assert "redis-enterprise-maintenance-checklist" in startup_context
 
-    envelopes = getattr(startup_context, "internal_tool_envelopes", [])
-    assert len(envelopes) == 1
-    assert envelopes[0]["data"]["results"][0]["document_hash"] == "maintenance-mode-overview"
+    envelopes = {
+        envelope["tool_key"]: envelope
+        for envelope in getattr(startup_context, "internal_tool_envelopes", [])
+    }
+    assert set(envelopes) == {
+        "knowledge.pinned_context",
+        "knowledge.startup_skills_check",
+    }
+    assert (
+        envelopes["knowledge.pinned_context"]["data"]["results"][0]["document_hash"]
+        == "maintenance-mode-overview"
+    )
+    assert (
+        envelopes["knowledge.startup_skills_check"]["data"]["results"][0]["document_hash"]
+        == "redis-enterprise-maintenance-checklist"
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- record startup `skills_check` provenance alongside pinned startup knowledge envelopes
- extend startup and retrieval eval scenarios to show both skill discovery and skill usage flows
- add unit coverage for startup envelope building, metadata-only tool capability extraction, deduping, and failure handling

## Validation
- `./.venv/bin/pytest tests/unit/agent/test_knowledge_context.py tests/unit/evaluation/test_knowledge_scenarios.py tests/unit/evaluation/test_retrieval_scenarios.py tests/unit/agent/test_checkpointing.py tests/unit/agent/test_chat_agent.py tests/unit/agent/test_agent.py tests/unit/evaluation/test_runtime.py tests/unit/tools/test_target_discovery_provider.py tests/unit/tools/test_manager.py -q`
- `./.venv/bin/pytest tests/unit/evaluation/test_prompt_scenarios.py tests/unit/evaluation/test_scenario_corpus.py tests/unit/evaluation/test_knowledge_scenarios.py -q`
- `uvx mfcqi analyze --skip-llm redis_sre_agent/agent/knowledge_context.py`
- repo commit hooks: `ruff format check`, `ruff check`, `pytest unit tests`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes what `build_startup_knowledge_context` returns (additional internal envelopes) and updates evaluation expectations, which could affect downstream prompt/tool telemetry consumers.
> 
> **Overview**
> Startup grounding now records *skill discovery provenance* by attaching an internal `knowledge.startup_skills_check` envelope (mirroring pinned-document envelopes) to the returned `StartupKnowledgeContext`.
> 
> Unit and evaluation tests are updated/added to assert the new envelope shape, ensure capability extraction works when only `tool.metadata.capability` is set, verify envelope deduplication, and confirm startup context assembly continues when pinned-doc or skills-check calls fail.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5c52030c596b63ade829743ea04a93302b9c7f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->