### PR TITLE
Add approval UI and CLI debug logging

### DIFF
--- a/docs/how-to/api.md
+++ b/docs/how-to/api.md
@@ -169,6 +169,38 @@ curl -fsS -X POST http://localhost:8080/api/v1/tasks \
   }' | jq
 ```
 
+#### Natural-language target discovery and comparison
+If your deployment has target discovery configured, you can omit `instance_id` and `cluster_id`
+and let the agent resolve targets from the message text.
+
+```bash
+# Let the agent discover one target from natural language
+curl -fsS -X POST http://localhost:8080/api/v1/tasks \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "message": "Check whether the production checkout cache is under memory pressure"
+  }' | jq
+
+# Ask for a comparison across multiple discovered targets
+curl -fsS -X POST http://localhost:8080/api/v1/tasks \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "message": "Compare checkout cache and session cache for memory pressure and evictions"
+  }' | jq
+```
+
+If the reference is ambiguous, the task should stay discovery-first and request clarification
+instead of making live claims. Continue the same thread with the narrowed target description:
+
+```bash
+curl -fsS -X POST http://localhost:8080/api/v1/tasks \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "thread_id": "<thread_id>",
+    "message": "Use the prod checkout cache in us-east-1"
+  }' | jq
+```
+
 ### 5) Prepare knowledge and validate what the agent knows
 Run an ingestion job, then search to confirm content is available.
 ```bash
@@ -227,6 +259,54 @@ curl -fsS http://localhost:8080/api/v1/schedules/<schedule_id>/runs | jq
 - Tasks: `GET /api/v1/tasks/{task_id}`
 - Threads: `GET /api/v1/threads`, `GET /api/v1/threads/{thread_id}`
 - WebSocket: `ws://localhost:8080/api/v1/ws/tasks/{thread_id}`
+
+#### Approval-driven tasks
+Some write actions pause a task in `awaiting_approval`. When that happens:
+
+- `GET /api/v1/tasks/<task_id>` can include `pending_approval`.
+- `GET /api/v1/threads/<thread_id>` can also surface `task_id`, `pending_approval`, and `resume_supported`.
+- `GET /api/v1/tasks/<task_id>/approvals` lists the full approval history for the task.
+- `POST /api/v1/tasks/<task_id>/resume` records an `approved` or `rejected` decision and resumes
+  execution when the task is waiting on that approval.
+
+If you use the web UI triage page, the same approval flow is available there: the conversation
+view shows the pending approval summary, loads approval history for the latest task on the thread,
+and can submit approve/reject decisions directly from the browser.
+
+Inspect approval history:
+
+```bash
+curl -fsS http://localhost:8080/api/v1/tasks/<task_id>/approvals | jq
+```
+
+Approve a pending action:
+
+```bash
+curl -fsS -X POST http://localhost:8080/api/v1/tasks/<task_id>/resume \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "approval_id": "<approval_id>",
+    "decision": "approved",
+    "decision_by": "oncall@example.com",
+    "decision_comment": "Confirmed during incident review"
+  }' | jq
+```
+
+Reject a pending action:
+
+```bash
+curl -fsS -X POST http://localhost:8080/api/v1/tasks/<task_id>/resume \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "approval_id": "<approval_id>",
+    "decision": "rejected",
+    "decision_by": "oncall@example.com",
+    "decision_comment": "Do not run this action on production"
+  }' | jq
+```
+
+The current CLI does not yet expose approvals listing or resume commands, so use the API for
+human-in-the-loop decision handling.
 
 ### 8) Observability
 - Prometheus scrape: `GET /api/v1/metrics`

--- a/docs/how-to/cli.md
+++ b/docs/how-to/cli.md
@@ -56,6 +56,42 @@ uv run redis-sre-agent instance test <id>
   ```
   - For diagnostic prompts, cluster-scoped queries are auto-upgraded to triage.
 
+#### Natural-language target discovery
+When target-discovery integrations are configured, you can ask for a target in natural language
+instead of supplying `-r` or `-c` up front.
+
+```bash
+uv run redis-sre-agent query \
+  "Check whether the production checkout cache is under memory pressure"
+```
+
+If the reference is ambiguous, the agent should ask for clarification instead of making live
+claims. Continue the same thread with the narrower identifier:
+
+```bash
+uv run redis-sre-agent query -t <thread_id> \
+  "Use the prod checkout cache in us-east-1"
+```
+
+#### Multi-target comparison
+When the prompt clearly asks for a comparison, the agent can keep more than one discovered target
+in scope and compare them in one conversation.
+
+```bash
+uv run redis-sre-agent query \
+  "Compare checkout cache and session cache for memory pressure and evictions"
+```
+
+You can continue the thread to narrow or reshape the comparison set:
+
+```bash
+uv run redis-sre-agent query -t <thread_id> \
+  "Keep only the production caches and summarize which one needs attention first"
+```
+
+These discovery-first flows depend on your configured target catalog and bindings. If discovery is
+not configured, use explicit `-r <instance_id>` or `-c <cluster_id>` flags instead.
+
 ### 4) Prepare knowledge for better answers (ingest a batch)
 Load docs so the agent can cite internal knowledge.
 ```bash
@@ -198,6 +234,15 @@ uv run redis-sre-agent thread get <thread_id>
 uv run redis-sre-agent thread trace <message_id_or_decision_trace_id>
 uv run redis-sre-agent thread sources <thread_id>
 ```
+
+#### Approval-driven tasks
+Some write actions can pause a task in `awaiting_approval`. The current CLI lets you inspect the
+task or thread state, but approval history and resume actions are not exposed as CLI commands.
+
+- `task get <task_id>` shows the latest status and can include `pending_approval`.
+- `thread get <thread_id>` can also surface `task_id`, `pending_approval`, and `resume_supported`.
+- Use the HTTP API or the web UI triage page to list approval records and submit `approved` or
+  `rejected` decisions.
 
 #### Citations in thread history
 Use these commands together when you want citation-level provenance for an answer:

--- a/docs/how-to/evals.md
+++ b/docs/how-to/evals.md
@@ -6,7 +6,9 @@ It has two main entry points:
 1. Deterministic mocked evals for development and regression testing.
 2. Live-model suite runs for manual or scheduled baseline checks.
 
-The CLI currently exposes scenario listing, live-suite execution, and baseline comparison. Mocked one-off runs are currently easiest to drive through `pytest` or the Python entrypoints.
+The CLI exposes scenario listing, one-off mocked-scenario execution, live-suite execution, and
+baseline comparison. For deterministic regression coverage, prefer the pytest-backed mocked eval
+suite; `eval run` is best for interactive debugging and ad hoc inspection.
 
 ### Terms Used In This Guide
 
@@ -69,20 +71,32 @@ Do not treat `evals/scenarios/` as a single live-model suite. Most of those scen
 
 ### Running One Mocked Scenario
 
-Use the CLI when you want to execute a single mocked scenario directly:
+Use the CLI when you want to execute a single mocked scenario directly.
+
+For the most self-contained CLI path, start with an `agent_only` scenario. It still uses your
+configured model credentials, but it avoids the local Redis/task-system dependency that
+`full_turn` scenarios need.
 
 ```bash
 uv run redis-sre-agent eval run \
-  evals/scenarios/prompt/chat-iterative-tool-use/scenario.yaml
+  evals/scenarios/prompt/knowledge-agent-no-live-access/scenario.yaml
 ```
 
 For machine-readable output:
 
 ```bash
 uv run redis-sre-agent eval run \
-  evals/scenarios/prompt/chat-iterative-tool-use/scenario.yaml \
+  evals/scenarios/prompt/knowledge-agent-no-live-access/scenario.yaml \
   --json
 ```
+
+Requirements and caveats:
+
+- `agent_only` scenarios avoid local Redis/task orchestration, but they still execute the configured
+  model. Set `OPENAI_API_KEY` or the equivalent compatible-endpoint settings before using `eval run`.
+- `full_turn` scenarios exercise the real thread/task orchestration path and therefore also need the
+  local Redis-backed runtime available.
+- Scenarios marked `llm_mode: live` require explicit live opt-in with `--allow-live-llm`.
 
 Useful options:
 
@@ -272,4 +286,4 @@ Use live suites when:
 
 - The scenario corpus mixes `full_turn`, `agent_only`, `prompt`, `redis`, `knowledge`, `retrieval`, and `sources` lanes under one tree.
 - Live suites coerce loaded scenarios to live LLM mode before execution, even when the source manifest is authored for replay mode.
-- The current CLI does not yet expose a dedicated `run scenario` command for mocked evals, so `pytest` and the Python entrypoints are the intended developer workflow.
+- The CLI now exposes `eval run` for one-off debugging, but the supported deterministic regression gate remains the pytest workflow documented above.

--- a/docs/how-to/source-document-features.md
+++ b/docs/how-to/source-document-features.md
@@ -19,6 +19,7 @@ name: example-skill
 summary: Short summary shown in skills TOC.
 priority: high
 pinned: true
+url: https://example.com/docs/example-document
 version: latest
 product_labels: redis-enterprise,redis-cloud
 ---
@@ -33,6 +34,7 @@ Supported common fields:
 - `summary`: short summary used in listings/TOC
 - `priority`: `high`, `normal`, `low`
 - `pinned`: whether to inject into startup context
+- `url`: canonical external URL to publish as `source_url` during ingestion
 - `version`: version tag for retrieval filtering
 - `product_labels`: comma-separated product labels
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,7 +21,7 @@ Redis SRE Agent gives platform teams an AI operator for Redis. It answers Redis 
 - Ad-hoc triage from the API: [how-to/api.md](how-to/api.md)
 - Eval system and live-suite workflows: [how-to/evals.md](how-to/evals.md)
 - Agent Memory Server integration: [how-to/agent-memory-server-integration.md](how-to/agent-memory-server-integration.md)
-- Scheduled health checks: [how-to/cli.md#6-schedule-recurring-checks](how-to/cli.md#6-schedule-recurring-checks)
+- Scheduled health checks: [how-to/cli.md#7-schedule-recurring-checks](how-to/cli.md#7-schedule-recurring-checks)
 - Provider and MCP integration: [how-to/tool-providers.md](how-to/tool-providers.md)
 - Knowledge ingestion and search: [how-to/pipelines.md](how-to/pipelines.md)
 

--- a/redis_sre_agent/api/schemas.py
+++ b/redis_sre_agent/api/schemas.py
@@ -157,6 +157,7 @@ class ThreadResponse(BaseModel):
     """
 
     thread_id: str
+    task_id: Optional[str] = None
     user_id: Optional[str] = None
     priority: int = 0
     tags: List[str] = Field(default_factory=list)

--- a/redis_sre_agent/api/threads.py
+++ b/redis_sre_agent/api/threads.py
@@ -161,6 +161,7 @@ async def get_thread(thread_id: str) -> ThreadResponse:
     result = None
     error_message = None
     task_status = None
+    latest_task_id = None
     pending_approval = None
     resume_supported = False
 
@@ -188,6 +189,7 @@ async def get_thread(thread_id: str) -> ThreadResponse:
 
     return ThreadResponse(
         thread_id=thread_id,
+        task_id=latest_task_id,
         user_id=(metadata.get("user_id") if metadata else None),
         priority=(metadata.get("priority", 0) if metadata else 0),
         tags=(metadata.get("tags", []) if metadata else []),

--- a/redis_sre_agent/cli/cluster.py
+++ b/redis_sre_agent/cli/cluster.py
@@ -13,6 +13,7 @@ from rich.console import Console
 from rich.table import Table
 from ulid import ULID
 
+from redis_sre_agent.cli.logging_utils import log_cli_exception
 from redis_sre_agent.core import clusters as core_clusters
 from redis_sre_agent.core.cluster_admin_defaults import (
     build_enterprise_admin_missing_fields_error,
@@ -68,6 +69,7 @@ def clusters_list(as_json: bool, limit: int):
         try:
             items = await core_clusters.get_clusters()
         except Exception as e:
+            log_cli_exception(__name__, "cluster CLI command failed", e)
             if as_json:
                 print(_json.dumps({"error": str(e)}))
             else:
@@ -139,6 +141,7 @@ def clusters_get(cluster_id: str, as_json: bool):
 
             console.print(table)
         except Exception as e:
+            log_cli_exception(__name__, "cluster CLI command failed", e)
             if as_json:
                 print(_json.dumps({"error": str(e), "id": cluster_id}))
             else:
@@ -248,6 +251,7 @@ def clusters_create(
             else:
                 click.echo(f"✅ Created cluster {new_cluster.id}")
         except Exception as e:
+            log_cli_exception(__name__, "cluster CLI command failed", e)
             if as_json:
                 print(_json.dumps({"error": str(e)}))
             else:
@@ -349,6 +353,7 @@ def clusters_update(
             else:
                 click.echo(f"✅ Updated cluster {validated.id}")
         except Exception as e:
+            log_cli_exception(__name__, "cluster CLI command failed", e)
             if as_json:
                 print(_json.dumps({"error": str(e), "id": cluster_id}))
             else:
@@ -392,6 +397,7 @@ def clusters_delete(cluster_id: str, yes: bool, as_json: bool):
             else:
                 click.echo(f"✅ Deleted cluster {cluster_id}")
         except Exception as e:
+            log_cli_exception(__name__, "cluster CLI command failed", e)
             if as_json:
                 print(_json.dumps({"error": str(e), "id": cluster_id}))
             else:
@@ -434,6 +440,7 @@ def clusters_backfill_instance_links(dry_run: bool, force: bool, as_json: bool):
                 for err in payload["errors"]:
                     click.echo(f"    - {err}")
         except Exception as e:
+            log_cli_exception(__name__, "cluster CLI command failed", e)
             if as_json:
                 print(_json.dumps({"error": str(e)}))
             else:

--- a/redis_sre_agent/cli/index.py
+++ b/redis_sre_agent/cli/index.py
@@ -9,6 +9,8 @@ import click
 from rich.console import Console
 from rich.table import Table
 
+from redis_sre_agent.cli.logging_utils import log_cli_exception
+
 
 @click.group()
 def index():
@@ -87,6 +89,7 @@ def index_list(as_json: bool):
                     }
                 )
             except Exception as e:
+                log_cli_exception(__name__, "index CLI command failed", e)
                 results.append(
                     {
                         "name": name,

--- a/redis_sre_agent/cli/instance.py
+++ b/redis_sre_agent/cli/instance.py
@@ -13,6 +13,7 @@ from rich.console import Console
 from rich.table import Table
 from ulid import ULID
 
+from redis_sre_agent.cli.logging_utils import log_cli_exception
 from redis_sre_agent.core import clusters as core_clusters
 from redis_sre_agent.core import instances as core_instances
 from redis_sre_agent.core.redis import test_redis_connection
@@ -69,6 +70,7 @@ def instances_list(as_json: bool, limit: int):
         try:
             items = await core_instances.get_instances()
         except Exception as e:
+            log_cli_exception(__name__, "instance CLI command failed", e)
             if as_json:
                 print(_json.dumps({"error": str(e)}))
             else:
@@ -148,6 +150,7 @@ def instances_get(instance_id: str, as_json: bool):
 
             console.print(table)
         except Exception as e:
+            log_cli_exception(__name__, "instance CLI command failed", e)
             if as_json:
                 print(_json.dumps({"error": str(e), "id": instance_id}))
             else:
@@ -341,6 +344,7 @@ def instances_create(
             else:
                 click.echo(f"✅ Created instance {new_inst.id}")
         except Exception as e:
+            log_cli_exception(__name__, "instance CLI command failed", e)
             if as_json:
                 print(_json.dumps({"error": str(e)}))
             else:
@@ -557,6 +561,7 @@ def instances_update(
             else:
                 click.echo(f"✅ Updated instance {updated.id}")
         except Exception as e:
+            log_cli_exception(__name__, "instance CLI command failed", e)
             if as_json:
                 print(_json.dumps({"error": str(e), "id": instance_id}))
             else:
@@ -601,6 +606,7 @@ def instances_delete(instance_id: str, yes: bool, as_json: bool):
             else:
                 click.echo(f"✅ Deleted instance {instance_id}")
         except Exception as e:
+            log_cli_exception(__name__, "instance CLI command failed", e)
             if as_json:
                 print(_json.dumps({"error": str(e), "id": instance_id}))
             else:
@@ -629,6 +635,7 @@ def instances_test_url(connection_url: str, as_json: bool):
             else:
                 click.echo(("✅ " if ok else "❌ ") + payload["message"] + f" to {host_info}")
         except Exception as e:
+            log_cli_exception(__name__, "instance CLI command failed", e)
             if as_json:
                 print(_json.dumps({"success": False, "error": str(e)}))
             else:
@@ -664,6 +671,7 @@ def instances_test(instance_id: str, as_json: bool):
             else:
                 click.echo(("✅ " if ok else "❌ ") + payload["message"] + f" to {inst.name}")
         except Exception as e:
+            log_cli_exception(__name__, "instance CLI command failed", e)
             if as_json:
                 print(_json.dumps({"success": False, "error": str(e), "id": instance_id}))
             else:

--- a/redis_sre_agent/cli/knowledge.py
+++ b/redis_sre_agent/cli/knowledge.py
@@ -10,6 +10,7 @@ import click
 from rich.console import Console
 from rich.table import Table
 
+from redis_sre_agent.cli.logging_utils import log_cli_exception
 from redis_sre_agent.core.knowledge_helpers import (
     get_all_document_fragments,
     get_related_document_fragments,
@@ -113,6 +114,7 @@ def knowledge_fragments(document_hash: str, as_json: bool, include_metadata: boo
                 document_hash, include_metadata=include_metadata
             )
         except Exception as e:
+            log_cli_exception(__name__, "knowledge CLI command failed", e)
             payload = {"error": str(e), "document_hash": document_hash}
             if as_json:
                 print(_json.dumps(payload))
@@ -179,6 +181,7 @@ def knowledge_related(document_hash: str, chunk_index: int, window: int, as_json
                 document_hash, current_chunk_index=chunk_index, context_window=window
             )
         except Exception as e:
+            log_cli_exception(__name__, "knowledge CLI command failed", e)
             payload = {"error": str(e), "document_hash": document_hash}
             if as_json:
                 print(_json.dumps(payload))

--- a/redis_sre_agent/cli/logging_utils.py
+++ b/redis_sre_agent/cli/logging_utils.py
@@ -1,0 +1,44 @@
+"""Shared CLI logging helpers."""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Optional
+
+_LOGGING_FORMAT = "%(asctime)s %(levelname)s %(name)s: %(message)s"
+
+
+def _requested_log_level() -> Optional[int]:
+    raw = (os.getenv("LOG_LEVEL") or "").strip()
+    if not raw:
+        return None
+    return getattr(logging, raw.upper(), logging.INFO)
+
+
+def configure_cli_logging() -> Optional[int]:
+    """Configure CLI logging when LOG_LEVEL is explicitly set."""
+    level = _requested_log_level()
+    if level is None:
+        return None
+
+    root_logger = logging.getLogger()
+    if not root_logger.handlers:
+        logging.basicConfig(level=level, format=_LOGGING_FORMAT)
+    root_logger.setLevel(level)
+    for handler in root_logger.handlers:
+        handler.setLevel(level)
+    return level
+
+
+def log_cli_exception(logger_name: str, message: str, exc: BaseException) -> None:
+    """Emit CLI exception details when LOG_LEVEL requests logging."""
+    level = configure_cli_logging()
+    if level is None:
+        return
+
+    logger = logging.getLogger(logger_name)
+    if logger.isEnabledFor(logging.DEBUG):
+        logger.exception(message)
+    else:
+        logger.error("%s: %s", message, exc)

--- a/redis_sre_agent/cli/logging_utils.py
+++ b/redis_sre_agent/cli/logging_utils.py
@@ -7,6 +7,7 @@ import os
 from typing import Optional
 
 _LOGGING_FORMAT = "%(asctime)s %(levelname)s %(name)s: %(message)s"
+_CLI_LOGGED_ATTR = "_redis_sre_cli_logged"
 
 
 def _requested_log_level() -> Optional[int]:
@@ -31,6 +32,16 @@ def configure_cli_logging() -> Optional[int]:
     return level
 
 
+def mark_cli_exception_logged(exc: BaseException) -> None:
+    """Mark an exception as already emitted through CLI logging."""
+    setattr(exc, _CLI_LOGGED_ATTR, True)
+
+
+def was_cli_exception_logged(exc: BaseException) -> bool:
+    """Return whether the CLI has already logged this exception."""
+    return bool(getattr(exc, _CLI_LOGGED_ATTR, False))
+
+
 def log_cli_exception(logger_name: str, message: str, exc: BaseException) -> None:
     """Emit CLI exception details when LOG_LEVEL requests logging."""
     level = configure_cli_logging()
@@ -38,7 +49,9 @@ def log_cli_exception(logger_name: str, message: str, exc: BaseException) -> Non
         return
 
     logger = logging.getLogger(logger_name)
+    exc_info = (type(exc), exc, exc.__traceback__)
     if logger.isEnabledFor(logging.DEBUG):
-        logger.exception(message)
+        logger.error(message, exc_info=exc_info)
     else:
         logger.error("%s: %s", message, exc)
+    mark_cli_exception_logged(exc)

--- a/redis_sre_agent/cli/main.py
+++ b/redis_sre_agent/cli/main.py
@@ -5,7 +5,11 @@ import importlib
 import click
 
 from redis_sre_agent import __version__
-from redis_sre_agent.cli.logging_utils import configure_cli_logging, log_cli_exception
+from redis_sre_agent.cli.logging_utils import (
+    configure_cli_logging,
+    log_cli_exception,
+    was_cli_exception_logged,
+)
 
 configure_cli_logging()
 
@@ -70,7 +74,8 @@ class LazyGroup(click.MultiCommand):
         except (click.ClickException, click.Abort, SystemExit):
             raise
         except Exception as exc:
-            log_cli_exception(__name__, "CLI command failed", exc)
+            if not was_cli_exception_logged(exc):
+                log_cli_exception(__name__, "CLI command failed", exc)
             raise
 
 

--- a/redis_sre_agent/cli/main.py
+++ b/redis_sre_agent/cli/main.py
@@ -5,6 +5,9 @@ import importlib
 import click
 
 from redis_sre_agent import __version__
+from redis_sre_agent.cli.logging_utils import configure_cli_logging, log_cli_exception
+
+configure_cli_logging()
 
 # Map command names to their module:attribute for lazy import
 _COMMANDS = {
@@ -49,6 +52,7 @@ class LazyGroup(click.MultiCommand):
         return list(_COMMANDS.keys()) + list(_BUILTIN_COMMANDS)
 
     def get_command(self, ctx, name):
+        configure_cli_logging()
         # Handle built-in commands
         if name == "version":
             return version
@@ -59,6 +63,15 @@ class LazyGroup(click.MultiCommand):
         module_path, attr = target.split(":", 1)
         mod = importlib.import_module(module_path)
         return getattr(mod, attr)
+
+    def invoke(self, ctx):
+        try:
+            return super().invoke(ctx)
+        except (click.ClickException, click.Abort, SystemExit):
+            raise
+        except Exception as exc:
+            log_cli_exception(__name__, "CLI command failed", exc)
+            raise
 
 
 @click.command(cls=LazyGroup)

--- a/redis_sre_agent/cli/pipeline.py
+++ b/redis_sre_agent/cli/pipeline.py
@@ -6,6 +6,8 @@ from pathlib import Path
 
 import click
 
+from redis_sre_agent.cli.logging_utils import log_cli_exception
+
 from ..pipelines.orchestrator import PipelineOrchestrator
 
 
@@ -153,6 +155,7 @@ def scrape(artifacts_path: str, scrapers: str, latest_only: bool, docs_path: str
             return results
 
         except Exception as e:
+            log_cli_exception(__name__, "pipeline CLI command failed", e)
             click.echo(f"❌ Scraping failed: {e}")
             raise
 
@@ -201,6 +204,7 @@ def ingest(batch_date: str, artifacts_path: str, latest_only: bool, verbose: boo
             return results
 
         except Exception as e:
+            log_cli_exception(__name__, "pipeline CLI command failed", e)
             click.echo(f"❌ Ingestion failed: {e}")
             raise
 
@@ -260,6 +264,7 @@ def full(artifacts_path: str, scrapers: str, latest_only: bool, docs_path: str):
             return results
 
         except Exception as e:
+            log_cli_exception(__name__, "pipeline CLI command failed", e)
             click.echo(f"❌ Full pipeline failed: {e}")
             raise
 
@@ -299,6 +304,7 @@ def status(artifacts_path: str):
             return status_info
 
         except Exception as e:
+            log_cli_exception(__name__, "pipeline CLI command failed", e)
             click.echo(f"❌ Status check failed: {e}")
             raise
 
@@ -380,6 +386,7 @@ def cleanup(keep_days: int, artifacts_path: str):
             return results
 
         except Exception as e:
+            log_cli_exception(__name__, "pipeline CLI command failed", e)
             click.echo(f"❌ Cleanup failed: {e}")
             raise
 
@@ -451,6 +458,7 @@ def runbooks(url: str, test_url: str, list_urls: bool, artifacts_path: str):
             _echo_runbook_job_results(results)
 
         except Exception as e:
+            log_cli_exception(__name__, "pipeline CLI command failed", e)
             click.echo(f"❌ Runbook generation failed: {e}")
             raise
 
@@ -548,6 +556,7 @@ def prepare_sources(
                 )
 
         except Exception as e:
+            log_cli_exception(__name__, "pipeline CLI command failed", e)
             click.echo(f"❌ Source preparation failed: {e}")
             raise
 

--- a/redis_sre_agent/cli/query.py
+++ b/redis_sre_agent/cli/query.py
@@ -15,6 +15,7 @@ from ulid import ULID
 from redis_sre_agent.agent.chat_agent import get_chat_agent
 from redis_sre_agent.agent.langgraph_agent import get_sre_agent
 from redis_sre_agent.agent.router import AgentType, route_to_appropriate_agent
+from redis_sre_agent.cli.logging_utils import log_cli_exception
 from redis_sre_agent.core.citation_message import (
     build_citation_message_payloads,
     should_include_citations,
@@ -288,6 +289,7 @@ def query(
             )
 
         except Exception as e:
+            log_cli_exception(__name__, "query CLI command failed", e)
             console.print(f"[red]❌ Error: {e}[/red]")
             exit(1)
         finally:

--- a/redis_sre_agent/cli/runbook.py
+++ b/redis_sre_agent/cli/runbook.py
@@ -11,6 +11,7 @@ from typing import Optional
 import click
 
 from redis_sre_agent.agent.runbook_generator import RunbookGenerator
+from redis_sre_agent.cli.logging_utils import log_cli_exception
 
 logger = logging.getLogger(__name__)
 
@@ -133,6 +134,7 @@ def generate(
                 return 1
 
         except Exception as e:
+            log_cli_exception(__name__, "runbook CLI command failed", e)
             click.echo(f"❌ Error generating runbook: {e}")
             logger.exception("Runbook generation failed")
             return 1
@@ -218,6 +220,7 @@ def evaluate(input_dir: str, output_file: Optional[str]):
                 )
 
             except Exception as e:
+                log_cli_exception(__name__, "runbook CLI command failed", e)
                 click.echo(f"   ❌ Failed to evaluate {md_file.name}: {e}")
 
         # Summary

--- a/redis_sre_agent/cli/schedules.py
+++ b/redis_sre_agent/cli/schedules.py
@@ -11,6 +11,7 @@ from docket import Docket
 from rich.console import Console
 from rich.table import Table
 
+from redis_sre_agent.cli.logging_utils import log_cli_exception
 from redis_sre_agent.core.docket_tasks import get_redis_url, process_agent_turn
 from redis_sre_agent.core.keys import RedisKeys
 from redis_sre_agent.core.redis import get_redis_client
@@ -48,6 +49,7 @@ def schedules_list(as_json: bool, tz: str | None, limit: int):
         try:
             items = await list_schedules()
         except Exception as e:
+            log_cli_exception(__name__, "schedules CLI command failed", e)
             if as_json:
                 print(_json.dumps({"error": str(e)}))
             else:
@@ -134,6 +136,7 @@ def schedules_get(schedule_id: str, as_json: bool, tz: str | None):
         try:
             s = await get_schedule(schedule_id)
         except Exception as e:
+            log_cli_exception(__name__, "schedules CLI command failed", e)
             payload = {"error": str(e), "id": schedule_id}
             if as_json:
                 print(_json.dumps(payload))
@@ -259,6 +262,7 @@ def schedules_create(
             else:
                 click.echo(f"✅ Created schedule {sched.id}")
         except Exception as e:
+            log_cli_exception(__name__, "schedules CLI command failed", e)
             if as_json:
                 print(_json.dumps({"error": str(e)}))
             else:
@@ -352,6 +356,7 @@ def schedules_update(
             else:
                 click.echo(f"✅ Updated schedule {sched.id}")
         except Exception as e:
+            log_cli_exception(__name__, "schedules CLI command failed", e)
             if as_json:
                 print(_json.dumps({"error": str(e), "id": schedule_id}))
             else:
@@ -394,6 +399,7 @@ def schedules_enable(schedule_id: str, as_json: bool):
             else:
                 click.echo(f"✅ Enabled schedule {sched.id}")
         except Exception as e:
+            log_cli_exception(__name__, "schedules CLI command failed", e)
             if as_json:
                 print(_json.dumps({"error": str(e), "id": schedule_id}))
             else:
@@ -433,6 +439,7 @@ def schedules_disable(schedule_id: str, as_json: bool):
             else:
                 click.echo(f"✅ Disabled schedule {sched.id}")
         except Exception as e:
+            log_cli_exception(__name__, "schedules CLI command failed", e)
             if as_json:
                 print(_json.dumps({"error": str(e), "id": schedule_id}))
             else:
@@ -469,6 +476,7 @@ def schedules_delete(schedule_id: str, yes: bool, as_json: bool):
             else:
                 click.echo(f"✅ Deleted schedule {schedule_id}")
         except Exception as e:
+            log_cli_exception(__name__, "schedules CLI command failed", e)
             if as_json:
                 print(_json.dumps({"error": str(e), "id": schedule_id}))
             else:
@@ -542,6 +550,7 @@ def schedules_run_now(schedule_id: str, as_json: bool):
                         context=run_context,
                     )
                 except Exception as e:
+                    log_cli_exception(__name__, "schedules CLI command failed", e)
                     if "already exists" in str(e).lower() or "duplicate" in str(e).lower():
                         docket_task_id = "already_running"
                     else:
@@ -559,6 +568,7 @@ def schedules_run_now(schedule_id: str, as_json: bool):
             else:
                 click.echo(f"✅ Triggered schedule {schedule_id} (thread {thread_id})")
         except Exception as e:
+            log_cli_exception(__name__, "schedules CLI command failed", e)
             if as_json:
                 print(_json.dumps({"error": str(e), "id": schedule_id}))
             else:
@@ -720,6 +730,7 @@ def schedules_runs(schedule_id: str, as_json: bool, tz: str | None, limit: int):
 
             console.print(table)
         except Exception as e:
+            log_cli_exception(__name__, "schedules CLI command failed", e)
             if as_json:
                 print(_json.dumps({"error": str(e), "id": schedule_id}))
             else:

--- a/redis_sre_agent/cli/support_package.py
+++ b/redis_sre_agent/cli/support_package.py
@@ -11,6 +11,7 @@ import click
 from rich.console import Console
 from rich.table import Table
 
+from redis_sre_agent.cli.logging_utils import log_cli_exception
 from redis_sre_agent.core.config import settings
 from redis_sre_agent.tools.support_package.manager import SupportPackageManager
 from redis_sre_agent.tools.support_package.storage import LocalStorage, S3Storage
@@ -61,6 +62,7 @@ def upload(path: Path, package_id: Optional[str], as_json: bool):
             else:
                 click.echo(f"✅ Uploaded support package: {result_id}")
         except Exception as e:
+            log_cli_exception(__name__, "support package CLI command failed", e)
             if as_json:
                 print(_json.dumps({"error": str(e)}))
             else:
@@ -106,6 +108,7 @@ def list_packages(as_json: bool, limit: int):
 
             console.print(table)
         except Exception as e:
+            log_cli_exception(__name__, "support package CLI command failed", e)
             if as_json:
                 print(_json.dumps({"error": str(e)}))
             else:
@@ -147,6 +150,7 @@ def extract(package_id: str, as_json: bool):
             else:
                 click.echo(f"✅ Extracted to: {extract_path}")
         except Exception as e:
+            log_cli_exception(__name__, "support package CLI command failed", e)
             if as_json:
                 print(_json.dumps({"error": str(e), "package_id": package_id}))
             else:
@@ -177,6 +181,7 @@ def delete(package_id: str, yes: bool, as_json: bool):
             else:
                 click.echo(f"✅ Deleted package: {package_id}")
         except Exception as e:
+            log_cli_exception(__name__, "support package CLI command failed", e)
             if as_json:
                 print(_json.dumps({"error": str(e), "package_id": package_id}))
             else:
@@ -226,6 +231,7 @@ def info(package_id: str, as_json: bool):
 
             console.print(table)
         except Exception as e:
+            log_cli_exception(__name__, "support package CLI command failed", e)
             if as_json:
                 print(_json.dumps({"error": str(e), "package_id": package_id}))
             else:

--- a/redis_sre_agent/cli/tasks.py
+++ b/redis_sre_agent/cli/tasks.py
@@ -6,6 +6,8 @@ import asyncio
 
 import click
 
+from redis_sre_agent.cli.logging_utils import log_cli_exception
+
 
 @click.group()
 def task():
@@ -165,6 +167,7 @@ def task_get(task_id: str, as_json: bool):
         try:
             t = await get_task_by_id(task_id=task_id)
         except Exception as e:
+            log_cli_exception(__name__, "tasks CLI command failed", e)
             if as_json:
                 print(_json.dumps({"error": str(e), "task_id": task_id}))
             else:
@@ -267,6 +270,7 @@ def task_purge(
                     return timedelta(seconds=float(s[:-1]))
                 return timedelta(seconds=float(s))
             except Exception as e:
+                log_cli_exception(__name__, "tasks CLI command failed", e)
                 raise ValueError(f"Invalid duration '{s}': {e}")
 
         if not purge_all and not older_than and not status:
@@ -397,6 +401,7 @@ def task_delete(task_id: str, yes: bool, as_json: bool):
         try:
             await delete_task_core(task_id=task_id, redis_client=client)
         except Exception as e:
+            log_cli_exception(__name__, "tasks CLI command failed", e)
             payload = {"task_id": task_id, "status": "error", "error": str(e)}
             if as_json:
                 print(_json.dumps(payload))

--- a/redis_sre_agent/cli/threads.py
+++ b/redis_sre_agent/cli/threads.py
@@ -11,6 +11,7 @@ from rich.console import Console
 from rich.table import Table
 
 from redis_sre_agent.agent.helpers import extract_citation_groups
+from redis_sre_agent.cli.logging_utils import log_cli_exception
 from redis_sre_agent.core.keys import RedisKeys
 from redis_sre_agent.core.redis import (
     SRE_THREADS_INDEX,
@@ -311,6 +312,7 @@ def thread_reindex(drop: bool, limit: int, start: int):
                 console.print(f"[yellow]Dropped index:[/yellow] {SRE_THREADS_INDEX}")
 
             except Exception as e:
+                log_cli_exception(__name__, "threads CLI command failed", e)
                 console.print(f"[yellow]idx.drop() unavailable/failed:[/yellow] {e}")
                 try:
                     client = await tm._get_client()
@@ -332,6 +334,7 @@ def thread_reindex(drop: bool, limit: int, start: int):
             else:
                 console.print(f"[green]Index exists:[/green] {SRE_THREADS_INDEX}")
         except Exception as e:
+            log_cli_exception(__name__, "threads CLI command failed", e)
             console.print(f"[yellow]Warning ensuring index:[/yellow] {e}")
 
         # Backfill all thread docs
@@ -600,6 +603,7 @@ def thread_purge(
                 # default seconds if no suffix
                 return timedelta(seconds=float(s))
             except Exception as e:
+                log_cli_exception(__name__, "threads CLI command failed", e)
                 raise ValueError(f"Invalid duration '{s}': {e}")
 
         if not purge_all and not older_than:

--- a/redis_sre_agent/cli/worker.py
+++ b/redis_sre_agent/cli/worker.py
@@ -12,6 +12,7 @@ import click
 import psutil
 from docket import Docket, Worker
 
+from redis_sre_agent.cli.logging_utils import log_cli_exception
 from redis_sre_agent.core.config import settings
 from redis_sre_agent.core.docket_tasks import register_sre_tasks
 from redis_sre_agent.observability.tracing import setup_tracing
@@ -159,6 +160,7 @@ def start(concurrency: int):
             else:
                 logger.warning("⚠️ Failed to create some Redis indices")
         except Exception as e:
+            log_cli_exception(__name__, "worker CLI command failed", e)
             logger.error(f"Failed to initialize Redis indices: {e}")
             # Continue anyway - some functionality may still work
 
@@ -171,6 +173,7 @@ def start(concurrency: int):
             migration_summary = await run_instances_to_clusters_migration(source="worker_startup")
             logger.info("Instance-cluster backfill summary: %s", migration_summary.to_dict())
         except Exception as e:
+            log_cli_exception(__name__, "worker CLI command failed", e)
             logger.warning("Instance-cluster startup migration failed (continuing): %s", e)
 
         try:
@@ -190,6 +193,7 @@ def start(concurrency: int):
                 tasks=["redis_sre_agent.core.docket_tasks:SRE_TASK_COLLECTION"],
             )
         except Exception as e:
+            log_cli_exception(__name__, "worker CLI command failed", e)
             logger.error(f"\u274c Worker error: {e}")
             raise
 
@@ -198,6 +202,7 @@ def start(concurrency: int):
     except KeyboardInterrupt:
         click.echo("\nSRE worker stopped by user")
     except Exception as e:
+        log_cli_exception(__name__, "worker CLI command failed", e)
         click.echo(f"Unexpected worker error: {e}")
         raise
 
@@ -224,6 +229,7 @@ def status(verbose: bool):
             click.echo("✗ Workers: No active workers found")
 
     except Exception as e:
+        log_cli_exception(__name__, "worker CLI command failed", e)
         click.echo(f"✗ Redis: Failed to connect ({e})")
         click.echo("  Worker cannot run without Redis")
         sys.exit(1)
@@ -268,5 +274,6 @@ def stop():
                 click.echo(f"✗ Permission denied to stop process {pid}")
 
     except Exception as e:
+        log_cli_exception(__name__, "worker CLI command failed", e)
         click.echo(f"✗ Error: {e}", err=True)
         sys.exit(1)

--- a/redis_sre_agent/core/clusters.py
+++ b/redis_sre_agent/core/clusters.py
@@ -191,10 +191,10 @@ async def get_clusters() -> List[RedisCluster]:
                     )
                 out.append(RedisCluster(**cluster_data))
             except Exception as e:
-                logger.error("Failed to load cluster from search result: %s. Skipping.", e)
+                logger.exception("Failed to load cluster from search result: %s. Skipping.", e)
         return out
     except Exception as e:
-        logger.error("Failed to get clusters from Redis: %s", e)
+        logger.exception("Failed to get clusters from Redis: %s", e)
         return []
 
 
@@ -271,12 +271,12 @@ async def query_clusters(
                     )
                 clusters.append(RedisCluster(**cluster_data))
             except Exception as e:
-                logger.error("Failed to load cluster from query result: %s. Skipping.", e)
+                logger.exception("Failed to load cluster from query result: %s. Skipping.", e)
 
         return ClusterQueryResult(clusters=clusters, total=total, limit=limit, offset=offset)
 
     except Exception as e:
-        logger.error("Failed to query clusters: %s", e)
+        logger.exception("Failed to query clusters: %s", e)
         return ClusterQueryResult(clusters=[], total=0, limit=limit, offset=offset)
 
 
@@ -433,5 +433,5 @@ async def get_cluster_by_id(cluster_id: str) -> Optional[RedisCluster]:
 
         return RedisCluster(**cluster_data)
     except Exception as e:
-        logger.error("Failed to get cluster by ID %s: %s", cluster_id, e)
+        logger.exception("Failed to get cluster by ID %s: %s", cluster_id, e)
         return None

--- a/redis_sre_agent/core/instances.py
+++ b/redis_sre_agent/core/instances.py
@@ -394,10 +394,10 @@ async def get_instances() -> List[RedisInstance]:
                     inst_data["admin_password"] = get_secret_value(inst_data["admin_password"])
                 out.append(RedisInstance(**inst_data))
             except Exception as e:
-                logger.error("Failed to load instance from search result: %s. Skipping.", e)
+                logger.exception("Failed to load instance from search result: %s. Skipping.", e)
         return out
     except Exception as e:
-        logger.error("Failed to get instances from Redis: %s", e)
+        logger.exception("Failed to get instances from Redis: %s", e)
         return []
 
 
@@ -513,7 +513,7 @@ async def query_instances(
                     inst_data["admin_password"] = get_secret_value(inst_data["admin_password"])
                 instances.append(RedisInstance(**inst_data))
             except Exception as e:
-                logger.error("Failed to load instance from query result: %s. Skipping.", e)
+                logger.exception("Failed to load instance from query result: %s. Skipping.", e)
 
         return InstanceQueryResult(
             instances=instances,
@@ -523,7 +523,7 @@ async def query_instances(
         )
 
     except Exception as e:
-        logger.error("Failed to query instances: %s", e)
+        logger.exception("Failed to query instances: %s", e)
         return InstanceQueryResult(instances=[], total=0, limit=limit, offset=offset)
 
 
@@ -719,7 +719,7 @@ async def get_session_instances(thread_id: str) -> List[RedisInstance]:
             out.append(RedisInstance(**inst_data))
         return out
     except Exception as e:
-        logger.error("Failed to get session instances for %s: %s", thread_id, e)
+        logger.exception("Failed to get session instances for %s: %s", thread_id, e)
         return []
 
 
@@ -745,7 +745,7 @@ async def add_session_instance(thread_id: str, instance: RedisInstance) -> bool:
         await redis_client.set(RedisKeys.thread_instances(thread_id), json.dumps(items), ex=3600)
         return True
     except Exception as e:
-        logger.error("Failed to add session instance for %s: %s", thread_id, e)
+        logger.exception("Failed to add session instance for %s: %s", thread_id, e)
         return False
 
 
@@ -805,7 +805,7 @@ async def create_instance(
             raise ValueError("Failed to save instance to storage")
         return new_inst
     except Exception as e:
-        logger.error("Failed to create instance programmatically: %s", e)
+        logger.exception("Failed to create instance programmatically: %s", e)
         raise
 
 
@@ -835,7 +835,7 @@ async def get_instance_by_id(instance_id: str) -> Optional[RedisInstance]:
 
         return RedisInstance(**inst_data)
     except Exception as e:
-        logger.error("Failed to get instance by ID %s: %s", instance_id, e)
+        logger.exception("Failed to get instance by ID %s: %s", instance_id, e)
         return None
 
 
@@ -876,7 +876,7 @@ async def get_instance_by_name(instance_name: str) -> Optional[RedisInstance]:
 
         return RedisInstance(**inst_data)
     except Exception as e:
-        logger.error("Failed to get instance by name %s: %s", instance_name, e)
+        logger.exception("Failed to get instance by name %s: %s", instance_name, e)
         return None
 
 

--- a/redis_sre_agent/core/redis.py
+++ b/redis_sre_agent/core/redis.py
@@ -764,7 +764,7 @@ async def test_redis_connection(
         await client.aclose()
         return True
     except Exception as e:
-        logger.error(f"Redis connection test failed: {e}")
+        logger.exception(f"Redis connection test failed: {e}")
         return False
 
 
@@ -784,7 +784,7 @@ async def test_vector_search(config: Optional[Settings] = None) -> bool:
         exists = await index.exists()
         return exists
     except Exception as e:
-        logger.error(f"Vector search test failed: {e}")
+        logger.exception(f"Vector search test failed: {e}")
         return False
 
 
@@ -923,7 +923,7 @@ async def create_indices(config: Optional[Settings] = None) -> bool:
                 logger.debug("Index already exists: %s", idx_name)
         return True
     except Exception as e:
-        logger.error(f"Failed to create indices: {e}")
+        logger.exception(f"Failed to create indices: {e}")
         return False
 
 
@@ -971,7 +971,7 @@ async def recreate_indices(
             result["indices"][name] = "recreated"
 
         except Exception as e:
-            logger.error(f"Failed to recreate index {name}: {e}")
+            logger.exception(f"Failed to recreate index {name}: {e}")
             result["indices"][name] = f"error: {e}"
             result["success"] = False
 
@@ -1004,7 +1004,7 @@ async def initialize_redis(config: Optional[Settings] = None) -> dict:
             vectorizer = get_vectorizer(config=cfg)
             status["vectorizer"] = "available" if vectorizer else "unavailable"
     except Exception as e:
-        logger.error(f"Vectorizer initialization failed: {e}")
+        logger.exception(f"Vectorizer initialization failed: {e}")
         status["vectorizer"] = "unavailable"
 
     # Create indices if Redis is available
@@ -1059,5 +1059,5 @@ async def initialize_docket(config: Optional[Settings] = None) -> bool:
         logger.warning("Docket not available - task queue functionality will be limited")
         return False
     except Exception as e:
-        logger.error(f"Failed to initialize: {e}")
+        logger.exception(f"Failed to initialize: {e}")
         return False

--- a/redis_sre_agent/core/threads.py
+++ b/redis_sre_agent/core/threads.py
@@ -185,7 +185,7 @@ Subject:"""
             return True
 
         except Exception as e:
-            logger.error(f"Failed to update thread {thread_id} subject: {e}")
+            logger.exception(f"Failed to update thread {thread_id} subject: {e}")
             return False
 
     async def set_thread_subject(self, thread_id: str, subject: str) -> bool:
@@ -204,7 +204,7 @@ Subject:"""
             logger.info(f"Set thread {thread_id} subject: {subject}")
             return True
         except Exception as e:
-            logger.error(f"Failed to set thread {thread_id} subject: {e}")
+            logger.exception(f"Failed to set thread {thread_id} subject: {e}")
             return False
 
     async def _upsert_thread_search_doc(self, thread_id: str) -> bool:
@@ -315,7 +315,7 @@ Subject:"""
             return True
 
         except Exception as e:
-            logger.error(f"Failed to remove thread {thread_id} from index: {e}")
+            logger.exception(f"Failed to remove thread {thread_id} from index: {e}")
             return False
 
     async def list_threads(
@@ -486,7 +486,7 @@ Subject:"""
             )
 
         except Exception as e:
-            logger.error(f"Failed to get thread state {thread_id}: {e}")
+            logger.exception(f"Failed to get thread state {thread_id}: {e}")
             return None
 
     async def update_thread_context(
@@ -554,7 +554,7 @@ Subject:"""
             return True
 
         except Exception as e:
-            logger.error(f"Failed to update context for thread {thread_id}: {e}")
+            logger.exception(f"Failed to update context for thread {thread_id}: {e}")
             return False
 
     async def append_messages(self, thread_id: str, messages: List[Dict[str, Any]]) -> bool:
@@ -603,7 +603,7 @@ Subject:"""
             return True
 
         except Exception as e:
-            logger.error(f"Failed to append messages for thread {thread_id}: {e}")
+            logger.exception(f"Failed to append messages for thread {thread_id}: {e}")
             return False
 
     async def _save_thread_state(self, thread_state: Thread) -> bool:
@@ -659,7 +659,7 @@ Subject:"""
             return True
 
         except Exception as e:
-            logger.error(f"Failed to save thread state {thread_state.thread_id}: {e}")
+            logger.exception(f"Failed to save thread state {thread_state.thread_id}: {e}")
             return False
 
     async def delete_thread(self, thread_id: str) -> bool:
@@ -689,7 +689,7 @@ Subject:"""
             return True
 
         except Exception as e:
-            logger.error(f"Failed to delete thread {thread_id}: {e}")
+            logger.exception(f"Failed to delete thread {thread_id}: {e}")
             return False
 
     async def set_message_trace(
@@ -731,7 +731,7 @@ Subject:"""
             logger.debug(f"Stored decision trace for message {message_id}")
             return True
         except Exception as e:
-            logger.error(f"Failed to store message trace {message_id}: {e}")
+            logger.exception(f"Failed to store message trace {message_id}: {e}")
             return False
 
     async def get_message_trace(self, message_id: str) -> Optional[Dict[str, Any]]:
@@ -750,7 +750,7 @@ Subject:"""
                 return None
             return json.loads(data if isinstance(data, str) else data.decode())
         except Exception as e:
-            logger.error(f"Failed to get message trace {message_id}: {e}")
+            logger.exception(f"Failed to get message trace {message_id}: {e}")
             return None
 
 

--- a/specs/manual-qa-0.4.0.md
+++ b/specs/manual-qa-0.4.0.md
@@ -1,0 +1,311 @@
+# 0.4.0 Manual QA Plan
+
+## Scope
+
+This plan covers the feature delta from `v0.3.1` to `origin/main` as of 2026-04-29. The main user-facing changes in that range came from:
+
+- `#116` thread subject generation
+- `#119` TOML and JSON config support
+- `#120` exact-search compatibility improvements
+- `#122` expanded MCP admin/query tooling and analyzer-facing query entrypoints
+- `#124` natural-language target discovery
+- `#131` Agent Memory Server integration
+- `#133` multi-target investigation and comparison
+- `#135` MCP stdio logging isolation
+- `#137` path-based source document updates
+- `#138` source identity preservation during `prepare_sources`
+- `#141` pluggable target binding/discovery
+- `#142` published UI air-gap image support
+- `#144` mocked eval runtime and reporting harness
+- `#145` HITL approvals and resume
+- `#146` pipeline scrape stall fixes and progress visibility
+- `#147` runtime triage follow-up fixes
+- `#149` Agent Skills package support
+- `#150` startup skill grounding provenance
+- `#151` local `expand_evidence` execution fixes
+- `#153` explicit source-document frontmatter `url`
+
+## Common QA Setup
+
+- Test both CLI and API-driven workflows where both surfaces exist.
+- Use Redis 8 for the primary validation path.
+- If an older Redis Search deployment is available, include one compatibility pass for exact-search behavior.
+- Exercise at least one run with `config.yaml`, one with `config.toml`, and one with `config.json`.
+- Capture screenshots or transcripts for failures in task status, approvals, UI, and docs examples.
+- For every feature area below, verify the linked docs are current and execute the examples exactly as written before trying edited variants.
+
+## 1. Configuration, Bootstrap, and Operational Safety
+
+Related changes: `#116`, `#119`, `#120`, `#135`, `#147`
+
+Docs to verify:
+
+- `README.md`
+- `docs/how-to/configuration.md`
+- `docs/reference/configuration.md`
+- `docs/operations/gotchas.md`
+- `docs/reference/api.md`
+
+Manual checks:
+
+1. Start the app with equivalent settings expressed in YAML, TOML, and JSON and verify the resolved config is identical.
+2. Verify explicit config path selection wins over auto-discovered default files when multiple formats exist.
+3. Create a thread with and without an initial user message and verify subject generation behaves sensibly and never yields an empty placeholder.
+4. Start the MCP server in stdio mode and verify machine-readable stdout is clean while logs route to stderr.
+5. Run exact identifier-style knowledge queries on Redis 8 and, if available, an older Redis Search target to confirm graceful compatibility behavior.
+6. Trigger a known runtime error path and confirm the surfaced error is actionable instead of silently empty.
+
+Edge cases:
+
+- malformed TOML or JSON
+- multiple config files present at once
+- empty thread seed message
+- quoted literal search phrase vs natural-language query
+- stdio startup with verbose logging enabled
+
+## 2. Natural-Language Target Discovery and Binding
+
+Related changes: `#124`, `#141`, `#147`
+
+Docs to verify:
+
+- `docs/how-to/tool-providers.md`
+- `docs/how-to/local-dev.md`
+- `docs/reference/configuration.md`
+- `specs/natural-language-target-discovery-spec.md`
+
+Manual checks:
+
+1. Ask for a known Redis target by friendly name, alias, environment, and partial description and verify the same target is selected consistently.
+2. Ask for an ambiguous target and verify the agent asks a clarifying question instead of binding arbitrarily.
+3. Ask for a nonexistent target and verify the failure is explicit and safe.
+4. Continue an existing thread after a target is attached and verify later turns reuse the binding correctly.
+5. Swap discovery and binding configuration to any non-default backend available in test config and verify registry-driven loading still works.
+
+Edge cases:
+
+- alias matches across instance and cluster records
+- one query resolving to multiple environments
+- missing credentials after successful discovery
+- bound thread resumed after process restart
+
+## 3. Multi-Target Investigation and Comparison
+
+Related changes: `#133`, `#147`
+
+Docs to verify:
+
+- `docs/how-to/cli.md`
+- `docs/reference/api.md`
+- `docs/reference/cli.md`
+
+Manual checks:
+
+1. Ask the chat agent to compare two attached targets and verify evidence is collected per target before summarization.
+2. Run the same comparison through any CLI or MCP entrypoint that supports target context and verify the result format is stable.
+3. Mix cluster and instance targets in the same comparison and verify the narrative stays explicit about scope.
+4. Ask a follow-up question about only one of the compared targets and verify the agent narrows scope correctly.
+
+Edge cases:
+
+- duplicate target selection in the same request
+- one healthy target and one failing target
+- three or more targets when `allow_multiple=true`
+- partial evidence availability on one target only
+
+## 4. Query, Admin, and Thread-Oriented MCP Surfaces
+
+Related changes: `#122`, `#147`
+
+Docs to verify:
+
+- `docs/reference/api.md`
+- `docs/reference/cli.md`
+- `docs/how-to/cli.md`
+
+Manual checks:
+
+1. Exercise `redis_sre_query` with only free-text input, then with `instance_id`, `cluster_id`, `thread_id`, and `support_package_id`.
+2. Validate one create/read/update/delete workflow for instances, clusters, schedules, and support packages in a safe non-production environment.
+3. Confirm task, thread, citations, approvals, and source inspection tools return coherent cross-links after a completed run.
+4. Verify queue-and-watch flows still work after using the routed query entrypoint.
+
+Edge cases:
+
+- query with both live target and support package context
+- query continuation on an old thread
+- invalid ids for each object family
+- empty result sets from list/search tools
+
+## 5. HITL Approvals and Resume
+
+Related changes: `#145`
+
+Docs to verify:
+
+- `docs/reference/api.md`
+- `specs/hitl-approvals-and-resume-spec.md`
+
+Manual checks:
+
+1. Run a read-only task and confirm write-capable actions are blocked or classified correctly.
+2. Run a task that requires approval, verify it enters `awaiting_approval`, and inspect approval metadata on the task and thread.
+3. Approve the pending action and confirm resume continues the interrupted run instead of starting from scratch.
+4. Reject the pending action and verify the task records the rejection cleanly.
+5. Trigger two approval boundaries in one logical task and verify both cycles work.
+
+Edge cases:
+
+- repeated resume submission for the same approval
+- expired approval
+- approval after worker restart
+- approval mismatch or stale approval id
+
+## 6. Agent Memory Server Integration
+
+Related changes: `#131`
+
+Docs to verify:
+
+- `docs/how-to/agent-memory-server-integration.md`
+- `README.md`
+
+Manual checks:
+
+1. Run a conversation with `user_id` only and verify user-scoped memory recall and later persistence.
+2. Run with target scope only and verify asset-scoped recall without unrelated personalization.
+3. Run with both `user_id` and target scope and verify both memory classes influence the answer.
+4. Run with neither and verify the agent skips long-term memory cleanly.
+5. Simulate AMS unavailability and confirm fail-open behavior still preserves live-tool and KB functionality.
+
+Edge cases:
+
+- conflicting user-scoped vs asset-scoped memory
+- stale memory contradicted by live telemetry
+- first conversation with no prior memory
+- memory write after a failed run
+
+## 7. Agent Skills Retrieval, Package Support, and Startup Grounding
+
+Related changes: `#149`, `#150`, `#151`
+
+Docs to verify:
+
+- `docs/how-to/source-document-features.md`
+- `docs/how-to/configuration.md`
+- `specs/agent-skills-protocol-support-spec.md`
+
+Manual checks:
+
+1. Ingest and retrieve a legacy single-file skill and an Agent Skills package and verify both appear in `skills_check`.
+2. Retrieve a package resource with `get_skill_resource` and verify truncation rules and metadata are correct.
+3. Confirm startup grounding records skill discovery provenance and that the envelopes are inspectable later.
+4. Ask for a workflow that needs `expand_evidence` and verify local-only tool execution works without remote tool-manager routing failures.
+5. Verify script, text asset, and helper-file references from a skill package remain retrieval-only and are not executed implicitly.
+
+Edge cases:
+
+- skill package missing `SKILL.md`
+- large resource file hitting the character budget
+- duplicate skill names across legacy and package formats
+- skill retrieval with no query vs tight query
+
+## 8. Source Documents, Front Matter, and Ingestion Identity
+
+Related changes: `#137`, `#138`, `#146`, `#153`
+
+Docs to verify:
+
+- `docs/how-to/pipelines.md`
+- `docs/how-to/source-document-features.md`
+
+Manual checks:
+
+1. Add a new markdown document under `source_documents/`, run `prepare_sources`, then ingest and verify it appears in retrieval.
+2. Update the same file in place and verify the change is treated as an update, not a duplicate insert.
+3. Rename or move the file and verify path-based identity handling produces the expected add/update/delete behavior.
+4. Delete a previously ingested source document and verify cleanup behavior is correct.
+5. Add front matter with explicit `url` and verify both the stored document and chunk metadata use that URL instead of a `file://` path.
+6. Mix standard docs, pinned docs, and skill packages under the source root and verify discovery still classifies them correctly.
+7. Run a long scrape/prepare flow and confirm progress visibility updates move forward without apparent stalls.
+
+Edge cases:
+
+- nested source roots
+- duplicate content at different paths
+- same path with changed frontmatter only
+- invalid frontmatter
+- explicit `url` present but blank or whitespace-only
+
+## 9. Mocked Eval Runtime, Reporting, and Comparison
+
+Related changes: `#144`, `#150`
+
+Docs to verify:
+
+- `docs/how-to/evals.md`
+- `docs/reference/cli.md`
+- `specs/mocked-agent-eval-system-spec.md`
+- `specs/eval-fixture-layout-spec.md`
+
+Manual checks:
+
+1. Run `eval list` and confirm scenario discovery matches the repo contents.
+2. Run one mocked scenario through the supported local workflow and verify reports are generated in the documented location.
+3. Run a live-suite command with the documented trigger settings and verify baseline policy handling is correct.
+4. Compare a candidate run against a baseline and verify both pass and fail paths are easy to interpret.
+5. Confirm scenarios that include skills or startup knowledge show the expected evidence provenance.
+
+Edge cases:
+
+- missing baseline artifact
+- missing scenario report in candidate output
+- scenario with retrieval disabled vs retrieval enabled
+- malformed scenario manifest
+
+## 10. Docker, UI Example, and Air-Gapped Deployment
+
+Related changes: `#125`, `#130`, `#140`, `#142`
+
+Docs to verify:
+
+- `docs/operations/docker-deployment.md`
+- `docs/operations/airgap-deployment.md`
+- `docs/ui/experimental.md`
+- `README.md`
+
+Manual checks:
+
+1. Build and start the local Docker stack and verify the UI, API, and supporting services come up cleanly.
+2. Run the `ui/example` dev flow and verify the example app builds, hot reloads, and exercises the updated form paths.
+3. Build the air-gap bundle with default options and verify both backend and UI images are present.
+4. Repeat the bundle build with `--skip-ui-image`, `--skip-artifacts`, custom tags, and optional push settings and verify the outputs match the docs.
+5. Pull and run the published UI air-gap image path described in docs and verify it serves correctly behind the compose profile.
+
+Edge cases:
+
+- npm patch drift after lockfile refresh
+- repeated docker rebuilds with cached layers
+- running the UI profile only
+- incomplete offline environment variables
+
+## 11. Documentation and Example Audit
+
+This is a cross-cutting exit gate for the entire release.
+
+Manual checks:
+
+1. For every feature area above, confirm at least one user-facing doc mentions the feature and links to the right command or API surface.
+2. Execute every newly added or materially changed command example in:
+   - `README.md`
+   - `docs/how-to/*.md`
+   - `docs/operations/*.md`
+   - `docs/ui/experimental.md`
+3. Flag examples that require unstated prerequisites, wrong paths, stale image tags, or incorrect trigger values.
+4. Verify generated references remain in sync with the implemented CLI and API.
+
+Exit criteria:
+
+- Every feature added since `v0.3.1` has at least one explicit manual QA pass.
+- Every changed example either runs as written or is documented as intentionally illustrative.
+- Any doc gaps are recorded as release blockers or immediate follow-up tasks.

--- a/tests/unit/api/test_threads_api.py
+++ b/tests/unit/api/test_threads_api.py
@@ -188,6 +188,7 @@ class TestThreadsAPI:
         assert resp.status_code == 200
         data = resp.json()
         assert data["pending_approval"]["approval_id"] == "approval-1"
+        assert data["task_id"] == "task-1"
         assert data["resume_supported"] is True
 
     def test_update_thread_not_found(self, client):

--- a/tests/unit/cli/test_cli_instances.py
+++ b/tests/unit/cli/test_cli_instances.py
@@ -1,5 +1,7 @@
 """Tests for the `instance` CLI command group."""
 
+import logging
+import os
 from unittest.mock import AsyncMock, patch
 
 from click.testing import CliRunner
@@ -50,6 +52,43 @@ def test_instances_list_json_with_item():
     assert result.exit_code == 0
     assert "redis-dev-123" in result.output
     assert "dev-cache" in result.output
+
+
+def test_instances_create_logs_exception_trace_when_debug_enabled(caplog):
+    runner = CliRunner()
+
+    with (
+        patch.dict(os.environ, {"LOG_LEVEL": "DEBUG"}, clear=False),
+        patch.object(
+            core_instances,
+            "get_instances",
+            new=AsyncMock(side_effect=RuntimeError("Connection failed")),
+        ),
+        caplog.at_level(logging.DEBUG),
+    ):
+        result = runner.invoke(
+            instance,
+            [
+                "create",
+                "--name",
+                "dev-cache",
+                "--connection-url",
+                "redis://localhost:6380/0",
+                "--environment",
+                "development",
+                "--usage",
+                "cache",
+                "--description",
+                "Dev cache",
+            ],
+        )
+
+    assert result.exit_code == 0
+    assert "❌ Error: Connection failed" in result.output
+    assert any(
+        record.getMessage() == "instance CLI command failed" and record.exc_info
+        for record in caplog.records
+    )
 
 
 def test_instance_update_set_extension_data():

--- a/tests/unit/cli/test_cli_logging_utils.py
+++ b/tests/unit/cli/test_cli_logging_utils.py
@@ -1,0 +1,48 @@
+"""Tests for shared CLI logging helpers."""
+
+import logging
+import os
+from unittest.mock import patch
+
+import click
+import pytest
+
+from redis_sre_agent.cli.logging_utils import log_cli_exception
+from redis_sre_agent.cli.main import LazyGroup
+
+
+def test_log_cli_exception_uses_explicit_exception_info_outside_except(caplog):
+    try:
+        raise RuntimeError("boom")
+    except RuntimeError as exc:
+        captured = exc
+
+    with (
+        patch.dict(os.environ, {"LOG_LEVEL": "DEBUG"}, clear=False),
+        caplog.at_level(logging.DEBUG),
+    ):
+        log_cli_exception(__name__, "debug failure", captured)
+
+    record = next(record for record in caplog.records if record.getMessage() == "debug failure")
+    assert record.exc_info is not None
+    assert record.exc_info[1] is captured
+
+
+def test_lazy_group_skips_duplicate_logging_for_already_logged_exception():
+    group = LazyGroup(name="test")
+    ctx = click.Context(group)
+
+    try:
+        raise RuntimeError("boom")
+    except RuntimeError as exc:
+        captured = exc
+
+    with patch.dict(os.environ, {"LOG_LEVEL": "DEBUG"}, clear=False):
+        log_cli_exception(__name__, "command failure", captured)
+
+        with patch("redis_sre_agent.cli.main.log_cli_exception") as mock_log:
+            with patch.object(click.MultiCommand, "invoke", side_effect=captured):
+                with pytest.raises(RuntimeError, match="boom"):
+                    group.invoke(ctx)
+
+    mock_log.assert_not_called()

--- a/ui/src/components/TaskMonitor.tsx
+++ b/ui/src/components/TaskMonitor.tsx
@@ -1,6 +1,8 @@
 import React, { useState, useEffect, useRef } from "react";
 import ReactMarkdown from "react-markdown";
-import sreAgentApi from "../services/sreAgentApi";
+import sreAgentApi, {
+  PendingApprovalSummary,
+} from "../services/sreAgentApi";
 
 interface TaskUpdate {
   timestamp: string;
@@ -25,6 +27,10 @@ interface TaskMonitorProps {
   initialQuery?: string;
   onStatusChange?: (status: string) => void;
   onCompleted?: (info: { status: string; response?: string }) => void;
+  onApprovalStateChange?: (
+    pendingApproval: PendingApprovalSummary | null,
+    resumeSupported: boolean,
+  ) => void;
 }
 
 const TaskMonitor: React.FC<TaskMonitorProps> = ({
@@ -32,6 +38,7 @@ const TaskMonitor: React.FC<TaskMonitorProps> = ({
   initialQuery,
   onStatusChange,
   onCompleted,
+  onApprovalStateChange,
 }) => {
   const [isConnected, setIsConnected] = useState(false);
   const [connectionError, setConnectionError] = useState<string | null>(null);
@@ -41,7 +48,9 @@ const TaskMonitor: React.FC<TaskMonitorProps> = ({
 
   const wsRef = useRef<WebSocket | null>(null);
   const messagesEndRef = useRef<HTMLDivElement>(null);
-  const reconnectTimeoutRef = useRef<number | null>(null);
+  const reconnectTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null,
+  );
   const lastMessageIdRef = useRef<string | null>(null);
   const lastRenderTimeRef = useRef<number>(0);
   const isIntentionalCloseRef = useRef<boolean>(false);
@@ -205,12 +214,21 @@ const TaskMonitor: React.FC<TaskMonitorProps> = ({
             : "in_progress";
       }
 
+      onApprovalStateChange?.(
+        taskStatus.pending_approval || null,
+        Boolean(taskStatus.resume_supported),
+      );
       setCurrentStatus(derivedStatus);
       onStatusChange?.(derivedStatus);
       const inProgress = ["queued", "in_progress", "running"].includes(
         derivedStatus,
       );
       setIsThinking(inProgress);
+
+      if (derivedStatus === "awaiting_approval") {
+        disconnect();
+        return;
+      }
 
       // If complete, notify parent and disconnect
       if (

--- a/ui/src/pages/Dashboard.tsx
+++ b/ui/src/pages/Dashboard.tsx
@@ -11,33 +11,12 @@ import {
 } from "@radar/ui-kit";
 import {
   sreAgentApi,
+  type KnowledgeStatsResponse,
   type TaskStatusResponse,
   type RedisInstance,
+  type SystemHealthResponse,
 } from "../services/sreAgentApi";
 import { maskRedisUrl } from "../utils/urlMasking";
-
-interface KnowledgeStats {
-  total_documents: number;
-  total_chunks: number;
-  last_ingestion: string | null;
-  ingestion_status: "idle" | "running" | "error";
-  document_types: Record<string, number>;
-  storage_size_mb: number;
-}
-
-interface SystemHealth {
-  status: string;
-  components: {
-    redis_connection: string;
-    vectorizer: string;
-    indices_created: string;
-    vector_search: string;
-    task_system: string;
-    workers: string;
-  };
-  timestamp: string;
-  version: string;
-}
 
 interface ConversationThread {
   id: string;
@@ -57,10 +36,10 @@ const Dashboard = () => {
   // Data states
   const [conversations, setConversations] = useState<ConversationThread[]>([]);
   const [instances, setInstances] = useState<RedisInstance[]>([]);
-  const [knowledgeStats, setKnowledgeStats] = useState<KnowledgeStats | null>(
+  const [knowledgeStats, setKnowledgeStats] = useState<KnowledgeStatsResponse | null>(
     null,
   );
-  const [systemHealth, setSystemHealth] = useState<SystemHealth | null>(null);
+  const [systemHealth, setSystemHealth] = useState<SystemHealthResponse | null>(null);
 
   const loadDashboardData = async () => {
     setError("");

--- a/ui/src/pages/Triage.tsx
+++ b/ui/src/pages/Triage.tsx
@@ -4,7 +4,12 @@ import { Card, CardHeader, CardContent, Button } from "@radar/ui-kit";
 import { ConfirmDialog } from "../components/Modal";
 import ReactMarkdown from "react-markdown";
 import TaskMonitor from "../components/TaskMonitor";
-import sreAgentApi, { RedisCluster, RedisInstance } from "../services/sreAgentApi";
+import sreAgentApi, {
+  ApprovalRecord,
+  PendingApprovalSummary,
+  RedisCluster,
+  RedisInstance,
+} from "../services/sreAgentApi";
 
 // Simple fallback components for missing UI kit components
 const Loader = ({ size = "md" }: { size?: "sm" | "md" | "lg" }) => (
@@ -86,6 +91,13 @@ const Triage = () => {
   const [isThinking, setIsThinking] = useState(false);
   const [showWebSocketMonitor, setShowWebSocketMonitor] = useState(false);
   const [isThreadBusy, setIsThreadBusy] = useState(false);
+  const [activeTaskId, setActiveTaskId] = useState<string | null>(null);
+  const [pendingApproval, setPendingApproval] =
+    useState<PendingApprovalSummary | null>(null);
+  const [resumeSupported, setResumeSupported] = useState(false);
+  const [approvalHistory, setApprovalHistory] = useState<ApprovalRecord[]>([]);
+  const [approvalComment, setApprovalComment] = useState("");
+  const [isSubmittingApproval, setIsSubmittingApproval] = useState(false);
 
   const [liveModeLocked, setLiveModeLocked] = useState(false);
   const [expandedCitations, setExpandedCitations] = useState<Set<string>>(
@@ -120,7 +132,10 @@ const Triage = () => {
       /^\*\*(Sources for previous response|Discovered context|Startup context loaded)\*\*\n?/,
       "",
     );
-  const pollingIntervalRef = useRef<number | null>(null);
+  const pollingIntervalRef = useRef<ReturnType<typeof setInterval> | null>(
+    null,
+  );
+  const approvalBlocked = Boolean(pendingApproval && resumeSupported);
 
   const userId = "sre-user-1"; // In a real app, this would come from auth
 
@@ -473,6 +488,11 @@ const Triage = () => {
     setError("");
     setShowNewConversation(true);
     setShowWebSocketMonitor(false);
+    setActiveTaskId(null);
+    setPendingApproval(null);
+    setResumeSupported(false);
+    setApprovalHistory([]);
+    setApprovalComment("");
 
     // Clear any `thread` query parameter from the URL so that the page
     // no longer treats an existing thread as selected. Without this, the
@@ -525,6 +545,11 @@ const Triage = () => {
     setShowNewConversation(false);
     setLiveModeLocked(sidebarActive);
     setShowWebSocketMonitor(sidebarActive);
+    setActiveTaskId(null);
+    setPendingApproval(null);
+    setResumeSupported(false);
+    setApprovalHistory([]);
+    setApprovalComment("");
 
     // On mobile only, switch to chat view
     if (window.innerWidth < 768) {
@@ -580,10 +605,55 @@ const Triage = () => {
         status.status as any,
       );
       setIsThreadBusy(active);
+      setActiveTaskId(status.task_id || null);
+      setPendingApproval(status.pending_approval || null);
+      setResumeSupported(Boolean(status.resume_supported));
+      if (status.task_id) {
+        const approvals = await sreAgentApi.getTaskApprovals(status.task_id);
+        setApprovalHistory(approvals);
+      } else {
+        setApprovalHistory([]);
+      }
       if (!liveModeLocked) setShowWebSocketMonitor(active);
     } catch (err) {
       console.warn("Could not load thread status:", err);
       setIsThreadBusy(false);
+      setActiveTaskId(null);
+      setPendingApproval(null);
+      setResumeSupported(false);
+      setApprovalHistory([]);
+    }
+  };
+
+  const handleApprovalDecision = async (decision: "approved" | "rejected") => {
+    if (!activeTaskId || !pendingApproval || !resumeSupported) {
+      return;
+    }
+
+    setIsSubmittingApproval(true);
+    setError("");
+
+    try {
+      await sreAgentApi.resumeTask(activeTaskId, {
+        approval_id: pendingApproval.approval_id,
+        decision,
+        decision_by: userId,
+        decision_comment: approvalComment.trim() || undefined,
+      });
+
+      setPendingApproval(null);
+      setResumeSupported(false);
+      setApprovalComment("");
+      await loadThreads();
+      if (activeThreadId) {
+        await selectThread(activeThreadId);
+      }
+    } catch (err) {
+      setError(
+        `Failed to submit approval decision: ${err instanceof Error ? err.message : "Unknown error"}`,
+      );
+    } finally {
+      setIsSubmittingApproval(false);
     }
   };
 
@@ -612,6 +682,14 @@ const Triage = () => {
         return;
       }
 
+      if (activeThreadId && approvalBlocked) {
+        setError(
+          "This task is waiting for human approval. Resume through the API until UI approval actions are added.",
+        );
+        setIsLoading(false);
+        return;
+      }
+
       // If no active thread, create a new one
       if (!activeThreadId) {
         const triageResponse = await sreAgentApi.startNewConversation(
@@ -632,6 +710,11 @@ const Triage = () => {
         sessionStorage.setItem(`thread-${threadId}-query`, messageContent);
         setShowWebSocketMonitor(true);
         setIsThreadBusy(true);
+        setActiveTaskId(null);
+        setPendingApproval(null);
+        setResumeSupported(false);
+        setApprovalHistory([]);
+        setApprovalComment("");
 
         // Add new thread to the list
         const resolvedInstanceName = selectedInstanceId
@@ -677,6 +760,11 @@ const Triage = () => {
         setShowWebSocketMonitor(true);
         setIsThreadBusy(true);
         setLiveModeLocked(true);
+        setActiveTaskId(null);
+        setPendingApproval(null);
+        setResumeSupported(false);
+        setApprovalHistory([]);
+        setApprovalComment("");
       }
 
       // WebSocket will handle updates - reset loading state after API call succeeds
@@ -712,6 +800,11 @@ const Triage = () => {
         setMessages([]);
         setError("");
         setIsPolling(false);
+        setActiveTaskId(null);
+        setPendingApproval(null);
+        setResumeSupported(false);
+        setApprovalHistory([]);
+        setApprovalComment("");
 
         // Stop polling
         if (pollingIntervalRef.current) {
@@ -1048,12 +1141,37 @@ const Triage = () => {
                         if (active) {
                           setShowWebSocketMonitor(true);
                           setLiveModeLocked(true);
+                        } else if (status === "awaiting_approval") {
+                          setIsThreadBusy(false);
+                          setShowWebSocketMonitor(false);
+                          setLiveModeLocked(false);
+                        }
+                      }}
+                      onApprovalStateChange={async (
+                        nextPendingApproval,
+                        nextResumeSupported,
+                      ) => {
+                        setPendingApproval(nextPendingApproval);
+                        setResumeSupported(nextResumeSupported);
+                        if (nextPendingApproval && nextResumeSupported) {
+                          setIsThreadBusy(false);
+                          setShowWebSocketMonitor(false);
+                          setLiveModeLocked(false);
+                          await loadThreads();
+                          if (activeThreadId) {
+                            await selectThread(activeThreadId);
+                          }
                         }
                       }}
                       onCompleted={async () => {
                         setIsThreadBusy(false);
                         setLiveModeLocked(false);
                         setShowWebSocketMonitor(false);
+                        setActiveTaskId(null);
+                        setPendingApproval(null);
+                        setResumeSupported(false);
+                        setApprovalHistory([]);
+                        setApprovalComment("");
                         await loadThreads();
                         if (activeThreadId) {
                           await selectThread(activeThreadId);
@@ -1062,6 +1180,110 @@ const Triage = () => {
                     />
                   ) : (
                     <div className="h-full overflow-y-auto p-4 space-y-4">
+                      {approvalBlocked && pendingApproval && (
+                        <div className="rounded-redis-md border border-amber-300 bg-amber-50 px-4 py-3 text-amber-950">
+                          <div className="text-redis-sm font-semibold">
+                            Approval required
+                          </div>
+                          <div className="mt-1 text-redis-sm">
+                            This task is paused waiting for human approval to
+                            continue: {pendingApproval.summary}
+                          </div>
+                          <div className="mt-2 text-redis-xs text-amber-900">
+                            Requested{" "}
+                            {new Date(
+                              pendingApproval.requested_at,
+                            ).toLocaleString()}
+                            {pendingApproval.expires_at
+                              ? ` • Expires ${new Date(
+                                  pendingApproval.expires_at,
+                                ).toLocaleString()}`
+                              : ""}
+                          </div>
+                          <div className="mt-2 text-redis-xs text-amber-900">
+                            Review the pending action, optionally add a comment,
+                            then approve or reject it here to resume the task.
+                          </div>
+                          {activeTaskId && (
+                            <>
+                              {approvalHistory.length > 0 && (
+                                <div className="mt-3 rounded-redis-sm border border-amber-200 bg-white/60 p-3">
+                                  <div className="text-redis-xs font-semibold uppercase tracking-wide text-amber-900">
+                                    Approval history
+                                  </div>
+                                  <div className="mt-2 space-y-2">
+                                    {approvalHistory.map((approval) => (
+                                      <div
+                                        key={approval.approval_id}
+                                        className="text-redis-xs text-amber-950"
+                                      >
+                                        <div className="font-medium">
+                                          {approval.tool_name}
+                                        </div>
+                                        <div>
+                                          Status: {approval.status}
+                                          {approval.decision?.decision_by
+                                            ? ` • By ${approval.decision.decision_by}`
+                                            : ""}
+                                        </div>
+                                        <div>
+                                          Requested{" "}
+                                          {new Date(
+                                            approval.requested_at,
+                                          ).toLocaleString()}
+                                        </div>
+                                        {approval.decision?.decision_comment && (
+                                          <div>
+                                            Comment:{" "}
+                                            {approval.decision.decision_comment}
+                                          </div>
+                                        )}
+                                      </div>
+                                    ))}
+                                  </div>
+                                </div>
+                              )}
+                              <div className="mt-3 space-y-2">
+                                <label className="block text-redis-xs font-semibold uppercase tracking-wide text-amber-900">
+                                  Decision comment
+                                </label>
+                                <textarea
+                                  value={approvalComment}
+                                  onChange={(e) =>
+                                    setApprovalComment(e.target.value)
+                                  }
+                                  placeholder="Optional comment for the approval record"
+                                  className="w-full rounded-redis-sm border border-amber-300 bg-white px-3 py-2 text-redis-sm text-foreground focus:outline-none focus:ring-2 focus:ring-amber-400"
+                                  rows={3}
+                                  disabled={isSubmittingApproval}
+                                />
+                                <div className="flex gap-2">
+                                  <Button
+                                    variant="primary"
+                                    onClick={() =>
+                                      handleApprovalDecision("approved")
+                                    }
+                                    disabled={isSubmittingApproval}
+                                  >
+                                    {isSubmittingApproval
+                                      ? "Submitting..."
+                                      : "Approve and Resume"}
+                                  </Button>
+                                  <Button
+                                    variant="outline"
+                                    onClick={() =>
+                                      handleApprovalDecision("rejected")
+                                    }
+                                    disabled={isSubmittingApproval}
+                                  >
+                                    Reject
+                                  </Button>
+                                </div>
+                              </div>
+                            </>
+                          )}
+                        </div>
+                      )}
                       {messages.length === 0 ? (
                         <div className="text-redis-sm text-redis-dusk-04">
                           No messages yet for this conversation.
@@ -1226,10 +1448,16 @@ const Triage = () => {
                       value={inputMessage}
                       onChange={(e) => setInputMessage(e.target.value)}
                       onKeyPress={handleKeyPress}
-                      placeholder="Continue the conversation..."
+                      placeholder={
+                        approvalBlocked
+                          ? "Approval required before this conversation can continue"
+                          : "Continue the conversation..."
+                      }
                       className="flex-1 p-3 border border-redis-dusk-06 rounded-redis-sm resize-none focus:outline-none focus:ring-2 focus:ring-redis-blue-03 focus:border-transparent min-h-[60px]"
                       rows={2}
-                      disabled={isLoading || agentStatus !== "available"}
+                      disabled={
+                        isLoading || agentStatus !== "available" || approvalBlocked
+                      }
                     />
                     {isThreadBusy ? (
                       <Button
@@ -1238,6 +1466,10 @@ const Triage = () => {
                         className="self-end"
                       >
                         Stop
+                      </Button>
+                    ) : approvalBlocked ? (
+                      <Button variant="outline" disabled className="self-end">
+                        Use Approval Controls Above
                       </Button>
                     ) : (
                       <Button
@@ -1255,7 +1487,9 @@ const Triage = () => {
                     )}
                   </div>
                   <div className="text-redis-xs text-redis-dusk-04 mt-2">
-                    {isThreadBusy
+                    {approvalBlocked
+                      ? "This task is paused for approval. Use the approval controls above to approve or reject it."
+                      : isThreadBusy
                       ? "Task is running — press Stop to cancel before sending a new message."
                       : agentStatus === "available"
                         ? "Press Enter to send, Shift+Enter for new line"

--- a/ui/src/pages/Triage.tsx
+++ b/ui/src/pages/Triage.tsx
@@ -139,6 +139,14 @@ const Triage = () => {
 
   const userId = "sre-user-1"; // In a real app, this would come from auth
 
+  const resetApprovalState = () => {
+    setActiveTaskId(null);
+    setPendingApproval(null);
+    setResumeSupported(false);
+    setApprovalHistory([]);
+    setApprovalComment("");
+  };
+
   const scrollToBottom = () => {
     messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
   };
@@ -488,11 +496,7 @@ const Triage = () => {
     setError("");
     setShowNewConversation(true);
     setShowWebSocketMonitor(false);
-    setActiveTaskId(null);
-    setPendingApproval(null);
-    setResumeSupported(false);
-    setApprovalHistory([]);
-    setApprovalComment("");
+    resetApprovalState();
 
     // Clear any `thread` query parameter from the URL so that the page
     // no longer treats an existing thread as selected. Without this, the
@@ -545,11 +549,7 @@ const Triage = () => {
     setShowNewConversation(false);
     setLiveModeLocked(sidebarActive);
     setShowWebSocketMonitor(sidebarActive);
-    setActiveTaskId(null);
-    setPendingApproval(null);
-    setResumeSupported(false);
-    setApprovalHistory([]);
-    setApprovalComment("");
+    resetApprovalState();
 
     // On mobile only, switch to chat view
     if (window.innerWidth < 768) {
@@ -618,10 +618,7 @@ const Triage = () => {
     } catch (err) {
       console.warn("Could not load thread status:", err);
       setIsThreadBusy(false);
-      setActiveTaskId(null);
-      setPendingApproval(null);
-      setResumeSupported(false);
-      setApprovalHistory([]);
+      resetApprovalState();
     }
   };
 
@@ -710,11 +707,7 @@ const Triage = () => {
         sessionStorage.setItem(`thread-${threadId}-query`, messageContent);
         setShowWebSocketMonitor(true);
         setIsThreadBusy(true);
-        setActiveTaskId(null);
-        setPendingApproval(null);
-        setResumeSupported(false);
-        setApprovalHistory([]);
-        setApprovalComment("");
+        resetApprovalState();
 
         // Add new thread to the list
         const resolvedInstanceName = selectedInstanceId
@@ -760,11 +753,7 @@ const Triage = () => {
         setShowWebSocketMonitor(true);
         setIsThreadBusy(true);
         setLiveModeLocked(true);
-        setActiveTaskId(null);
-        setPendingApproval(null);
-        setResumeSupported(false);
-        setApprovalHistory([]);
-        setApprovalComment("");
+        resetApprovalState();
       }
 
       // WebSocket will handle updates - reset loading state after API call succeeds
@@ -800,11 +789,7 @@ const Triage = () => {
         setMessages([]);
         setError("");
         setIsPolling(false);
-        setActiveTaskId(null);
-        setPendingApproval(null);
-        setResumeSupported(false);
-        setApprovalHistory([]);
-        setApprovalComment("");
+        resetApprovalState();
 
         // Stop polling
         if (pollingIntervalRef.current) {
@@ -1167,11 +1152,7 @@ const Triage = () => {
                         setIsThreadBusy(false);
                         setLiveModeLocked(false);
                         setShowWebSocketMonitor(false);
-                        setActiveTaskId(null);
-                        setPendingApproval(null);
-                        setResumeSupported(false);
-                        setApprovalHistory([]);
-                        setApprovalComment("");
+                        resetApprovalState();
                         await loadThreads();
                         if (activeThreadId) {
                           await selectThread(activeThreadId);

--- a/ui/src/pages/Triage.tsx
+++ b/ui/src/pages/Triage.tsx
@@ -684,7 +684,7 @@ const Triage = () => {
 
       if (activeThreadId && approvalBlocked) {
         setError(
-          "This task is waiting for human approval. Resume through the API until UI approval actions are added.",
+          "This task is waiting for human approval. Use the approval controls above to approve or reject it before continuing.",
         );
         setIsLoading(false);
         return;

--- a/ui/src/services/sreAgentApi.ts
+++ b/ui/src/services/sreAgentApi.ts
@@ -12,11 +12,50 @@ export interface TaskUpdate {
   metadata: Record<string, any>;
 }
 
+export interface PendingApprovalSummary {
+  approval_id: string;
+  interrupt_id: string;
+  tool_name: string;
+  summary: string;
+  requested_at: string;
+  expires_at?: string | null;
+  status: "pending" | "approved" | "rejected" | "expired" | "superseded";
+}
+
+export interface ApprovalDecision {
+  decision: "approved" | "rejected";
+  decision_by?: string;
+  decision_comment?: string;
+  decision_at: string;
+}
+
+export interface ApprovalRecord {
+  approval_id: string;
+  task_id: string;
+  thread_id: string;
+  graph_thread_id: string;
+  interrupt_id: string;
+  graph_type: string;
+  graph_version: string;
+  tool_name: string;
+  tool_args: Record<string, any>;
+  tool_args_preview: Record<string, any>;
+  action_kind: string;
+  action_hash: string;
+  target_handles: string[];
+  status: "pending" | "approved" | "rejected" | "expired" | "superseded";
+  requested_at: string;
+  expires_at?: string | null;
+  decision?: ApprovalDecision | null;
+}
+
 export interface TaskStatusResponse {
   thread_id: string;
+  task_id?: string;
   status:
     | "queued"
     | "in_progress"
+    | "awaiting_approval"
     | "completed"
     | "done"
     | "failed"
@@ -31,6 +70,8 @@ export interface TaskStatusResponse {
   updates: TaskUpdate[];
   result?: Record<string, any>;
   error_message?: string;
+  pending_approval?: PendingApprovalSummary | null;
+  resume_supported: boolean;
   metadata: {
     created_at: string;
     updated_at: string;
@@ -63,6 +104,13 @@ export interface ThreadSummary {
   cluster_id?: string;
   // Optional count of user/assistant messages, provided by backend when available
   message_count?: number;
+}
+
+export interface TaskResumeRequest {
+  approval_id: string;
+  decision: "approved" | "rejected";
+  decision_by?: string;
+  decision_comment?: string;
 }
 
 export interface RedisInstance {
@@ -216,6 +264,30 @@ export interface ClusterListResponse {
   total: number;
   limit: number;
   offset: number;
+}
+
+export interface KnowledgeStatsResponse {
+  total_documents: number;
+  total_chunks: number;
+  last_ingestion: string | null;
+  ingestion_status: "idle" | "running" | "error";
+  document_types: Record<string, number>;
+  storage_size_mb: number;
+}
+
+export interface SystemHealthResponse {
+  status: string;
+  components: {
+    redis_connection: string;
+    vectorizer: string;
+    indices_created: string;
+    vector_search: string;
+    task_system: string;
+    workers: string;
+    [key: string]: string;
+  };
+  timestamp: string;
+  version: string;
 }
 
 export interface CreateClusterRequest {
@@ -439,6 +511,7 @@ class SREAgentAPI {
 
     return {
       thread_id: thread.thread_id,
+      task_id: thread.task_id,
       status,
       messages: messages.map((m: any) => ({
         role: m.role,
@@ -456,6 +529,8 @@ class SREAgentAPI {
         : [],
       result: thread.result,
       error_message: thread.error_message,
+      pending_approval: thread.pending_approval || null,
+      resume_supported: Boolean(thread.resume_supported),
       metadata: {
         created_at: thread?.metadata?.created_at,
         updated_at: thread?.metadata?.updated_at,
@@ -467,6 +542,64 @@ class SREAgentAPI {
       },
       context: thread.context || {},
     } as TaskStatusResponse;
+  }
+
+  async getTaskApprovals(taskId: string): Promise<ApprovalRecord[]> {
+    const response = await fetch(`${this.tasksBaseUrl}/tasks/${taskId}/approvals`);
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`HTTP ${response.status}: ${errorText}`);
+    }
+
+    const data = await response.json();
+    return Array.isArray(data.approvals) ? data.approvals : [];
+  }
+
+  async resumeTask(
+    taskId: string,
+    request: TaskResumeRequest,
+  ): Promise<TaskStatusResponse> {
+    const response = await fetch(`${this.tasksBaseUrl}/tasks/${taskId}/resume`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(request),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`HTTP ${response.status}: ${errorText}`);
+    }
+
+    const task = await response.json();
+    return {
+      thread_id: task.thread_id,
+      task_id: task.task_id,
+      status: task.status,
+      messages: [],
+      updates: Array.isArray(task.updates)
+        ? task.updates.map((u: any) => ({
+            timestamp: u.timestamp,
+            message: u.message,
+            type: u.update_type || u.type,
+            metadata: u.metadata || {},
+          }))
+        : [],
+      result: task.result,
+      error_message: task.error_message,
+      pending_approval: task.pending_approval || null,
+      resume_supported: Boolean(task.resume_supported),
+      metadata: {
+        created_at: task.created_at,
+        updated_at: task.updated_at,
+        priority: 0,
+        tags: [],
+        subject: task.subject,
+      },
+      context: {},
+    };
   }
 
   async listTasks(
@@ -1113,16 +1246,20 @@ class SREAgentAPI {
   }
 
   // Knowledge Base Methods
-  async getKnowledgeStats(): Promise<{
-    total_documents: number;
-    total_chunks: number;
-    last_ingestion: string | null;
-  }> {
+  async getKnowledgeStats(): Promise<KnowledgeStatsResponse> {
     const response = await fetch(`${this.tasksBaseUrl}/knowledge/stats`);
     if (!response.ok) {
       throw new Error(`Failed to get knowledge stats: ${response.statusText}`);
     }
-    return response.json();
+    const data = await response.json();
+    return {
+      total_documents: data.total_documents ?? 0,
+      total_chunks: data.total_chunks ?? 0,
+      last_ingestion: data.last_ingestion ?? null,
+      ingestion_status: data.ingestion_status ?? "idle",
+      document_types: data.document_types ?? {},
+      storage_size_mb: data.storage_size_mb ?? 0,
+    };
   }
 
   async getKnowledgeJobs(): Promise<any[]> {
@@ -1196,16 +1333,27 @@ class SREAgentAPI {
   }
 
   // System Health Methods
-  async getSystemHealth(): Promise<{
-    status: string;
-    components: Record<string, string>;
-    version?: string;
-  }> {
+  async getSystemHealth(): Promise<SystemHealthResponse> {
     const response = await fetch(`${this.tasksBaseUrl}/health`);
     if (!response.ok) {
       throw new Error(`Failed to get system health: ${response.statusText}`);
     }
-    return response.json();
+    const data = await response.json();
+    const components = data.components || {};
+    return {
+      status: data.status ?? "unknown",
+      components: {
+        redis_connection: components.redis_connection ?? "unknown",
+        vectorizer: components.vectorizer ?? "unknown",
+        indices_created: components.indices_created ?? "unknown",
+        vector_search: components.vector_search ?? "unknown",
+        task_system: components.task_system ?? "unknown",
+        workers: components.workers ?? "unknown",
+        ...components,
+      },
+      timestamp: data.timestamp ?? new Date().toISOString(),
+      version: data.version ?? "unknown",
+    };
   }
 
   // Schedule Methods

--- a/ui/src/services/sreAgentApi.ts
+++ b/ui/src/services/sreAgentApi.ts
@@ -1343,13 +1343,13 @@ class SREAgentAPI {
     return {
       status: data.status ?? "unknown",
       components: {
+        ...components,
         redis_connection: components.redis_connection ?? "unknown",
         vectorizer: components.vectorizer ?? "unknown",
         indices_created: components.indices_created ?? "unknown",
         vector_search: components.vector_search ?? "unknown",
         task_system: components.task_system ?? "unknown",
         workers: components.workers ?? "unknown",
-        ...components,
       },
       timestamp: data.timestamp ?? new Date().toISOString(),
       version: data.version ?? "unknown",

--- a/ui/src/vite-env.d.ts
+++ b/ui/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />


### PR DESCRIPTION
## Summary
- add approval state and approve/reject flows to the triage UI
- document target discovery, approvals, eval behavior, and source frontmatter URLs
- log CLI and helper exceptions when `LOG_LEVEL=DEBUG` is enabled
- include the 0.4.0 manual QA plan artifact

## Verification
- `uv run pytest -q tests/unit/api/test_threads_api.py tests/unit/cli/test_cli_instances.py`
- `./node_modules/.bin/tsc --noEmit -p tsconfig.json`
- `npm run build`
- `make docs-build`
- pre-commit hooks during `git commit` (`ruff`, full `tests/unit`, `mkdocs build --strict`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches task/thread status surfaces and the triage UI control flow around `awaiting_approval`, so regressions could break live monitoring or resume handling. Logging/doc changes are low risk but widespread across CLI commands.
> 
> **Overview**
> Adds **human-in-the-loop approvals** to the web triage flow: the UI now detects `awaiting_approval`, stops live streaming, shows pending approval details + history, and allows approve/reject to resume the task via new API calls.
> 
> Extends the thread API payload to include the latest `task_id` (alongside `pending_approval`/`resume_supported`) so clients can link threads to approval state, and updates the UI API client/types accordingly.
> 
> Improves operability and docs: introduces shared CLI logging helpers that emit exception details only when `LOG_LEVEL` is set (with stack traces in DEBUG), upgrades several backend error logs to `logger.exception`, and expands how-to docs (target discovery, approvals, eval CLI behavior, source frontmatter `url`) plus a new `0.4.0` manual QA plan.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82f1ba72733cd3187997bd3bb849609b005339b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->