### PR TITLE
Fix MCP input schema preservation

### DIFF
--- a/redis_sre_agent/tools/mcp/provider.py
+++ b/redis_sre_agent/tools/mcp/provider.py
@@ -33,6 +33,29 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def _coerce_input_schema_dict(input_schema: Any) -> Optional[Dict[str, Any]]:
+    """Normalize MCP input schemas into plain JSON-serializable dicts."""
+    if isinstance(input_schema, dict):
+        return dict(input_schema)
+    if hasattr(input_schema, "model_dump"):
+        try:
+            payload = input_schema.model_dump(mode="json")
+        except TypeError:
+            payload = input_schema.model_dump()
+        if isinstance(payload, dict):
+            return dict(payload)
+    if hasattr(input_schema, "dict"):
+        payload = input_schema.dict()
+        if isinstance(payload, dict):
+            return dict(payload)
+    if hasattr(input_schema, "items"):
+        try:
+            return dict(input_schema.items())
+        except Exception:
+            return None
+    return None
+
+
 class MCPToolProvider(ToolProvider):
     """Dynamic tool provider that connects to an MCP server.
 
@@ -342,7 +365,7 @@ class MCPToolProvider(ToolProvider):
             capability = self._get_capability(tool_name)
 
             # Build parameters schema from MCP tool input schema
-            input_schema = mcp_tool.inputSchema or {}
+            input_schema = _coerce_input_schema_dict(mcp_tool.inputSchema) or {}
             parameters = {
                 "type": "object",
                 "properties": input_schema.get("properties", {}),
@@ -356,6 +379,21 @@ class MCPToolProvider(ToolProvider):
                 parameters=parameters,
             )
             schemas.append(schema)
+
+        return schemas
+
+    def get_input_schemas(self) -> Dict[str, Dict[str, Any]]:
+        """Return raw input schemas keyed by original MCP tool name."""
+        schemas: Dict[str, Dict[str, Any]] = {}
+
+        for mcp_tool in self._mcp_tools:
+            tool_name = mcp_tool.name
+            if not tool_name or not self._should_include_tool(tool_name):
+                continue
+
+            input_schema = _coerce_input_schema_dict(getattr(mcp_tool, "inputSchema", None))
+            if input_schema is not None:
+                schemas[tool_name] = input_schema
 
         return schemas
 

--- a/tests/unit/tools/mcp_provider/test_mcp_provider.py
+++ b/tests/unit/tools/mcp_provider/test_mcp_provider.py
@@ -1,5 +1,6 @@
 """Unit tests for MCP tool provider."""
 
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
@@ -184,6 +185,82 @@ class TestMCPToolProviderAsync:
         # Without connecting, schemas should be empty
         schemas = provider.create_tool_schemas()
         assert schemas == []
+
+    @pytest.mark.asyncio
+    async def test_get_input_schemas_returns_raw_schema_by_operation_name(self):
+        """Test that raw MCP schemas stay keyed by original tool names."""
+        config = MCPServerConfig(
+            command="test",
+            tools={"file_write": MCPToolConfig()},
+        )
+        provider = MCPToolProvider(server_name="afs_gateway", server_config=config)
+        provider._mcp_tools = [
+            SimpleNamespace(
+                name="file_write",
+                description="Write a file",
+                inputSchema={
+                    "title": "file_writeArguments",
+                    "type": "object",
+                    "properties": {
+                        "path": {"type": "string", "title": "Path"},
+                        "content": {"type": "string", "title": "Content"},
+                    },
+                    "required": ["path", "content"],
+                    "additionalProperties": False,
+                },
+            )
+        ]
+
+        schemas = provider.get_input_schemas()
+
+        assert schemas == {
+            "file_write": {
+                "title": "file_writeArguments",
+                "type": "object",
+                "properties": {
+                    "path": {"type": "string", "title": "Path"},
+                    "content": {"type": "string", "title": "Content"},
+                },
+                "required": ["path", "content"],
+                "additionalProperties": False,
+            }
+        }
+
+    @pytest.mark.asyncio
+    async def test_get_input_schemas_coerces_model_like_input_schema(self):
+        """Test that MCP model objects are serialized into plain dict schemas."""
+        config = MCPServerConfig(
+            command="test",
+            tools={"analyzer_list_accounts": MCPToolConfig()},
+        )
+        provider = MCPToolProvider(server_name="re_analyzer", server_config=config)
+
+        class _SchemaModel:
+            def model_dump(self, mode: str = "json") -> dict[str, object]:
+                assert mode == "json"
+                return {
+                    "$schema": "http://json-schema.org/draft-07/schema#",
+                    "type": "object",
+                    "properties": {"limit": {"type": "integer"}},
+                }
+
+        provider._mcp_tools = [
+            SimpleNamespace(
+                name="analyzer_list_accounts",
+                description="List accounts",
+                inputSchema=_SchemaModel(),
+            )
+        ]
+
+        schemas = provider.get_input_schemas()
+
+        assert schemas == {
+            "analyzer_list_accounts": {
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "type": "object",
+                "properties": {"limit": {"type": "integer"}},
+            }
+        }
 
     @pytest.mark.asyncio
     async def test_call_mcp_tool_not_connected(self):


### PR DESCRIPTION
## Summary
- normalize MCP `inputSchema` payloads into plain dicts before building tool schemas
- add a raw `get_input_schemas()` path keyed by original MCP tool name
- cover both plain-dict and model-like schema payloads in MCP provider tests

## Why
Some MCP servers publish valid `inputSchema` values as model objects rather than plain dicts. The provider currently assumes dict semantics directly, which can drop published schemas in downstream runtime manifest assembly even when the server returned them correctly.

## Testing
- `uv run --project /Users/andrew.brookins/src/redis-sre-agent-mcp-schema-pr --group dev pytest --no-cov /Users/andrew.brookins/src/redis-sre-agent-mcp-schema-pr/tests/unit/tools/mcp_provider/test_mcp_provider.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how MCP `inputSchema` values are normalized and exposed, which can affect tool parameter validation/manifest generation for all MCP-backed tools. Risk is moderate due to potential schema-shape differences, but the change is localized and covered by new unit tests.
> 
> **Overview**
> **Preserves MCP tool `inputSchema` data when servers return model-like objects instead of plain dicts.** The provider now coerces `inputSchema` into a JSON-serializable dict before building `ToolDefinition.parameters`, avoiding dropped/empty schemas.
> 
> Adds `MCPToolProvider.get_input_schemas()` to return the *raw* (normalized) schemas keyed by the original MCP tool name (pre-provider prefix). Updates unit tests to cover both dict and model-style schema payloads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 869408a7d220ad594f810536e68969ab7e5f77d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->