### PR TITLE
Prepare 0.4.0 release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "redis-sre-agent"
-version = "0.3.0"
+version = "0.3.1"
 description = "A LangGraph-based Redis SRE Agent for infrastructure monitoring and incident response"
 readme = "README.md"
 license = {file = "LICENSE.txt"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "redis-sre-agent"
-version = "0.3.1"
+version = "0.4.0"
 description = "A LangGraph-based Redis SRE Agent for infrastructure monitoring and incident response"
 readme = "README.md"
 license = {file = "LICENSE.txt"}

--- a/redis_sre_agent/pipelines/ingestion/processor_source_helpers.py
+++ b/redis_sre_agent/pipelines/ingestion/processor_source_helpers.py
@@ -202,13 +202,14 @@ def create_scraped_document_from_markdown(
     summary_raw = metadata.get("summary")
     summary = str(summary_raw).strip() if summary_raw is not None else ""
     pinned = parse_bool(metadata.get("pinned"), default=False)
+    explicit_url = str(metadata.get("url") or "").strip()
     passthrough_metadata = {
         key: value for key, value in metadata.items() if key not in RESERVED_METADATA_KEYS
     }
 
     return ScrapedDocument(
         title=title,
-        source_url=f"file://{md_file.absolute()}",
+        source_url=explicit_url or f"file://{md_file.absolute()}",
         content=content,
         category=category,
         doc_type=doc_type,

--- a/tests/unit/pipelines/ingestion/test_ingestion_processor.py
+++ b/tests/unit/pipelines/ingestion/test_ingestion_processor.py
@@ -415,6 +415,30 @@ class TestIngestionPipeline:
         assert document.metadata["name"] == "Incident Triage"
         assert document.metadata["summary"] == "Step-by-step triage process."
 
+    def test_create_scraped_document_from_markdown_uses_explicit_frontmatter_url(
+        self, pipeline, tmp_path
+    ):
+        """Frontmatter url should override the default file:// source for documents and chunks."""
+        md_file = tmp_path / "with-url.md"
+        md_file.write_text(
+            (
+                "---\n"
+                "url: https://example.com/knowledge/frontmatter\n"
+                "---\n\n"
+                "# Frontmatter URL\n\n"
+                "Some content.\n"
+            ),
+            encoding="utf-8",
+        )
+
+        document = create_scraped_document_from_markdown(md_file)
+        chunks = pipeline.processor.chunk_document(document)
+
+        assert document.source_url == "https://example.com/knowledge/frontmatter"
+        assert document.metadata["url"] == "https://example.com/knowledge/frontmatter"
+        assert len(chunks) == 1
+        assert chunks[0]["source"] == "https://example.com/knowledge/frontmatter"
+
     def test_create_scraped_document_from_markdown_reserved_metadata_cannot_be_overridden(
         self, pipeline, tmp_path
     ):

--- a/uv.lock
+++ b/uv.lock
@@ -3185,7 +3185,7 @@ wheels = [
 
 [[package]]
 name = "redis-sre-agent"
-version = "0.3.1"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "agent-memory-client" },

--- a/uv.lock
+++ b/uv.lock
@@ -3185,7 +3185,7 @@ wheels = [
 
 [[package]]
 name = "redis-sre-agent"
-version = "0.3.0"
+version = "0.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "agent-memory-client" },


### PR DESCRIPTION
## Summary
- retarget the release from `0.3.1` to `0.4.0`
- bump the package version to `0.4.0` in `pyproject.toml` and `uv.lock`
- support explicit frontmatter `url` values for source-document ingestion to address #148

## Testing
- `uv run pytest tests/unit/pipelines/ingestion/test_ingestion_processor.py tests/unit/pipelines/ingestion/test_ingestion_processor_additional.py --cov=redis_sre_agent.pipelines.ingestion.processor_source_helpers --cov-report=term-missing`
- `uv run pytest -q tests/test_docs_snippets.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how `source_url` is derived during ingestion, which can affect downstream indexing/deduplication and link attribution, though the code change is small and well-tested.
> 
> **Overview**
> Bumps `redis-sre-agent` version from `0.3.0` to `0.4.0` in `pyproject.toml` and `uv.lock`.
> 
> Updates source-document ingestion so a markdown frontmatter `url` overrides the default `file://...` `source_url` for the generated `ScrapedDocument` (and therefore chunk `source` values), and adds a unit test covering this behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19bd290e55f397f2c4f62d1cdb4f1aed01c725fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->