### PR TITLE
Fix air-gap UI startup and FAQ KB discovery

### DIFF
--- a/redis_sre_agent/pipelines/scraper/redis_kb.py
+++ b/redis_sre_agent/pipelines/scraper/redis_kb.py
@@ -27,7 +27,7 @@ class RedisKBScraper(BaseScraper):
 
     def __init__(self, storage: ArtifactStorage, config: Optional[Dict[str, Any]] = None):
         default_config = {
-            "base_url": "https://redis.io/kb",
+            "base_url": "https://redis.io/faq",
             "timeout": 30,
             "delay_between_requests": 1.0,
             "max_concurrent_requests": 5,
@@ -75,6 +75,11 @@ class RedisKBScraper(BaseScraper):
             await self._discover_kb_urls()
 
             self.logger.info(f"Found {len(self.url_to_categories)} KB articles to scrape")
+            if not self.url_to_categories:
+                self.logger.warning(
+                    "Redis KB discovery returned no article URLs. "
+                    "The redis.io FAQ/KB site structure may have changed."
+                )
 
             # Step 2: Scrape articles with concurrency control
             # Product labels are extracted from each article page (authoritative source)
@@ -147,7 +152,8 @@ class RedisKBScraper(BaseScraper):
 
         while page <= 20:  # Safety limit to prevent infinite loops
             try:
-                url = f"https://redis.io/kb/public?cat={category_id}&page={page}"
+                base_url = self.config["base_url"].rstrip("/")
+                url = f"{base_url}/public?cat={category_id}&page={page}"
                 self.logger.debug(f"Scraping {category_name} page {page}: {url}")
 
                 async with self.session.get(url) as response:
@@ -202,11 +208,15 @@ class RedisKBScraper(BaseScraper):
                 link = first_cell.find("a")
                 if link and link.get("href"):
                     href = link.get("href")
-                    # Only include KB article links
-                    if "/kb/doc/" in href:
+                    if self._is_article_href(href):
                         article_links.append(href)
 
         return article_links
+
+    @staticmethod
+    def _is_article_href(href: str) -> bool:
+        """Return True when an href points to a Redis FAQ/KB article."""
+        return "/kb/doc/" in href or "/faq/doc/" in href
 
     def _has_next_page(self, soup: BeautifulSoup, current_page: int) -> bool:
         """Check if there's a next page in the pagination."""

--- a/tests/unit/pipelines/scraper/test_redis_kb_scraper.py
+++ b/tests/unit/pipelines/scraper/test_redis_kb_scraper.py
@@ -215,30 +215,47 @@ class TestRedisKBScraper:
 
     def test_url_filtering_logic(self, scraper):
         """Test URL filtering logic for KB articles."""
-        # Test the URL filtering logic that would be used in search API discovery
         test_results = [
             {"url": "/kb/doc/article1", "title": "Article 1"},
+            {"url": "/faq/doc/article-faq", "title": "FAQ Article"},
             {"url": "/kb/doc/article2", "title": "Article 2"},
             {"url": "/docs/other", "title": "Other Doc"},  # Should be ignored
             {"url": "/kb/doc/article3", "title": "Article 3"},
         ]
 
-        # Simulate the filtering logic from _discover_through_search_api
         discovered_urls = set()
         for result in test_results:
-            if "url" in result and "/kb/doc/" in result["url"]:
+            if "url" in result and scraper._is_article_href(result["url"]):
                 from urllib.parse import urljoin
 
                 full_url = urljoin("https://redis.io", result["url"])
                 discovered_urls.add(full_url)
 
-        # Should have discovered 3 KB articles
-        kb_urls = [url for url in discovered_urls if "/kb/doc/" in url]
-        assert len(kb_urls) == 3
+        # Should have discovered 4 KB/FAQ articles
+        article_urls = [url for url in discovered_urls if "/kb/doc/" in url or "/faq/doc/" in url]
+        assert len(article_urls) == 4
         assert "https://redis.io/kb/doc/article1" in discovered_urls
+        assert "https://redis.io/faq/doc/article-faq" in discovered_urls
         assert "https://redis.io/kb/doc/article2" in discovered_urls
         assert "https://redis.io/kb/doc/article3" in discovered_urls
         assert "https://redis.io/docs/other" not in discovered_urls
+
+    def test_extract_article_links_accepts_faq_redirect_links(self, scraper):
+        """FAQ article links should still be accepted after the redis.io redirect."""
+        html_content = """
+        <table>
+            <tr><td><a href="/faq/doc/faq-article">FAQ Article</a></td></tr>
+            <tr><td><a href="/kb/doc/kb-article">KB Article</a></td></tr>
+            <tr><td><a href="/docs/other">Other Doc</a></td></tr>
+        </table>
+        """
+
+        soup = BeautifulSoup(html_content, "html.parser")
+
+        assert scraper._extract_article_links_from_page(soup) == [
+            "/faq/doc/faq-article",
+            "/kb/doc/kb-article",
+        ]
 
     @pytest.mark.asyncio
     async def test_error_handling(self, scraper):

--- a/ui/nginx.conf
+++ b/ui/nginx.conf
@@ -3,6 +3,7 @@ server {
     server_name localhost;
     root /usr/share/nginx/html;
     index index.html;
+    set $sre_ui_api_upstream ${SRE_UI_API_UPSTREAM};
 
     # Enable gzip compression
     gzip on;
@@ -25,7 +26,7 @@ server {
 
     # Proxy API requests to the backend
     location /api/ {
-        proxy_pass ${SRE_UI_API_UPSTREAM};
+        proxy_pass $sre_ui_api_upstream;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -41,7 +42,7 @@ server {
 
     # Proxy health check requests
     location /health {
-        proxy_pass ${SRE_UI_API_UPSTREAM};
+        proxy_pass $sre_ui_api_upstream;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -50,7 +51,7 @@ server {
 
     # Proxy metrics requests
     location /metrics {
-        proxy_pass ${SRE_UI_API_UPSTREAM};
+        proxy_pass $sre_ui_api_upstream;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/ui/nginx.conf
+++ b/ui/nginx.conf
@@ -3,6 +3,7 @@ server {
     server_name localhost;
     root /usr/share/nginx/html;
     index index.html;
+    resolver 127.0.0.11 valid=30s ipv6=off;
     set $sre_ui_api_upstream ${SRE_UI_API_UPSTREAM};
 
     # Enable gzip compression


### PR DESCRIPTION
## Summary
- stop the air-gap UI image from failing nginx startup when the backend hostname is unresolved at container boot
- update the `redis_kb` scraper to follow the current `redis.io/faq` path shape and accept `/faq/doc/...` article links
- add scraper coverage for both legacy `/kb/doc/...` and redirected `/faq/doc/...` article URLs

## Validation
- `uv run pytest -q tests/unit/pipelines/scraper/test_redis_kb_scraper.py`
- `docker build -t redis-sre-agent-ui:pr-airgap -f ui/Dockerfile --target production ./ui`
- `docker run --network none ... redis-sre-agent-ui:pr-airgap` and verified `/` serves HTML while `/api/v1/` returns `502` without crashing nginx

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates external-site scraping URL patterns and modifies Nginx proxy configuration; issues would mainly surface as missing scraped docs or UI backend proxy failures.
> 
> **Overview**
> Updates the Redis KB scraper to follow the current `https://redis.io/faq` structure: category pagination requests now build from configurable `base_url`, article-link filtering accepts both `/kb/doc/...` and redirected `/faq/doc/...`, and scraping logs a warning when discovery yields zero URLs.
> 
> Adjusts the UI `nginx.conf` to avoid startup failures when the backend hostname can’t be resolved at container boot (adds Docker DNS `resolver` and proxies via a variable-based upstream), and extends unit tests to cover the new FAQ URL handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7461a56a5f2caa12100fae7ebf60cabbb0def65. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->