### PR TITLE
Repair stale target discovery catalog

### DIFF
--- a/redis_sre_agent/api/app.py
+++ b/redis_sre_agent/api/app.py
@@ -24,6 +24,7 @@ from redis_sre_agent.core.migrations.instances_to_clusters import (
     run_instances_to_clusters_migration,
 )
 from redis_sre_agent.core.redis import initialize_redis
+from redis_sre_agent.core.targets import sync_target_catalog_from_authoritative_records
 from redis_sre_agent.observability.tracing import setup_tracing as setup_base_tracing
 from redis_sre_agent.tools.mcp.pool import MCPConnectionPool
 
@@ -112,6 +113,20 @@ async def lifespan(app: FastAPI):
         except Exception as e:
             logger.warning("Instance-cluster startup migration failed (continuing): %s", e)
             _app_startup_state["instance_cluster_migration"] = {"error": str(e)}
+
+        try:
+            authoritative_target_docs = await sync_target_catalog_from_authoritative_records()
+            _app_startup_state["target_catalog_sync"] = {
+                "status": "ok",
+                "target_count": len(authoritative_target_docs),
+            }
+            logger.info(
+                "Target catalog sync completed from authoritative records: %s targets",
+                len(authoritative_target_docs),
+            )
+        except Exception as e:
+            logger.warning("Target catalog startup sync failed (continuing): %s", e)
+            _app_startup_state["target_catalog_sync"] = {"error": str(e)}
 
         # Log configuration (mask Redis URL credentials)
         from redis_sre_agent.core.instances import mask_redis_url

--- a/redis_sre_agent/core/clusters.py
+++ b/redis_sre_agent/core/clusters.py
@@ -155,44 +155,52 @@ def _to_epoch(ts: Optional[str]) -> float:
             return 0.0
 
 
+async def _load_clusters_from_index() -> List[RedisCluster]:
+    """Load configured clusters directly from the clusters search index."""
+    await _ensure_clusters_index_exists()
+    index = await get_clusters_index()
+
+    try:
+        total = await index.query(CountQuery(filter_expression="*"))
+    except Exception:
+        total = 1000
+
+    if not total:
+        return []
+
+    q = FilterQuery(
+        filter_expression="*",
+        return_fields=["data"],
+        num_results=int(total) if isinstance(total, int) else 1000,
+    )
+    results = await index.query(q)
+
+    out: List[RedisCluster] = []
+    for doc in results or []:
+        try:
+            raw = doc.get("data")
+            if not raw:
+                continue
+            if isinstance(raw, bytes):
+                raw = raw.decode("utf-8")
+            cluster_data = json.loads(raw)
+            if cluster_data.get("admin_password"):
+                cluster_data["admin_password"] = get_secret_value(cluster_data["admin_password"])
+            out.append(RedisCluster(**cluster_data))
+        except Exception as e:
+            logger.exception("Failed to load cluster from search result: %s. Skipping.", e)
+    return out
+
+
+async def get_clusters_strict() -> List[RedisCluster]:
+    """Load configured clusters and surface transport/index failures to callers."""
+    return await _load_clusters_from_index()
+
+
 async def get_clusters() -> List[RedisCluster]:
     """Load configured clusters using a single FT.SEARCH over the clusters index."""
     try:
-        await _ensure_clusters_index_exists()
-        index = await get_clusters_index()
-
-        try:
-            total = await index.query(CountQuery(filter_expression="*"))
-        except Exception:
-            total = 1000
-
-        if not total:
-            return []
-
-        q = FilterQuery(
-            filter_expression="*",
-            return_fields=["data"],
-            num_results=int(total) if isinstance(total, int) else 1000,
-        )
-        results = await index.query(q)
-
-        out: List[RedisCluster] = []
-        for doc in results or []:
-            try:
-                raw = doc.get("data")
-                if not raw:
-                    continue
-                if isinstance(raw, bytes):
-                    raw = raw.decode("utf-8")
-                cluster_data = json.loads(raw)
-                if cluster_data.get("admin_password"):
-                    cluster_data["admin_password"] = get_secret_value(
-                        cluster_data["admin_password"]
-                    )
-                out.append(RedisCluster(**cluster_data))
-            except Exception as e:
-                logger.exception("Failed to load cluster from search result: %s. Skipping.", e)
-        return out
+        return await _load_clusters_from_index()
     except Exception as e:
         logger.exception("Failed to get clusters from Redis: %s", e)
         return []

--- a/redis_sre_agent/core/instances.py
+++ b/redis_sre_agent/core/instances.py
@@ -356,46 +356,55 @@ class RedisInstance(BaseModel):
             return None
 
 
+async def _load_instances_from_index() -> List[RedisInstance]:
+    """Load configured instances directly from the instances search index."""
+    await _ensure_instances_index_exists()
+    index = await get_instances_index()
+
+    # Determine how many docs exist, then fetch them in one search call.
+    try:
+        total = await index.query(CountQuery(filter_expression="*"))
+    except Exception:
+        total = 1000  # sensible fallback
+
+    if not total:
+        return []
+
+    q = FilterQuery(
+        filter_expression="*",
+        return_fields=["data"],  # full JSON payload is stored under 'data'
+        num_results=int(total) if isinstance(total, int) else 1000,
+    )
+    results = await index.query(q)
+
+    out: List[RedisInstance] = []
+    for doc in results or []:
+        try:
+            raw = doc.get("data")
+            if not raw:
+                continue
+            if isinstance(raw, bytes):
+                raw = raw.decode("utf-8")
+            inst_data = json.loads(raw)
+            if inst_data.get("connection_url"):
+                inst_data["connection_url"] = get_secret_value(inst_data["connection_url"])
+            if inst_data.get("admin_password"):
+                inst_data["admin_password"] = get_secret_value(inst_data["admin_password"])
+            out.append(RedisInstance(**inst_data))
+        except Exception as e:
+            logger.exception("Failed to load instance from search result: %s. Skipping.", e)
+    return out
+
+
+async def get_instances_strict() -> List[RedisInstance]:
+    """Load configured instances and surface transport/index failures to callers."""
+    return await _load_instances_from_index()
+
+
 async def get_instances() -> List[RedisInstance]:
     """Load configured instances using a single FT.SEARCH over the instances index."""
     try:
-        # Ensure index exists (best-effort) and read instance docs from RediSearch
-        await _ensure_instances_index_exists()
-        index = await get_instances_index()
-
-        # Determine how many docs exist, then fetch them in one search call
-        try:
-            total = await index.query(CountQuery(filter_expression="*"))
-        except Exception:
-            total = 1000  # sensible fallback
-
-        if not total:
-            return []
-
-        q = FilterQuery(
-            filter_expression="*",
-            return_fields=["data"],  # full JSON payload is stored under 'data'
-            num_results=int(total) if isinstance(total, int) else 1000,
-        )
-        results = await index.query(q)
-
-        out: List[RedisInstance] = []
-        for doc in results or []:
-            try:
-                raw = doc.get("data")
-                if not raw:
-                    continue
-                if isinstance(raw, bytes):
-                    raw = raw.decode("utf-8")
-                inst_data = json.loads(raw)
-                if inst_data.get("connection_url"):
-                    inst_data["connection_url"] = get_secret_value(inst_data["connection_url"])
-                if inst_data.get("admin_password"):
-                    inst_data["admin_password"] = get_secret_value(inst_data["admin_password"])
-                out.append(RedisInstance(**inst_data))
-            except Exception as e:
-                logger.exception("Failed to load instance from search result: %s. Skipping.", e)
-        return out
+        return await _load_instances_from_index()
     except Exception as e:
         logger.exception("Failed to get instances from Redis: %s", e)
         return []

--- a/redis_sre_agent/core/targets.py
+++ b/redis_sre_agent/core/targets.py
@@ -6,6 +6,8 @@ import copy
 import inspect
 import logging
 import re
+import time
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any, Awaitable, Callable, Dict, Iterable, List, Optional, Sequence
 from urllib.parse import urlparse
@@ -13,8 +15,18 @@ from urllib.parse import urlparse
 from pydantic import BaseModel, Field
 from redisvl.query import CountQuery, FilterQuery
 
-from redis_sre_agent.core.clusters import RedisCluster, get_cluster_by_id, get_clusters
-from redis_sre_agent.core.instances import RedisInstance, get_instance_by_id, get_instances
+from redis_sre_agent.core.clusters import (
+    RedisCluster,
+    get_cluster_by_id,
+    get_clusters,
+    get_clusters_strict,
+)
+from redis_sre_agent.core.instances import (
+    RedisInstance,
+    get_instance_by_id,
+    get_instances,
+    get_instances_strict,
+)
 from redis_sre_agent.core.redis import SRE_TARGETS_INDEX, get_redis_client, get_targets_index
 from redis_sre_agent.core.threads import ThreadManager
 from redis_sre_agent.targets import (
@@ -54,6 +66,44 @@ _TYPE_HINTS = {
     "clustered": "oss_cluster",
 }
 _HEALTHY_STATUSES = {"healthy", "ok", "active", "available", "connected"}
+_AUTHORITATIVE_TARGET_CATALOG_CACHE_TTL_SECONDS = 30.0
+_authoritative_target_catalog_snapshot_cache: Optional[AuthoritativeTargetCatalogSnapshot] = None
+_authoritative_target_catalog_snapshot_cache_expires_at = 0.0
+
+
+@dataclass
+class AuthoritativeTargetCatalogSnapshot:
+    """One authoritative target-catalog read reused across repair operations."""
+
+    instances: List[RedisInstance]
+    clusters: List[RedisCluster]
+    docs: List["TargetCatalogDoc"]
+
+
+def _cache_authoritative_target_catalog_snapshot(
+    snapshot: AuthoritativeTargetCatalogSnapshot,
+) -> AuthoritativeTargetCatalogSnapshot:
+    """Store the latest authoritative snapshot for bounded reuse on the hot path."""
+    global _authoritative_target_catalog_snapshot_cache
+    global _authoritative_target_catalog_snapshot_cache_expires_at
+
+    cached_snapshot = copy.deepcopy(snapshot)
+    _authoritative_target_catalog_snapshot_cache = cached_snapshot
+    _authoritative_target_catalog_snapshot_cache_expires_at = (
+        time.monotonic() + _AUTHORITATIVE_TARGET_CATALOG_CACHE_TTL_SECONDS
+    )
+    return copy.deepcopy(cached_snapshot)
+
+
+def _get_cached_authoritative_target_catalog_snapshot() -> Optional[
+    AuthoritativeTargetCatalogSnapshot
+]:
+    """Return the cached authoritative snapshot when it is still fresh."""
+    if _authoritative_target_catalog_snapshot_cache is None:
+        return None
+    if time.monotonic() >= _authoritative_target_catalog_snapshot_cache_expires_at:
+        return None
+    return copy.deepcopy(_authoritative_target_catalog_snapshot_cache)
 
 
 class TargetCatalogDoc(BaseModel):
@@ -690,6 +740,60 @@ def build_target_catalog_docs(
     return docs
 
 
+def _target_catalog_matches_authoritative_docs(
+    catalog_docs: Sequence[TargetCatalogDoc],
+    authoritative_docs: Sequence[TargetCatalogDoc],
+) -> bool:
+    """Return whether indexed target docs exactly match authoritative records."""
+    if len(catalog_docs) != len(authoritative_docs):
+        return False
+
+    catalog_by_id = {doc.target_id: doc for doc in catalog_docs}
+    authoritative_by_id = {doc.target_id: doc for doc in authoritative_docs}
+
+    if catalog_by_id.keys() != authoritative_by_id.keys():
+        return False
+
+    return all(
+        catalog_by_id[target_id].model_dump() == authoritative_by_id[target_id].model_dump()
+        for target_id in authoritative_by_id
+    )
+
+
+async def sync_target_catalog_from_authoritative_records() -> List[TargetCatalogDoc]:
+    """Rebuild and persist the target catalog from stored instances and clusters."""
+    authoritative_snapshot = await load_authoritative_target_catalog_snapshot(force_refresh=True)
+
+    try:
+        await sync_target_catalog(
+            instances=authoritative_snapshot.instances,
+            clusters=authoritative_snapshot.clusters,
+        )
+    except Exception:
+        logger.debug("Best-effort authoritative target catalog sync failed", exc_info=True)
+
+    return authoritative_snapshot.docs
+
+
+async def load_authoritative_target_catalog_snapshot(
+    *, force_refresh: bool = False
+) -> AuthoritativeTargetCatalogSnapshot:
+    """Load authoritative target records once for drift checks and syncs."""
+    if not force_refresh:
+        cached_snapshot = _get_cached_authoritative_target_catalog_snapshot()
+        if cached_snapshot is not None:
+            return cached_snapshot
+
+    authoritative_instances = await get_instances_strict()
+    authoritative_clusters = await get_clusters_strict()
+    snapshot = AuthoritativeTargetCatalogSnapshot(
+        instances=authoritative_instances,
+        clusters=authoritative_clusters,
+        docs=build_target_catalog_docs(authoritative_instances, authoritative_clusters),
+    )
+    return _cache_authoritative_target_catalog_snapshot(snapshot)
+
+
 async def _ensure_targets_index_exists() -> None:
     try:
         index = await get_targets_index()
@@ -795,6 +899,13 @@ async def sync_target_catalog(
         for stale_id in stale_ids:
             await client.delete(f"{SRE_TARGETS_INDEX}:{stale_id}")
 
+        _cache_authoritative_target_catalog_snapshot(
+            AuthoritativeTargetCatalogSnapshot(
+                instances=actual_instances,
+                clusters=actual_clusters,
+                docs=docs,
+            )
+        )
         return True
     except Exception:
         logger.exception("Failed to sync unified target catalog")
@@ -851,6 +962,30 @@ async def get_target_catalog(
                         continue
                 if cursor == 0:
                     break
+
+        authoritative_snapshot: Optional[AuthoritativeTargetCatalogSnapshot] = None
+        try:
+            authoritative_snapshot = await load_authoritative_target_catalog_snapshot()
+        except Exception:
+            logger.debug(
+                "Skipping target catalog drift repair because authoritative records were unavailable",
+                exc_info=True,
+            )
+
+        if authoritative_snapshot and not _target_catalog_matches_authoritative_docs(
+            docs, authoritative_snapshot.docs
+        ):
+            logger.info(
+                "Target catalog drift detected; using authoritative instance/cluster records"
+            )
+            try:
+                await sync_target_catalog(
+                    instances=authoritative_snapshot.instances,
+                    clusters=authoritative_snapshot.clusters,
+                )
+            except Exception:
+                logger.debug("Best-effort target catalog drift repair failed", exc_info=True)
+            docs = authoritative_snapshot.docs
 
         filtered: List[TargetCatalogDoc] = []
         for parsed in docs:

--- a/tests/integration/test_target_discovery_flow.py
+++ b/tests/integration/test_target_discovery_flow.py
@@ -15,8 +15,10 @@ from redis_sre_agent.core.instances import RedisInstance, save_instances
 from redis_sre_agent.core.redis import (
     SRE_CLUSTERS_SCHEMA,
     SRE_INSTANCES_SCHEMA,
+    SRE_TARGETS_INDEX,
     SRE_TARGETS_SCHEMA,
 )
+from redis_sre_agent.core.targets import TargetCatalogDoc
 from redis_sre_agent.core.tasks import TaskManager
 from redis_sre_agent.core.threads import ThreadManager
 from redis_sre_agent.targets import get_target_handle_store
@@ -330,6 +332,103 @@ async def test_target_inventory_tool_lists_known_targets_before_resolution(
         info_result = await mgr.resolve_tool_call(info_tool, {"section": "server"})
         assert info_result["status"] == "success"
         assert "redis_version" in info_result["data"]
+
+
+@pytest.mark.asyncio
+async def test_target_discovery_tool_repairs_stale_catalog_from_authoritative_instances(
+    async_redis_client,
+    redis_url,
+    redis_backed_target_state,
+):
+    """Discovery should self-heal when the target index drifts from stored instances."""
+
+    instance = RedisInstance(
+        id="redis-development-demo2",
+        name="demo2",
+        connection_url=redis_url,
+        environment="development",
+        usage="cache",
+        description="Demo Redis instance",
+        instance_type="oss_single",
+    )
+    await save_instances([instance])
+
+    cursor = 0
+    while True:
+        cursor, batch = await async_redis_client.scan(cursor=cursor, match=f"{SRE_TARGETS_INDEX}:*")
+        for key in batch or []:
+            await async_redis_client.delete(key)
+        if cursor == 0:
+            break
+
+    stale_doc = TargetCatalogDoc(
+        target_id="instance:redis-1",
+        target_kind="instance",
+        resource_id="redis-1",
+        display_name="New Instance",
+        name="New Instance",
+        environment="development",
+        status="unknown",
+        target_type="oss_single",
+        usage="cache",
+        search_text="new instance development cache",
+        capabilities=["redis", "diagnostics", "metrics", "logs"],
+    )
+    await async_redis_client.hset(
+        f"{SRE_TARGETS_INDEX}:{stale_doc.target_id}",
+        mapping={
+            "target_id": stale_doc.target_id,
+            "target_kind": stale_doc.target_kind,
+            "resource_id": stale_doc.resource_id,
+            "display_name": stale_doc.display_name,
+            "name": stale_doc.name,
+            "environment": stale_doc.environment or "",
+            "status": stale_doc.status or "",
+            "target_type": stale_doc.target_type or "",
+            "usage": stale_doc.usage or "",
+            "cluster_id": "",
+            "repo_slug": "",
+            "monitoring_identifier": "",
+            "logging_identifier": "",
+            "redis_cloud_subscription_id": "",
+            "redis_cloud_database_id": "",
+            "redis_cloud_database_name": "",
+            "search_aliases": "",
+            "capabilities": ",".join(stale_doc.capabilities),
+            "updated_at": 1,
+            "created_at": 1,
+            "search_text": stale_doc.search_text,
+            "user_id": "",
+            "data": stale_doc.model_dump_json(),
+        },
+    )
+
+    thread_manager = ThreadManager(redis_client=async_redis_client)
+    thread_id = await thread_manager.create_thread(
+        user_id="test-user",
+        session_id="test-session",
+        initial_context={},
+    )
+
+    async with ToolManager(thread_id=thread_id, user_id="test-user") as mgr:
+        list_tool = next(t.name for t in mgr.get_tools() if "list_known_redis_targets" in t.name)
+        inventory = await mgr.resolve_tool_call(list_tool, {})
+        assert inventory["status"] == "ok"
+        assert inventory["total_known_targets"] == 1
+        assert inventory["targets"][0]["display_name"] == "demo2"
+
+        resolve_tool = next(t.name for t in mgr.get_tools() if "resolve_redis_targets" in t.name)
+        resolution = await mgr.resolve_tool_call(
+            resolve_tool,
+            {
+                "query": "demo2",
+                "attach_tools": False,
+            },
+        )
+
+        assert resolution["status"] == "resolved"
+        assert resolution["matches"][0]["display_name"] == "demo2"
+        assert resolution["matches"][0]["environment"] == "development"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/api/test_app.py
+++ b/tests/unit/api/test_app.py
@@ -87,12 +87,16 @@ class TestLifespan:
         with (
             patch("redis_sre_agent.api.app.initialize_redis") as mock_init,
             patch("redis_sre_agent.api.app.run_instances_to_clusters_migration") as mock_migration,
+            patch(
+                "redis_sre_agent.api.app.sync_target_catalog_from_authoritative_records"
+            ) as mock_target_sync,
             patch("redis_sre_agent.core.docket_tasks.register_sre_tasks") as mock_register,
             patch.object(MCPConnectionPool, "start") as mock_pool_start,
             patch.object(MCPConnectionPool, "shutdown") as mock_pool_shutdown,
         ):
             mock_init.return_value = {"redis": "connected"}
             mock_migration.return_value = SimpleNamespace(to_dict=lambda: {})
+            mock_target_sync.return_value = []
             mock_register.return_value = None
             mock_pool_start.return_value = {}
             mock_pool_shutdown.return_value = None
@@ -104,6 +108,7 @@ class TestLifespan:
             # Verify startup was called
             mock_init.assert_called_once()
             mock_migration.assert_called_once()
+            mock_target_sync.assert_called_once()
             mock_register.assert_called_once()
             mock_pool_start.assert_called_once()
             mock_pool_shutdown.assert_called_once()
@@ -119,11 +124,15 @@ class TestLifespan:
         with (
             patch("redis_sre_agent.api.app.initialize_redis") as mock_init,
             patch("redis_sre_agent.api.app.run_instances_to_clusters_migration") as mock_migration,
+            patch(
+                "redis_sre_agent.api.app.sync_target_catalog_from_authoritative_records"
+            ) as mock_target_sync,
             patch.object(MCPConnectionPool, "start") as mock_pool_start,
             patch.object(MCPConnectionPool, "shutdown") as mock_pool_shutdown,
         ):
             mock_init.side_effect = Exception("Redis connection failed")
             mock_migration.return_value = SimpleNamespace(to_dict=lambda: {})
+            mock_target_sync.return_value = []
             mock_pool_start.return_value = {}
             mock_pool_shutdown.return_value = None
 
@@ -143,12 +152,16 @@ class TestLifespan:
         with (
             patch("redis_sre_agent.api.app.initialize_redis") as mock_init,
             patch("redis_sre_agent.api.app.run_instances_to_clusters_migration") as mock_migration,
+            patch(
+                "redis_sre_agent.api.app.sync_target_catalog_from_authoritative_records"
+            ) as mock_target_sync,
             patch("redis_sre_agent.core.docket_tasks.register_sre_tasks") as mock_register,
             patch.object(MCPConnectionPool, "start") as mock_pool_start,
             patch.object(MCPConnectionPool, "shutdown") as mock_pool_shutdown,
         ):
             mock_init.return_value = {"redis": "connected"}
             mock_migration.return_value = SimpleNamespace(to_dict=lambda: {})
+            mock_target_sync.return_value = []
             mock_register.side_effect = Exception("Task registration failed")
             mock_pool_start.return_value = {}
             mock_pool_shutdown.return_value = None
@@ -159,6 +172,7 @@ class TestLifespan:
 
             mock_init.assert_called_once()
             mock_migration.assert_called_once()
+            mock_target_sync.assert_called_once()
             mock_register.assert_called_once()
 
     @pytest.mark.asyncio
@@ -172,12 +186,16 @@ class TestLifespan:
         with (
             patch("redis_sre_agent.api.app.initialize_redis") as mock_init,
             patch("redis_sre_agent.api.app.run_instances_to_clusters_migration") as mock_migration,
+            patch(
+                "redis_sre_agent.api.app.sync_target_catalog_from_authoritative_records"
+            ) as mock_target_sync,
             patch("redis_sre_agent.core.docket_tasks.register_sre_tasks") as mock_register,
             patch.object(MCPConnectionPool, "start") as mock_pool_start,
             patch.object(MCPConnectionPool, "shutdown") as mock_pool_shutdown,
         ):
             mock_init.return_value = {"redis": "connected"}
             mock_migration.return_value = SimpleNamespace(to_dict=lambda: {})
+            mock_target_sync.return_value = []
             mock_register.return_value = None
             mock_pool_start.return_value = {}
             mock_pool_shutdown.return_value = None

--- a/tests/unit/core/test_targets.py
+++ b/tests/unit/core/test_targets.py
@@ -20,12 +20,22 @@ from redis_sre_agent.core.targets import (
     build_target_doc_from_instance,
     get_attached_target_handles_from_context,
     get_target_bindings_from_context,
+    get_target_catalog,
     materialize_bound_target_scope,
     resolve_target_query,
     sync_target_catalog,
 )
 from redis_sre_agent.core.threads import Thread, ThreadMetadata
 from redis_sre_agent.targets.services import TargetBindingService
+
+
+@pytest.fixture(autouse=True)
+def reset_authoritative_target_catalog_snapshot_cache():
+    target_module._authoritative_target_catalog_snapshot_cache = None
+    target_module._authoritative_target_catalog_snapshot_cache_expires_at = 0.0
+    yield
+    target_module._authoritative_target_catalog_snapshot_cache = None
+    target_module._authoritative_target_catalog_snapshot_cache_expires_at = 0.0
 
 
 def test_build_target_doc_from_instance_excludes_secrets_and_includes_aliases():
@@ -974,3 +984,167 @@ async def test_sync_target_catalog_scan_fallback_only_deletes_prefixed_stale_key
     assert result is True
     deleted_keys = [call.args[0] for call in mock_client.delete.await_args_list]
     assert deleted_keys == ["sre_targets:instance:stale-target"]
+
+
+@pytest.mark.asyncio
+async def test_get_target_catalog_repairs_stale_index_from_authoritative_records():
+    instance = RedisInstance(
+        id="redis-development-demo2",
+        name="demo2",
+        connection_url="redis://redis-demo:6379/0",
+        environment="development",
+        usage="cache",
+        description="Demo Redis instance",
+        instance_type="oss_single",
+    )
+    stale_doc = TargetCatalogDoc(
+        target_id="instance:redis-1",
+        target_kind="instance",
+        resource_id="redis-1",
+        display_name="New Instance",
+        name="New Instance",
+        environment="development",
+        status="unknown",
+        target_type="oss_single",
+        usage="cache",
+        search_text="New Instance development cache",
+        capabilities=["redis", "diagnostics", "metrics", "logs"],
+    )
+    mock_index = AsyncMock()
+    mock_index.query = AsyncMock(
+        side_effect=[
+            1,
+            [{"data": stale_doc.model_dump_json()}],
+        ]
+    )
+
+    with (
+        patch(
+            "redis_sre_agent.core.targets._ensure_targets_index_exists",
+            new=AsyncMock(return_value=None),
+        ),
+        patch(
+            "redis_sre_agent.core.targets.get_targets_index", new=AsyncMock(return_value=mock_index)
+        ),
+        patch("redis_sre_agent.core.targets.get_redis_client", return_value=AsyncMock()),
+        patch(
+            "redis_sre_agent.core.targets.get_instances_strict",
+            new=AsyncMock(return_value=[instance]),
+        ) as mock_get_instances,
+        patch(
+            "redis_sre_agent.core.targets.get_clusters_strict",
+            new=AsyncMock(return_value=[]),
+        ) as mock_get_clusters,
+        patch(
+            "redis_sre_agent.core.targets.sync_target_catalog", new=AsyncMock(return_value=True)
+        ) as mock_sync,
+    ):
+        docs = await get_target_catalog()
+
+    assert [doc.resource_id for doc in docs] == ["redis-development-demo2"]
+    mock_get_instances.assert_awaited_once()
+    mock_get_clusters.assert_awaited_once()
+    mock_sync.assert_awaited_once()
+    assert mock_sync.await_args.kwargs["instances"] == [instance]
+    assert mock_sync.await_args.kwargs["clusters"] == []
+
+
+@pytest.mark.asyncio
+async def test_get_target_catalog_keeps_index_docs_when_authoritative_fetch_fails():
+    indexed_doc = TargetCatalogDoc(
+        target_id="instance:redis-development-demo2",
+        target_kind="instance",
+        resource_id="redis-development-demo2",
+        display_name="demo2",
+        name="demo2",
+        environment="development",
+        status="healthy",
+        target_type="oss_single",
+        usage="cache",
+        search_text="demo2 development cache",
+        capabilities=["redis", "diagnostics", "metrics", "logs"],
+    )
+    mock_index = AsyncMock()
+    mock_index.query = AsyncMock(
+        side_effect=[
+            1,
+            [{"data": indexed_doc.model_dump_json()}],
+        ]
+    )
+
+    with (
+        patch(
+            "redis_sre_agent.core.targets._ensure_targets_index_exists",
+            new=AsyncMock(return_value=None),
+        ),
+        patch(
+            "redis_sre_agent.core.targets.get_targets_index", new=AsyncMock(return_value=mock_index)
+        ),
+        patch("redis_sre_agent.core.targets.get_redis_client", return_value=AsyncMock()),
+        patch(
+            "redis_sre_agent.core.targets.get_instances_strict",
+            new=AsyncMock(side_effect=RuntimeError("instances unavailable")),
+        ),
+        patch(
+            "redis_sre_agent.core.targets.get_clusters_strict",
+            new=AsyncMock(return_value=[]),
+        ),
+        patch(
+            "redis_sre_agent.core.targets.sync_target_catalog", new=AsyncMock(return_value=True)
+        ) as mock_sync,
+    ):
+        docs = await get_target_catalog()
+
+    assert [doc.resource_id for doc in docs] == ["redis-development-demo2"]
+    mock_sync.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_get_target_catalog_reuses_cached_authoritative_snapshot():
+    instance = RedisInstance(
+        id="redis-development-demo2",
+        name="demo2",
+        connection_url="redis://redis-demo:6379/0",
+        environment="development",
+        usage="cache",
+        description="Demo Redis instance",
+        instance_type="oss_single",
+    )
+    authoritative_doc = target_module.build_target_doc_from_instance(instance)
+    target_module._cache_authoritative_target_catalog_snapshot(
+        target_module.AuthoritativeTargetCatalogSnapshot(
+            instances=[instance],
+            clusters=[],
+            docs=[authoritative_doc],
+        )
+    )
+
+    mock_index = AsyncMock()
+    mock_index.query = AsyncMock(
+        side_effect=[
+            1,
+            [{"data": authoritative_doc.model_dump_json()}],
+        ]
+    )
+
+    with (
+        patch(
+            "redis_sre_agent.core.targets._ensure_targets_index_exists",
+            new=AsyncMock(return_value=None),
+        ),
+        patch(
+            "redis_sre_agent.core.targets.get_targets_index", new=AsyncMock(return_value=mock_index)
+        ),
+        patch("redis_sre_agent.core.targets.get_redis_client", return_value=AsyncMock()),
+        patch(
+            "redis_sre_agent.core.targets.get_instances_strict",
+            new=AsyncMock(side_effect=AssertionError("cache should avoid instance reload")),
+        ),
+        patch(
+            "redis_sre_agent.core.targets.get_clusters_strict",
+            new=AsyncMock(side_effect=AssertionError("cache should avoid cluster reload")),
+        ),
+    ):
+        docs = await get_target_catalog()
+
+    assert [doc.resource_id for doc in docs] == ["redis-development-demo2"]

--- a/tests/unit/evaluation/test_runtime.py
+++ b/tests/unit/evaluation/test_runtime.py
@@ -15,6 +15,7 @@ from redis_sre_agent.core.agent_memory import PreparedAgentTurnMemory, TurnMemor
 from redis_sre_agent.core.approvals import ApprovalRecord
 from redis_sre_agent.core.config import MCPServerConfig
 from redis_sre_agent.core.instances import RedisInstance
+from redis_sre_agent.core.targets import TargetCatalogDoc
 from redis_sre_agent.core.tasks import TaskMetadata, TaskState, TaskStatus, TaskUpdate
 from redis_sre_agent.core.threads import Message, Thread, ThreadMetadata
 from redis_sre_agent.evaluation.injection import EvalInjectionOverrides
@@ -1545,6 +1546,96 @@ async def test_run_full_turn_scenario_supports_discovery_first_approval_pause(
     assert len(approval_record.target_handles) == 1
     assert pending["summary"].endswith(f"on {approval_record.target_handles[0]}")
     assert _EvalApprovalProvider.actual_call_count == 0
+
+
+@pytest.mark.asyncio
+async def test_run_full_turn_scenario_without_eval_target_catalog_uses_runtime_catalog(
+    monkeypatch,
+):
+    scenario = EvalScenario.model_validate(
+        {
+            "id": "runtime-catalog-target-discovery",
+            "name": "Runtime catalog target discovery",
+            "provenance": {
+                "source_kind": "synthetic",
+                "source_pack": "fixture-pack",
+                "source_pack_version": "2026-05-01",
+                "golden": {"expectation_basis": "human_authored"},
+            },
+            "execution": {
+                "lane": "full_turn",
+                "query": "Check demo2 memory pressure.",
+                "route_via_router": False,
+                "agent": "chat",
+            },
+            "scope": {
+                "turn_scope": {
+                    "resolution_policy": "allow_zero_scope",
+                    "automation_mode": "automated",
+                }
+            },
+        }
+    )
+
+    runtime_doc = TargetCatalogDoc(
+        target_id="instance:redis-development-demo2",
+        target_kind="instance",
+        resource_id="redis-development-demo2",
+        display_name="demo2",
+        name="demo2",
+        environment="development",
+        status="unknown",
+        target_type="oss_single",
+        usage="cache",
+        search_text="demo2 development cache",
+        capabilities=["redis", "diagnostics", "metrics", "logs"],
+    )
+    runtime_catalog = AsyncMock(return_value=[runtime_doc])
+
+    async def turn_processor(**kwargs):
+        async with ToolManager(
+            thread_id=kwargs["thread_id"],
+            task_id=kwargs["task_id"],
+            user_id="user-123",
+        ) as tool_mgr:
+            resolve_tool = next(
+                tool.name
+                for tool in tool_mgr.get_tools()
+                if tool.name.startswith("target_discovery_")
+                and tool.name.endswith("resolve_redis_targets")
+            )
+            resolution = await tool_mgr.resolve_tool_call(
+                resolve_tool,
+                {
+                    "query": "demo2",
+                    "attach_tools": False,
+                },
+            )
+            return {"resolution": resolution}
+
+    _MemoryThreadManager.reset()
+    _MemoryTaskManager.reset()
+    monkeypatch.setattr("redis_sre_agent.evaluation.runtime.ThreadManager", _MemoryThreadManager)
+    monkeypatch.setattr("redis_sre_agent.evaluation.runtime.TaskManager", _MemoryTaskManager)
+    monkeypatch.setattr("redis_sre_agent.core.docket_tasks.ThreadManager", _MemoryThreadManager)
+    monkeypatch.setattr("redis_sre_agent.core.docket_tasks.TaskManager", _MemoryTaskManager)
+    monkeypatch.setattr(ToolManager, "_load_mcp_providers", AsyncMock())
+    monkeypatch.setattr(ToolManager, "_load_support_package_provider", AsyncMock())
+
+    with patch("redis_sre_agent.core.targets.get_target_catalog", new=runtime_catalog):
+        result = await run_full_turn_scenario(
+            scenario,
+            user_id="user-123",
+            session_id="session-123",
+            redis_client=object(),
+            turn_processor=turn_processor,
+        )
+
+    resolution = result.turn_result["resolution"]
+    assert resolution["status"] == "resolved"
+    assert resolution["matches"][0]["display_name"] == "demo2"
+    assert resolution["matches"][0]["environment"] == "development"
+    runtime_catalog.assert_awaited()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- repair stale `sre_targets` catalogs by comparing the indexed target docs with authoritative instance and cluster records and rebuilding when they drift
- sync the target catalog during API startup so upgraded stacks repopulate stale catalogs proactively
- add regressions for the stale-catalog runtime path, the API startup sync, the integration failure mode, and the eval runtime path that previously patched discovery away

## Why
Post-merge live QA found that unscoped chat queries could not resolve `demo2` by name even though the authoritative instance catalog still contained it. The Redis target catalog had drifted and only held a stale `New Instance` document, so discovery saw the wrong inventory.

Tests and evals missed this because existing coverage either:
- used `save_instances()`, which immediately rebuilt `sre_targets`
- patched `get_target_catalog()` with scenario-local data, bypassing the persisted runtime catalog entirely

## Validation
- `uv run ruff check redis_sre_agent/core/targets.py redis_sre_agent/api/app.py tests/unit/core/test_targets.py tests/unit/api/test_app.py tests/integration/test_target_discovery_flow.py tests/unit/evaluation/test_runtime.py`
- `uv run pytest tests/unit/core/test_targets.py tests/unit/api/test_app.py tests/unit/evaluation/test_runtime.py::test_run_full_turn_scenario_without_eval_target_catalog_uses_runtime_catalog`
- `uv run pytest --run-api-tests tests/integration/test_target_discovery_flow.py::test_target_discovery_tool_repairs_stale_catalog_from_authoritative_instances`
- live compose verification: unscoped `redis-sre-agent query -a chat "Check demo2 memory pressure and slow ops"` now resolves and auto-attaches `demo2`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds automatic drift detection/repair and an API-startup sync for the `sre_targets` catalog, which changes runtime discovery behavior and introduces extra Redis/index reads on hot paths (mitigated by a short TTL cache).
> 
> **Overview**
> Fixes cases where target discovery uses stale `sre_targets` data by **comparing the indexed target docs with authoritative instance/cluster records and rebuilding the catalog when they drift** (best-effort, non-fatal).
> 
> Adds an API startup step to proactively `sync_target_catalog_from_authoritative_records()` and records the outcome in startup state. Introduces `get_instances_strict()`/`get_clusters_strict()` plus a short-lived authoritative snapshot cache to support drift repair without silently swallowing transport/index failures.
> 
> Expands unit/integration/eval coverage for stale-catalog repair, startup sync invocation, cache reuse, and the runtime path that previously bypassed the persisted catalog.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 535fa3a0b56f46774bfb47a926ecdb0c6fc2b5f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->