### PR TITLE
Fix chat-agent local tool execution for expand_evidence

### DIFF
--- a/redis_sre_agent/agent/chat_agent.py
+++ b/redis_sre_agent/agent/chat_agent.py
@@ -486,6 +486,7 @@ class ChatAgent:
                 "tooldefs_by_name": {t.name: t for t in tooldefs},
                 "all_adapters": all_adapters,
                 "llm_with_expand": self.llm.bind_tools(all_adapters),
+                "local_tools": {expand_spec["name"]: expand_spec["func"]},
             }
             runtime_tools_by_generation[generation] = runtime
             return runtime
@@ -586,6 +587,7 @@ class ChatAgent:
                 new_tool_messages = await execute_tool_calls_with_gate(
                     tool_manager=tool_mgr,
                     tool_calls=tool_calls,
+                    local_tools=runtime["local_tools"],
                 )
 
                 # Build envelopes and create summarized messages for the LLM

--- a/redis_sre_agent/agent/tool_execution.py
+++ b/redis_sre_agent/agent/tool_execution.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
+import inspect
 import json
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from langchain_core.messages import ToolMessage
 
@@ -22,8 +23,16 @@ async def execute_tool_call_with_gate(
     tool_manager: Any,
     tool_name: str,
     tool_args: Dict[str, Any],
+    local_tools: Optional[Dict[str, Any]] = None,
 ) -> Any:
     """Execute a single tool call through the shared approval-aware boundary."""
+    local_tool = (local_tools or {}).get(tool_name)
+    if local_tool is not None:
+        result = local_tool(**dict(tool_args or {}))
+        if inspect.isawaitable(result):
+            return await result
+        return result
+
     results = await tool_manager.execute_tool_calls(
         [{"name": tool_name, "args": dict(tool_args or {})}]
     )
@@ -34,6 +43,7 @@ async def execute_tool_calls_with_gate(
     *,
     tool_manager: Any,
     tool_calls: List[Dict[str, Any]],
+    local_tools: Optional[Dict[str, Any]] = None,
 ) -> List[ToolMessage]:
     """Execute tool calls via the shared approval-aware runtime boundary."""
 
@@ -45,20 +55,39 @@ async def execute_tool_calls_with_gate(
         }
         for tool_call in tool_calls or []
     ]
-    results = await tool_manager.execute_tool_calls(
-        [
-            {"name": tool_call["name"], "args": tool_call["args"]}
-            for tool_call in normalized_tool_calls
-        ]
-    )
-    if len(results) != len(normalized_tool_calls):
+
+    tool_results: List[Any] = [None] * len(normalized_tool_calls)
+    manager_tool_calls: List[Dict[str, Any]] = []
+    manager_indices: List[int] = []
+    local_tool_map = local_tools or {}
+
+    for idx, tool_call in enumerate(normalized_tool_calls):
+        local_tool = local_tool_map.get(tool_call["name"])
+        if local_tool is not None:
+            result = local_tool(**tool_call["args"])
+            if inspect.isawaitable(result):
+                result = await result
+            tool_results[idx] = result
+            continue
+
+        manager_tool_calls.append({"name": tool_call["name"], "args": tool_call["args"]})
+        manager_indices.append(idx)
+
+    manager_results: List[Any] = []
+    if manager_tool_calls:
+        manager_results = await tool_manager.execute_tool_calls(manager_tool_calls)
+
+    if len(manager_results) != len(manager_tool_calls):
         raise RuntimeError(
             "Tool manager returned a mismatched number of results for the requested tool calls"
         )
 
+    for idx, result in zip(manager_indices, manager_results):
+        tool_results[idx] = result
+
     tool_messages: List[ToolMessage] = []
 
-    for tool_call, result in zip(normalized_tool_calls, results):
+    for tool_call, result in zip(normalized_tool_calls, tool_results):
         tool_name = tool_call["name"]
         tool_messages.append(
             ToolMessage(

--- a/tests/unit/agent/test_chat_agent.py
+++ b/tests/unit/agent/test_chat_agent.py
@@ -2163,6 +2163,9 @@ class TestChatAgentStartupContext:
 
         assert agent_state["toolset_generation"] == 1
         mock_execute_tool_calls.assert_awaited_once()
+        local_tools = mock_execute_tool_calls.await_args.kwargs["local_tools"]
+        assert "expand_evidence" in local_tools
+        assert callable(local_tools["expand_evidence"])
         assert mock_execute_tool_calls.await_args.kwargs["tool_manager"] is mock_tool_mgr
         assert mock_execute_tool_calls.await_args.kwargs["tool_calls"] == [
             {"id": "call-1", "name": "demo", "args": {}, "type": "tool_call"}

--- a/tests/unit/agent/test_tool_execution.py
+++ b/tests/unit/agent/test_tool_execution.py
@@ -87,3 +87,74 @@ async def test_execute_tool_calls_with_gate_rejects_mismatched_result_counts():
                 },
             ],
         )
+
+
+@pytest.mark.asyncio
+async def test_execute_tool_calls_with_gate_executes_local_tools_without_manager():
+    tool_manager = SimpleNamespace(execute_tool_calls=AsyncMock())
+
+    tool_messages = await execute_tool_calls_with_gate(
+        tool_manager=tool_manager,
+        tool_calls=[
+            {
+                "id": "tool-call-1",
+                "name": "expand_evidence",
+                "args": {"tool_key": "demo"},
+            }
+        ],
+        local_tools={
+            "expand_evidence": lambda tool_key: {
+                "status": "success",
+                "tool_key": tool_key,
+            }
+        },
+    )
+
+    assert len(tool_messages) == 1
+    assert '"tool_key": "demo"' in tool_messages[0].content
+    tool_manager.execute_tool_calls.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_execute_tool_calls_with_gate_preserves_order_with_local_and_manager_tools():
+    tool_manager = SimpleNamespace(
+        execute_tool_calls=AsyncMock(return_value=[{"status": "ok", "source": "manager"}]),
+    )
+
+    tool_messages = await execute_tool_calls_with_gate(
+        tool_manager=tool_manager,
+        tool_calls=[
+            {
+                "id": "tool-call-1",
+                "name": "expand_evidence",
+                "args": {"tool_key": "demo"},
+            },
+            {
+                "id": "tool-call-2",
+                "name": "redis_cloud_deadbeef_update_database",
+                "args": {"database_id": 7},
+            },
+        ],
+        local_tools={
+            "expand_evidence": lambda tool_key: {
+                "status": "success",
+                "tool_key": tool_key,
+                "source": "local",
+            }
+        },
+    )
+
+    assert [message.name for message in tool_messages] == [
+        "expand_evidence",
+        "redis_cloud_deadbeef_update_database",
+    ]
+    assert '"source": "local"' in tool_messages[0].content
+    assert '"source": "manager"' in tool_messages[1].content
+    tool_manager.execute_tool_calls.assert_awaited_once_with(
+        [
+            {
+                "name": "redis_cloud_deadbeef_update_database",
+                "args": {"database_id": 7},
+            }
+        ]
+    )


### PR DESCRIPTION
## Summary
- fix chat-agent local tool execution for `expand_evidence`
- route local workflow tools through the shared executor without sending them to `ToolManager`
- add regression coverage for local-only tool execution and mixed local/manager ordering

## Validation
- `uv run pytest tests/unit/agent/test_tool_execution.py tests/unit/agent/test_chat_agent.py -k 'expand_evidence or tool_node_uses_agent_generation_when_toolset_changes_mid_turn or execute_tool_calls_with_gate'`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the shared tool execution boundary to bypass `ToolManager` for locally-defined tools and to interleave local + managed tool results while preserving call order; bugs here could break tool-call execution or gating behavior.
> 
> **Overview**
> Fixes chat-agent execution of the local-only `expand_evidence` tool by passing a `local_tools` map into `execute_tool_calls_with_gate` and teaching the executor (`tool_execution.py`) to run matching local callables directly (sync or async) instead of delegating to `ToolManager`.
> 
> Updates batched execution to split local vs manager tool calls, then recombine results in the original order, and adds regression tests covering local-only execution, mixed local/manager ordering, and that the chat tool node supplies `expand_evidence` via `local_tools`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9554bc021f9612259df50d00c0786bd7ce3445d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->