### PR TITLE
Fix task-scoped Redis instance handoff

### DIFF
--- a/redis_sre_agent/agent/checkpointing.py
+++ b/redis_sre_agent/agent/checkpointing.py
@@ -161,6 +161,7 @@ async def persist_checkpoint_metadata(
                 ),
                 pending_approval_id=existing.pending_approval_id if existing else None,
                 pending_interrupt_id=existing.pending_interrupt_id if existing else None,
+                staged_session_instance=(existing.staged_session_instance if existing else None),
                 resume_count=existing.resume_count if existing else 0,
             )
         )
@@ -201,6 +202,7 @@ async def persist_approval_wait_state(
                 waiting_reason="approval_required",
                 pending_approval_id=pending.approval_id,
                 pending_interrupt_id=pending.interrupt_id,
+                staged_session_instance=resume_state.staged_session_instance,
                 resume_count=resume_state.resume_count,
             )
         )

--- a/redis_sre_agent/core/approvals.py
+++ b/redis_sre_agent/core/approvals.py
@@ -140,6 +140,7 @@ class GraphResumeState(BaseModel):
     waiting_reason: str
     pending_approval_id: Optional[str] = None
     pending_interrupt_id: Optional[str] = None
+    staged_session_instance: Optional[Dict[str, Any]] = None
     resume_count: int = 0
     updated_at: str = Field(default_factory=_now_iso)
 

--- a/redis_sre_agent/core/docket_tasks.py
+++ b/redis_sre_agent/core/docket_tasks.py
@@ -233,7 +233,8 @@ async def _resolve_instance_for_resume(
     if instance_id and restored.id != instance_id:
         return None
 
-    await add_session_instance(thread_id, restored)
+    if not await add_session_instance(thread_id, restored):
+        raise ValueError("Failed to restore staged session instance for resume")
     return restored
 
 

--- a/redis_sre_agent/core/docket_tasks.py
+++ b/redis_sre_agent/core/docket_tasks.py
@@ -31,6 +31,7 @@ from redis_sre_agent.core.citation_message import (
 )
 from redis_sre_agent.core.clusters import get_cluster_by_id
 from redis_sre_agent.core.config import Settings, settings
+from redis_sre_agent.core.encryption import encrypt_secret, get_secret_value
 from redis_sre_agent.core.instances import (
     RedisInstance,
     RedisInstanceType,
@@ -165,6 +166,79 @@ async def _stage_session_instance_from_message(
     return session_instance
 
 
+def _serialize_session_instance_snapshot(instance: RedisInstance) -> Dict[str, Any]:
+    """Persist a staged session instance in resume state with encrypted secrets."""
+    payload = instance.model_dump(mode="json")
+    if payload.get("connection_url"):
+        payload["connection_url"] = encrypt_secret(payload["connection_url"])
+    if payload.get("admin_password"):
+        payload["admin_password"] = encrypt_secret(payload["admin_password"])
+    return payload
+
+
+def _deserialize_session_instance_snapshot(payload: Dict[str, Any]) -> RedisInstance:
+    """Restore a staged session instance snapshot from resume state."""
+    data = dict(payload)
+    if data.get("connection_url"):
+        data["connection_url"] = get_secret_value(data["connection_url"])
+    if data.get("admin_password"):
+        data["admin_password"] = get_secret_value(data["admin_password"])
+    return RedisInstance(**data)
+
+
+async def _persist_staged_session_instance_for_resume(
+    *,
+    task_id: str,
+    thread_id: str,
+    redis_client: Any,
+) -> None:
+    """Store the current thread-scoped instance in durable resume state when needed."""
+    approval_manager = ApprovalManager(redis_client=redis_client)
+    resume_state = await approval_manager.get_resume_state(task_id)
+    if not resume_state:
+        return
+
+    thread = await ThreadManager(redis_client=redis_client).get_thread(thread_id)
+    thread_context = thread.context if thread else {}
+    instance_id = str(thread_context.get("instance_id") or "").strip() or None
+    if not instance_id:
+        return
+
+    for session_instance in await get_session_instances(thread_id):
+        if session_instance.id != instance_id:
+            continue
+        snapshot = _serialize_session_instance_snapshot(session_instance)
+        if resume_state.staged_session_instance == snapshot:
+            return
+        await approval_manager.save_resume_state(
+            resume_state.model_copy(update={"staged_session_instance": snapshot})
+        )
+        return
+
+
+async def _resolve_instance_for_resume(
+    *,
+    instance_id: Optional[str],
+    thread_id: str,
+    resume_state: Any,
+) -> Optional[RedisInstance]:
+    """Resolve a task target, falling back to a durable staged-instance snapshot."""
+    instance = await _resolve_instance_for_thread(instance_id, thread_id)
+    if instance is not None:
+        return instance
+
+    snapshot = getattr(resume_state, "staged_session_instance", None)
+    if not snapshot:
+        return None
+
+    restored = _deserialize_session_instance_snapshot(snapshot)
+    if instance_id and restored.id != instance_id:
+        return None
+
+    await add_session_instance(thread_id, restored)
+    return restored
+
+
 async def _transition_task_to_awaiting_approval(
     *,
     task_manager: TaskManager,
@@ -209,6 +283,11 @@ async def _transition_task_to_awaiting_approval(
     }
     await task_manager.set_task_result(task_id, result)
     try:
+        await _persist_staged_session_instance_for_resume(
+            task_id=task_id,
+            thread_id=thread_id,
+            redis_client=task_manager._redis,
+        )
         await task_manager._publish_stream_update(
             thread_id,
             "awaiting_approval",
@@ -2218,7 +2297,11 @@ async def resume_task_after_approval(
 
         instance_id = str(resume_context.get("instance_id") or "").strip() or None
         cluster_id = str(resume_context.get("cluster_id") or "").strip() or None
-        redis_instance = await _resolve_instance_for_thread(instance_id, thread_id)
+        redis_instance = await _resolve_instance_for_resume(
+            instance_id=instance_id,
+            thread_id=thread_id,
+            resume_state=resume_state,
+        )
         redis_cluster = await get_cluster_by_id(cluster_id) if cluster_id else None
 
         excluded_categories = resume_context.get("exclude_mcp_categories") or []
@@ -2325,7 +2408,11 @@ async def resume_task_after_approval(
 
     instance_id = str(resume_context.get("instance_id") or "").strip() or None
     cluster_id = str(resume_context.get("cluster_id") or "").strip() or None
-    target_instance = await _resolve_instance_for_thread(instance_id, thread_id)
+    target_instance = await _resolve_instance_for_resume(
+        instance_id=instance_id,
+        thread_id=thread_id,
+        resume_state=resume_state,
+    )
     target_cluster = await get_cluster_by_id(cluster_id) if cluster_id else None
 
     agent = get_sre_agent(

--- a/redis_sre_agent/core/docket_tasks.py
+++ b/redis_sre_agent/core/docket_tasks.py
@@ -208,8 +208,6 @@ async def _persist_staged_session_instance_for_resume(
         if session_instance.id != instance_id:
             continue
         snapshot = _serialize_session_instance_snapshot(session_instance)
-        if resume_state.staged_session_instance == snapshot:
-            return
         await approval_manager.save_resume_state(
             resume_state.model_copy(update={"staged_session_instance": snapshot})
         )
@@ -532,6 +530,11 @@ async def _transition_task_to_awaiting_approval_from_interrupt(
     await task_manager.set_task_result(task_id, result)
     await task_manager.update_task_status(task_id, TaskStatus.AWAITING_APPROVAL)
     try:
+        await _persist_staged_session_instance_for_resume(
+            task_id=task_id,
+            thread_id=thread_id,
+            redis_client=task_manager._redis,
+        )
         await task_manager._publish_stream_update(
             thread_id,
             "awaiting_approval",

--- a/redis_sre_agent/core/docket_tasks.py
+++ b/redis_sre_agent/core/docket_tasks.py
@@ -31,7 +31,13 @@ from redis_sre_agent.core.citation_message import (
 )
 from redis_sre_agent.core.clusters import get_cluster_by_id
 from redis_sre_agent.core.config import Settings, settings
-from redis_sre_agent.core.instances import create_instance, get_instance_by_id
+from redis_sre_agent.core.instances import (
+    RedisInstance,
+    RedisInstanceType,
+    add_session_instance,
+    get_instance_by_id,
+    get_session_instances,
+)
 from redis_sre_agent.core.knowledge_helpers import (
     ingest_sre_document_helper,
     search_knowledge_base_helper,
@@ -105,6 +111,58 @@ def _extract_pending_approval_from_interrupt(error: GraphInterrupt) -> Optional[
         if isinstance(payload, dict) and payload.get("kind") == "approval_required":
             return payload
     return None
+
+
+async def _resolve_instance_for_thread(
+    instance_id: Optional[str], thread_id: Optional[str]
+) -> Optional[RedisInstance]:
+    """Resolve an instance ID against persistent storage, then thread-scoped session instances."""
+    if not instance_id:
+        return None
+
+    instance = await get_instance_by_id(instance_id)
+    if instance or not thread_id:
+        return instance
+
+    for session_instance in await get_session_instances(thread_id):
+        if session_instance.id == instance_id:
+            return session_instance
+    return None
+
+
+async def _stage_session_instance_from_message(
+    *,
+    thread_id: str,
+    thread_user_id: Optional[str],
+    instance_details: Dict[str, str],
+) -> RedisInstance:
+    """Stage extracted connection details as a thread-scoped instance without mutating global config."""
+    connection_url = instance_details["connection_url"]
+    name = instance_details["name"]
+
+    for session_instance in await get_session_instances(thread_id):
+        if (
+            session_instance.name == name
+            or session_instance.connection_url.get_secret_value() == connection_url
+        ):
+            return session_instance
+
+    session_instance = RedisInstance(
+        id=f"redis-{instance_details['environment']}-{ULID()}",
+        name=name,
+        connection_url=connection_url,
+        environment=instance_details["environment"],
+        usage=instance_details["usage"],
+        description=instance_details.get(
+            "description", "Staged by agent from user-provided connection details"
+        ),
+        created_by="agent",
+        user_id=thread_user_id,
+        instance_type=RedisInstanceType.unknown,
+    )
+    if not await add_session_instance(thread_id, session_instance):
+        raise ValueError("Failed to stage session instance from provided details")
+    return session_instance
 
 
 async def _transition_task_to_awaiting_approval(
@@ -1383,6 +1441,7 @@ async def _process_agent_turn_impl(
         # Determine active targets
         active_instance_id = None
         active_cluster_id = None
+        staged_thread_instance: Optional[RedisInstance] = None
 
         if instance_id_from_client:
             # Client provided instance_id - use it and update thread
@@ -1464,23 +1523,22 @@ async def _process_agent_turn_impl(
             instance_details = _extract_instance_details_from_message(message)
 
             if instance_details:
-                # User provided connection details - create instance
+                # User provided connection details - stage a thread-scoped instance
                 try:
-                    logger.info("Creating instance from user-provided connection details")
-                    new_instance = await create_instance(
-                        name=instance_details["name"],
-                        connection_url=instance_details["connection_url"],
-                        environment=instance_details["environment"],
-                        usage=instance_details["usage"],
-                        description=instance_details.get(
-                            "description", "Created by agent from user-provided details"
-                        ),
-                        created_by="agent",
-                        user_id=thread.metadata.user_id,
+                    logger.info("Staging session instance from user-provided connection details")
+                    new_instance = await _stage_session_instance_from_message(
+                        thread_id=thread_id,
+                        thread_user_id=thread.metadata.user_id,
+                        instance_details=instance_details,
                     )
 
                     active_instance_id = new_instance.id
-                    logger.info(f"Created new instance: {new_instance.name} ({active_instance_id})")
+                    staged_thread_instance = new_instance
+                    logger.info(
+                        "Staged session instance: %s (%s)",
+                        new_instance.name,
+                        active_instance_id,
+                    )
 
                     # Save instance_id to thread context
                     await thread_manager.update_thread_context(
@@ -1498,15 +1556,18 @@ async def _process_agent_turn_impl(
                     _clear_attached_scope(thread.context)
                     await task_manager.add_task_update(
                         task_id,
-                        f"Created Redis instance: {new_instance.name} ({active_instance_id})",
-                        "instance_created",
+                        (
+                            "Using provided Redis connection details for this thread: "
+                            f"{new_instance.name} ({active_instance_id})"
+                        ),
+                        "instance_context",
                     )
 
                 except Exception as e:
-                    logger.warning(f"Failed to create instance from user details: {e}")
+                    logger.warning(f"Failed to stage session instance from user details: {e}")
                     await task_manager.add_task_update(
                         task_id,
-                        f"Could not create instance from provided details: {str(e)}",
+                        f"Could not stage provided Redis details for this thread: {str(e)}",
                         "instance_error",
                     )
                     # Continue without instance_id - will route to knowledge agent
@@ -1547,19 +1608,21 @@ async def _process_agent_turn_impl(
             routing_context.pop("instance_id", None)
 
         current_scope = _materialize_turn_scope(routing_context)
-        current_scope = await _ensure_handle_backed_turn_scope(
-            turn_scope=current_scope,
-            routing_context=routing_context,
-            thread_context=thread.context,
-            thread_id=thread_id,
-            task_id=task_id,
-            legacy_instance_id=(
-                routing_context.get("instance_id") or current_scope.seed_hints.get("instance_id")
-            ),
-            legacy_cluster_id=(
-                routing_context.get("cluster_id") or current_scope.seed_hints.get("cluster_id")
-            ),
-        )
+        if staged_thread_instance is None:
+            current_scope = await _ensure_handle_backed_turn_scope(
+                turn_scope=current_scope,
+                routing_context=routing_context,
+                thread_context=thread.context,
+                thread_id=thread_id,
+                task_id=task_id,
+                legacy_instance_id=(
+                    routing_context.get("instance_id")
+                    or current_scope.seed_hints.get("instance_id")
+                ),
+                legacy_cluster_id=(
+                    routing_context.get("cluster_id") or current_scope.seed_hints.get("cluster_id")
+                ),
+            )
         routing_context["turn_scope"] = current_scope.model_dump(mode="json")
 
         requested_agent_type = (context or {}).get("requested_agent_type")
@@ -1639,9 +1702,17 @@ async def _process_agent_turn_impl(
                 target_cluster = None
             else:
                 # Get the target instance for the chat agent
-                target_instance = (
-                    await get_instance_by_id(active_instance_id) if active_instance_id else None
-                )
+                target_instance = None
+                if active_instance_id:
+                    if (
+                        staged_thread_instance is not None
+                        and staged_thread_instance.id == active_instance_id
+                    ):
+                        target_instance = staged_thread_instance
+                    else:
+                        target_instance = await _resolve_instance_for_thread(
+                            active_instance_id, thread_id
+                        )
                 target_cluster = (
                     await get_cluster_by_id(active_cluster_id) if active_cluster_id else None
                 )
@@ -2147,7 +2218,7 @@ async def resume_task_after_approval(
 
         instance_id = str(resume_context.get("instance_id") or "").strip() or None
         cluster_id = str(resume_context.get("cluster_id") or "").strip() or None
-        redis_instance = await get_instance_by_id(instance_id) if instance_id else None
+        redis_instance = await _resolve_instance_for_thread(instance_id, thread_id)
         redis_cluster = await get_cluster_by_id(cluster_id) if cluster_id else None
 
         excluded_categories = resume_context.get("exclude_mcp_categories") or []
@@ -2254,7 +2325,7 @@ async def resume_task_after_approval(
 
     instance_id = str(resume_context.get("instance_id") or "").strip() or None
     cluster_id = str(resume_context.get("cluster_id") or "").strip() or None
-    target_instance = await get_instance_by_id(instance_id) if instance_id else None
+    target_instance = await _resolve_instance_for_thread(instance_id, thread_id)
     target_cluster = await get_cluster_by_id(cluster_id) if cluster_id else None
 
     agent = get_sre_agent(

--- a/redis_sre_agent/core/docket_tasks.py
+++ b/redis_sre_agent/core/docket_tasks.py
@@ -286,6 +286,9 @@ async def _transition_task_to_awaiting_approval(
             thread_id=thread_id,
             redis_client=task_manager._redis,
         )
+    except Exception:
+        logger.debug("Failed to persist staged session instance snapshot for task %s", task_id)
+    try:
         await task_manager._publish_stream_update(
             thread_id,
             "awaiting_approval",
@@ -535,6 +538,9 @@ async def _transition_task_to_awaiting_approval_from_interrupt(
             thread_id=thread_id,
             redis_client=task_manager._redis,
         )
+    except Exception:
+        logger.debug("Failed to persist staged session instance snapshot for task %s", task_id)
+    try:
         await task_manager._publish_stream_update(
             thread_id,
             "awaiting_approval",

--- a/tests/unit/agent/test_checkpointing.py
+++ b/tests/unit/agent/test_checkpointing.py
@@ -186,6 +186,7 @@ async def test_persist_approval_wait_state_reuses_shared_redis_client():
         graph_version="v1",
         checkpoint_ns=GRAPH_CHECKPOINT_NAMESPACE,
         checkpoint_id="checkpoint-1",
+        staged_session_instance=None,
         resume_count=0,
     )
     fake_pending_approval = SimpleNamespace(approval_id="approval-1", interrupt_id="interrupt-1")

--- a/tests/unit/core/test_tasks.py
+++ b/tests/unit/core/test_tasks.py
@@ -3173,6 +3173,94 @@ class TestResumeTaskAfterApproval:
         assert rehydrated_instance.connection_url.get_secret_value() == "redis://localhost:6379"
         assert mock_chat_agent.resume_query.await_count == 1
 
+    @pytest.mark.asyncio
+    async def test_resume_task_after_approval_raises_when_rehydrate_cache_restore_fails(self):
+        approval_error = _build_approval_required_error()
+        assert approval_error.approval_record is not None
+
+        staged_instance = RedisInstance(
+            id="redis-session-instance",
+            name="session-instance",
+            connection_url="redis://localhost:6379",
+            environment="development",
+            usage="cache",
+            description="Session-scoped instance",
+            instance_type="oss_single",
+        )
+
+        task_state = _build_awaiting_task_state(approval_error.pending_approval)
+        thread = Thread(
+            thread_id="thread-456",
+            messages=[],
+            context={"instance_id": "redis-session-instance"},
+            metadata=ThreadMetadata(session_id="session-1", user_id="user-1"),
+        )
+        resume_state = _build_resume_state(approval_error.approval_record).model_copy(
+            update={
+                "staged_session_instance": {
+                    **staged_instance.model_dump(mode="json"),
+                    "connection_url": "redis://localhost:6379",
+                }
+            }
+        )
+        decided_record = approval_error.approval_record.model_copy(
+            update={
+                "status": ApprovalStatus.APPROVED,
+                "decision": ApprovalDecision(decision=ApprovalDecisionType.APPROVED),
+            }
+        )
+
+        mock_task_manager = AsyncMock()
+        mock_task_manager.get_task_state = AsyncMock(return_value=task_state)
+        mock_task_manager.set_pending_approval = AsyncMock()
+        mock_task_manager.set_resume_supported = AsyncMock()
+        mock_task_manager.update_task_status = AsyncMock()
+        mock_task_manager.add_task_update = AsyncMock()
+        mock_task_manager.set_task_result = AsyncMock()
+        mock_task_manager._publish_stream_update = AsyncMock()
+
+        mock_thread_manager = AsyncMock()
+        mock_thread_manager.get_thread = AsyncMock(return_value=thread)
+
+        mock_approval_manager = AsyncMock()
+        mock_approval_manager.get_resume_state = AsyncMock(return_value=resume_state)
+        mock_approval_manager.get_approval = AsyncMock(return_value=approval_error.approval_record)
+        mock_approval_manager.record_decision = AsyncMock(return_value=decided_record)
+        mock_approval_manager.save_resume_state = AsyncMock()
+        mock_approval_manager.delete_resume_state = AsyncMock()
+
+        with (
+            patch("redis_sre_agent.core.docket_tasks.TaskManager", return_value=mock_task_manager),
+            patch(
+                "redis_sre_agent.core.docket_tasks.ThreadManager",
+                return_value=mock_thread_manager,
+            ),
+            patch(
+                "redis_sre_agent.core.docket_tasks.ApprovalManager",
+                return_value=mock_approval_manager,
+            ),
+            patch(
+                "redis_sre_agent.core.docket_tasks._resolve_instance_for_thread",
+                new=AsyncMock(return_value=None),
+            ),
+            patch(
+                "redis_sre_agent.core.docket_tasks.add_session_instance",
+                new=AsyncMock(return_value=False),
+            ) as mock_add_session_instance,
+        ):
+            with pytest.raises(
+                ValueError, match="Failed to restore staged session instance for resume"
+            ):
+                await resume_task_after_approval(
+                    task_id="task-123",
+                    approval_id=approval_error.approval_record.approval_id,
+                    decision="approved",
+                    redis_client=MagicMock(),
+                )
+
+        mock_add_session_instance.assert_awaited_once()
+        mock_approval_manager.delete_resume_state.assert_not_awaited()
+
 
 class TestApprovalTransitions:
     @pytest.mark.asyncio

--- a/tests/unit/core/test_tasks.py
+++ b/tests/unit/core/test_tasks.py
@@ -25,6 +25,8 @@ from redis_sre_agent.core.approvals import (
 from redis_sre_agent.core.docket_tasks import (
     SRE_TASK_COLLECTION,
     _thread_messages_to_conversation_history,
+    _transition_task_to_awaiting_approval,
+    _transition_task_to_awaiting_approval_from_interrupt,
     get_redis_url,
     ingest_sre_document,
     process_agent_turn,
@@ -3170,6 +3172,77 @@ class TestResumeTaskAfterApproval:
         assert rehydrated_instance.id == "redis-session-instance"
         assert rehydrated_instance.connection_url.get_secret_value() == "redis://localhost:6379"
         assert mock_chat_agent.resume_query.await_count == 1
+
+
+class TestApprovalTransitions:
+    @pytest.mark.asyncio
+    async def test_awaiting_approval_publish_survives_snapshot_persist_failure(self):
+        approval_error = _build_approval_required_error()
+        mock_task_manager = AsyncMock()
+        mock_task_manager.set_pending_approval = AsyncMock()
+        mock_task_manager.set_resume_supported = AsyncMock()
+        mock_task_manager.add_task_update = AsyncMock()
+        mock_task_manager.set_task_result = AsyncMock()
+        mock_task_manager.update_task_status = AsyncMock()
+        mock_task_manager._publish_stream_update = AsyncMock()
+
+        with patch(
+            "redis_sre_agent.core.docket_tasks._persist_staged_session_instance_for_resume",
+            new=AsyncMock(side_effect=RuntimeError("persist failed")),
+        ):
+            result = await _transition_task_to_awaiting_approval(
+                task_manager=mock_task_manager,
+                task_id="task-123",
+                thread_id="thread-456",
+                error=approval_error,
+            )
+
+        assert result["status"] == TaskStatus.AWAITING_APPROVAL.value
+        mock_task_manager._publish_stream_update.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_interrupt_awaiting_approval_publish_survives_snapshot_persist_failure(self):
+        next_error = _build_approval_required_error(
+            tool_name="redis_cloud_deadbeef_delete_database",
+            summary="redis_cloud_deadbeef_delete_database on tgt-db-1",
+        )
+        assert next_error.pending_approval is not None
+        interrupt_payload = {
+            "kind": "approval_required",
+            "approval_id": next_error.pending_approval.approval_id,
+            "interrupt_id": next_error.pending_approval.interrupt_id,
+            "tool_name": next_error.pending_approval.tool_name,
+            "pending_approval": next_error.pending_approval.model_dump(mode="json"),
+        }
+
+        mock_task_manager = AsyncMock()
+        mock_task_manager.get_task_state = AsyncMock(return_value=None)
+        mock_task_manager.set_pending_approval = AsyncMock()
+        mock_task_manager.set_resume_supported = AsyncMock()
+        mock_task_manager.add_task_update = AsyncMock()
+        mock_task_manager.set_task_result = AsyncMock()
+        mock_task_manager.update_task_status = AsyncMock()
+        mock_task_manager._publish_stream_update = AsyncMock()
+
+        with patch(
+            "redis_sre_agent.core.docket_tasks._persist_staged_session_instance_for_resume",
+            new=AsyncMock(side_effect=RuntimeError("persist failed")),
+        ):
+            result = await _transition_task_to_awaiting_approval_from_interrupt(
+                task_manager=mock_task_manager,
+                task_id="task-123",
+                thread_id="thread-456",
+                error=GraphInterrupt(
+                    (
+                        Interrupt(
+                            value=interrupt_payload, id=next_error.pending_approval.interrupt_id
+                        ),
+                    )
+                ),
+            )
+
+        assert result["status"] == TaskStatus.AWAITING_APPROVAL.value
+        mock_task_manager._publish_stream_update.assert_awaited_once()
 
 
 class TestRunAgentWithProgress:

--- a/tests/unit/core/test_tasks.py
+++ b/tests/unit/core/test_tasks.py
@@ -2557,7 +2557,7 @@ class TestProcessAgentTurn:
         assert kwargs["context"]["target_bindings"]
 
     @pytest.mark.asyncio
-    async def test_process_agent_turn_created_instance_clears_stale_attached_scope(self):
+    async def test_process_agent_turn_staged_session_instance_clears_stale_attached_scope(self):
         mock_redis = AsyncMock()
         mock_thread = MagicMock()
         mock_thread.context = {
@@ -2630,7 +2630,7 @@ class TestProcessAgentTurn:
                 },
             ),
             patch(
-                "redis_sre_agent.core.docket_tasks.create_instance",
+                "redis_sre_agent.core.docket_tasks._stage_session_instance_from_message",
                 new=AsyncMock(return_value=new_instance),
             ),
             patch(
@@ -2638,7 +2638,7 @@ class TestProcessAgentTurn:
                 return_value=mock_chat_agent,
             ),
             patch(
-                "redis_sre_agent.core.docket_tasks.get_instance_by_id",
+                "redis_sre_agent.core.docket_tasks._resolve_instance_for_thread",
                 new=AsyncMock(return_value=new_instance),
             ),
             patch(
@@ -2663,6 +2663,196 @@ class TestProcessAgentTurn:
         assert update_call.args[1]["target_bindings"] == []
         assert update_call.args[1]["target_toolset_generation"] == 0
         assert update_call.args[1]["turn_scope"] == ""
+
+    @pytest.mark.asyncio
+    async def test_process_agent_turn_staged_session_instance_can_pause_for_approval(self):
+        approval_error = _build_approval_required_error()
+        mock_redis = AsyncMock()
+        mock_thread = MagicMock()
+        mock_thread.context = {}
+        mock_thread.messages = []
+        mock_thread.metadata.user_id = "test-user"
+        mock_thread.metadata.session_id = "session-1"
+
+        mock_thread_manager = AsyncMock()
+        mock_thread_manager.get_thread = AsyncMock(return_value=mock_thread)
+        mock_thread_manager.update_thread_context = AsyncMock()
+        mock_thread_manager.append_message = AsyncMock()
+        mock_thread_manager.update_thread = AsyncMock()
+
+        mock_task_manager = AsyncMock()
+        mock_task_manager.create_task = AsyncMock(return_value="provided-task-123")
+        mock_task_manager.add_task_update = AsyncMock()
+        mock_task_manager.set_task_result = AsyncMock()
+        mock_task_manager.set_task_error = AsyncMock()
+        mock_task_manager.set_pending_approval = AsyncMock()
+        mock_task_manager.set_resume_supported = AsyncMock()
+        mock_task_manager.update_task_status = AsyncMock()
+        mock_task_manager.get_task_state = AsyncMock(
+            return_value=_build_awaiting_task_state(approval_error.pending_approval)
+        )
+        mock_task_manager._publish_stream_update = AsyncMock()
+
+        new_instance = RedisInstance(
+            id="redis-session-instance",
+            name="session-instance",
+            connection_url="redis://localhost:6379",
+            environment="development",
+            usage="cache",
+            description="Session-scoped instance",
+            instance_type="oss_single",
+        )
+
+        mock_chat_agent = MagicMock()
+        mock_chat_agent.process_query = AsyncMock(side_effect=approval_error)
+
+        with (
+            patch("redis_sre_agent.core.docket_tasks.get_redis_client", return_value=mock_redis),
+            patch(
+                "redis_sre_agent.core.docket_tasks.ThreadManager", return_value=mock_thread_manager
+            ),
+            patch("redis_sre_agent.core.docket_tasks.TaskManager", return_value=mock_task_manager),
+            patch(
+                "redis_sre_agent.core.docket_tasks.route_to_appropriate_agent",
+                new=AsyncMock(return_value=AgentType.REDIS_CHAT),
+            ),
+            patch(
+                "redis_sre_agent.core.docket_tasks._extract_instance_details_from_message",
+                return_value={
+                    "name": "session-instance",
+                    "connection_url": "redis://localhost:6379",
+                    "environment": "development",
+                    "usage": "cache",
+                },
+            ),
+            patch(
+                "redis_sre_agent.core.docket_tasks._stage_session_instance_from_message",
+                new=AsyncMock(return_value=new_instance),
+            ) as mock_stage_instance,
+            patch(
+                "redis_sre_agent.core.docket_tasks._resolve_instance_for_thread",
+                new=AsyncMock(return_value=new_instance),
+            ),
+            patch(
+                "redis_sre_agent.core.docket_tasks.get_chat_agent",
+                return_value=mock_chat_agent,
+            ),
+            patch(
+                "redis_sre_agent.core.docket_tasks.ULID", return_value="01HXTESTMESSAGEID1234567890"
+            ),
+            patch("opentelemetry.trace.get_tracer") as mock_tracer,
+        ):
+            mock_span = MagicMock()
+            mock_span.end = MagicMock()
+            mock_span.set_attribute = MagicMock()
+            mock_tracer.return_value.start_span.return_value = mock_span
+
+            result = await process_agent_turn(
+                thread_id="thread-123",
+                message="register qa-approval-live at redis://localhost:6379/0",
+                task_id="provided-task-123",
+            )
+
+        assert result["status"] == TaskStatus.AWAITING_APPROVAL.value
+        assert result["pending_approval"]["approval_id"] == "approval-1"
+        mock_stage_instance.assert_awaited_once()
+        mock_task_manager.set_pending_approval.assert_awaited()
+        assert all(
+            len(call.args) < 3 or call.args[2] != "instance_created"
+            for call in mock_task_manager.add_task_update.await_args_list
+        )
+
+    @pytest.mark.asyncio
+    async def test_process_agent_turn_uses_freshly_staged_instance_without_redis_round_trip(self):
+        mock_redis = AsyncMock()
+        mock_thread = MagicMock()
+        mock_thread.context = {}
+        mock_thread.messages = []
+        mock_thread.metadata.user_id = "test-user"
+        mock_thread.metadata.session_id = "session-1"
+
+        mock_thread_manager = AsyncMock()
+        mock_thread_manager.get_thread = AsyncMock(return_value=mock_thread)
+        mock_thread_manager.update_thread_context = AsyncMock()
+        mock_thread_manager.append_message = AsyncMock()
+        mock_thread_manager.update_thread = AsyncMock()
+
+        mock_task_manager = AsyncMock()
+        mock_task_manager.create_task = AsyncMock(return_value="provided-task-123")
+        mock_task_manager.add_task_update = AsyncMock()
+        mock_task_manager.set_task_result = AsyncMock()
+        mock_task_manager.set_task_error = AsyncMock()
+        mock_task_manager.get_task_state = AsyncMock(return_value=MagicMock(updates=[]))
+        mock_task_manager._publish_stream_update = AsyncMock()
+
+        staged_instance = RedisInstance(
+            id="redis-session-instance",
+            name="session-instance",
+            connection_url="redis://localhost:6379",
+            environment="development",
+            usage="cache",
+            description="Session-scoped instance",
+            instance_type="oss_single",
+        )
+
+        mock_chat_agent = MagicMock()
+        mock_chat_agent.process_query = AsyncMock(
+            return_value=AgentResponse(
+                response="Chat response",
+                search_results=[],
+                tool_envelopes=[],
+            )
+        )
+
+        with (
+            patch("redis_sre_agent.core.docket_tasks.get_redis_client", return_value=mock_redis),
+            patch(
+                "redis_sre_agent.core.docket_tasks.ThreadManager", return_value=mock_thread_manager
+            ),
+            patch("redis_sre_agent.core.docket_tasks.TaskManager", return_value=mock_task_manager),
+            patch(
+                "redis_sre_agent.core.docket_tasks.route_to_appropriate_agent",
+                new=AsyncMock(return_value=AgentType.REDIS_CHAT),
+            ),
+            patch(
+                "redis_sre_agent.core.docket_tasks._extract_instance_details_from_message",
+                return_value={
+                    "name": "session-instance",
+                    "connection_url": "redis://localhost:6379",
+                    "environment": "development",
+                    "usage": "cache",
+                },
+            ),
+            patch(
+                "redis_sre_agent.core.docket_tasks._stage_session_instance_from_message",
+                new=AsyncMock(return_value=staged_instance),
+            ),
+            patch(
+                "redis_sre_agent.core.docket_tasks._resolve_instance_for_thread",
+                new=AsyncMock(return_value=None),
+            ) as mock_resolve_instance,
+            patch(
+                "redis_sre_agent.core.docket_tasks.get_chat_agent",
+                return_value=mock_chat_agent,
+            ) as mock_get_chat_agent,
+            patch(
+                "redis_sre_agent.core.docket_tasks.ULID", return_value="01HXTESTMESSAGEID1234567890"
+            ),
+            patch("opentelemetry.trace.get_tracer") as mock_tracer,
+        ):
+            mock_span = MagicMock()
+            mock_span.end = MagicMock()
+            mock_span.set_attribute = MagicMock()
+            mock_tracer.return_value.start_span.return_value = mock_span
+
+            await process_agent_turn(
+                thread_id="thread-123",
+                message="redis://localhost:6379 environment: development usage: cache",
+                task_id="provided-task-123",
+            )
+
+        mock_resolve_instance.assert_not_awaited()
+        assert mock_get_chat_agent.call_args.kwargs["redis_instance"] == staged_instance
 
 
 class TestResumeTaskAfterApproval:
@@ -2770,6 +2960,99 @@ class TestResumeTaskAfterApproval:
             pending_approval=resumed_task_state.pending_approval,
         )
         mock_approval_manager.delete_resume_state.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_resume_task_after_approval_uses_thread_scoped_instance_resolution(self):
+        approval_error = _build_approval_required_error()
+        assert approval_error.approval_record is not None
+
+        task_state = _build_awaiting_task_state(approval_error.pending_approval)
+        thread = Thread(
+            thread_id="thread-456",
+            messages=[],
+            context={"instance_id": "redis-session-instance"},
+            metadata=ThreadMetadata(session_id="session-1", user_id="user-1"),
+        )
+        resume_state = _build_resume_state(approval_error.approval_record)
+        decided_record = approval_error.approval_record.model_copy(
+            update={
+                "status": ApprovalStatus.APPROVED,
+                "decision": ApprovalDecision(decision=ApprovalDecisionType.APPROVED),
+            }
+        )
+
+        resolved_instance = RedisInstance(
+            id="redis-session-instance",
+            name="session-instance",
+            connection_url="redis://localhost:6379",
+            environment="development",
+            usage="cache",
+            description="Session-scoped instance",
+            instance_type="oss_single",
+        )
+
+        mock_task_manager = AsyncMock()
+        mock_task_manager.get_task_state = AsyncMock(
+            side_effect=[task_state, MagicMock(status=TaskStatus.IN_PROGRESS)]
+        )
+        mock_task_manager.set_pending_approval = AsyncMock()
+        mock_task_manager.set_resume_supported = AsyncMock()
+        mock_task_manager.update_task_status = AsyncMock()
+        mock_task_manager.add_task_update = AsyncMock()
+        mock_task_manager.set_task_result = AsyncMock()
+        mock_task_manager._publish_stream_update = AsyncMock()
+
+        mock_thread_manager = AsyncMock()
+        mock_thread_manager.get_thread = AsyncMock(return_value=thread)
+        mock_thread_manager.append_messages = AsyncMock()
+        mock_thread_manager.set_message_trace = AsyncMock()
+
+        mock_approval_manager = AsyncMock()
+        mock_approval_manager.get_resume_state = AsyncMock(return_value=resume_state)
+        mock_approval_manager.get_approval = AsyncMock(return_value=approval_error.approval_record)
+        mock_approval_manager.record_decision = AsyncMock(return_value=decided_record)
+        mock_approval_manager.save_resume_state = AsyncMock()
+        mock_approval_manager.delete_resume_state = AsyncMock()
+
+        mock_response = AgentResponse(
+            response="approved and completed",
+            search_results=[],
+            tool_envelopes=[],
+        )
+        mock_chat_agent = MagicMock()
+        mock_chat_agent.resume_query = AsyncMock(return_value=mock_response)
+
+        with (
+            patch("redis_sre_agent.core.docket_tasks.TaskManager", return_value=mock_task_manager),
+            patch(
+                "redis_sre_agent.core.docket_tasks.ThreadManager",
+                return_value=mock_thread_manager,
+            ),
+            patch(
+                "redis_sre_agent.core.docket_tasks.ApprovalManager",
+                return_value=mock_approval_manager,
+            ),
+            patch(
+                "redis_sre_agent.core.docket_tasks._resolve_instance_for_thread",
+                new=AsyncMock(return_value=resolved_instance),
+            ) as mock_resolve_instance,
+            patch("redis_sre_agent.agent.chat_agent.ChatAgent", return_value=mock_chat_agent),
+            patch(
+                "redis_sre_agent.agent.checkpointing.persist_approval_wait_state",
+                new=AsyncMock(),
+            ),
+        ):
+            result = await resume_task_after_approval(
+                task_id="task-123",
+                approval_id=approval_error.approval_record.approval_id,
+                decision="approved",
+                redis_client=MagicMock(),
+            )
+
+        assert result["response"]["response"] == "approved and completed"
+        mock_resolve_instance.assert_awaited_once_with("redis-session-instance", "thread-456")
+        mock_chat_agent.resume_query.assert_awaited_once()
+        mock_approval_manager.delete_resume_state.assert_awaited_once_with("task-123")
 
 
 class TestRunAgentWithProgress:

--- a/tests/unit/core/test_tasks.py
+++ b/tests/unit/core/test_tasks.py
@@ -3054,6 +3054,114 @@ class TestResumeTaskAfterApproval:
         mock_chat_agent.resume_query.assert_awaited_once()
         mock_approval_manager.delete_resume_state.assert_awaited_once_with("task-123")
 
+    @pytest.mark.asyncio
+    async def test_resume_task_after_approval_rehydrates_expired_thread_scoped_instance(self):
+        approval_error = _build_approval_required_error()
+        assert approval_error.approval_record is not None
+
+        staged_instance = RedisInstance(
+            id="redis-session-instance",
+            name="session-instance",
+            connection_url="redis://localhost:6379",
+            environment="development",
+            usage="cache",
+            description="Session-scoped instance",
+            instance_type="oss_single",
+        )
+
+        task_state = _build_awaiting_task_state(approval_error.pending_approval)
+        thread = Thread(
+            thread_id="thread-456",
+            messages=[],
+            context={"instance_id": "redis-session-instance"},
+            metadata=ThreadMetadata(session_id="session-1", user_id="user-1"),
+        )
+        resume_state = _build_resume_state(approval_error.approval_record).model_copy(
+            update={
+                "staged_session_instance": {
+                    **staged_instance.model_dump(mode="json"),
+                    "connection_url": "redis://localhost:6379",
+                }
+            }
+        )
+        decided_record = approval_error.approval_record.model_copy(
+            update={
+                "status": ApprovalStatus.APPROVED,
+                "decision": ApprovalDecision(decision=ApprovalDecisionType.APPROVED),
+            }
+        )
+
+        mock_task_manager = AsyncMock()
+        mock_task_manager.get_task_state = AsyncMock(
+            side_effect=[task_state, MagicMock(status=TaskStatus.IN_PROGRESS)]
+        )
+        mock_task_manager.set_pending_approval = AsyncMock()
+        mock_task_manager.set_resume_supported = AsyncMock()
+        mock_task_manager.update_task_status = AsyncMock()
+        mock_task_manager.add_task_update = AsyncMock()
+        mock_task_manager.set_task_result = AsyncMock()
+        mock_task_manager._publish_stream_update = AsyncMock()
+
+        mock_thread_manager = AsyncMock()
+        mock_thread_manager.get_thread = AsyncMock(return_value=thread)
+        mock_thread_manager.append_messages = AsyncMock()
+        mock_thread_manager.set_message_trace = AsyncMock()
+
+        mock_approval_manager = AsyncMock()
+        mock_approval_manager.get_resume_state = AsyncMock(return_value=resume_state)
+        mock_approval_manager.get_approval = AsyncMock(return_value=approval_error.approval_record)
+        mock_approval_manager.record_decision = AsyncMock(return_value=decided_record)
+        mock_approval_manager.save_resume_state = AsyncMock()
+        mock_approval_manager.delete_resume_state = AsyncMock()
+
+        mock_response = AgentResponse(
+            response="approved and completed",
+            search_results=[],
+            tool_envelopes=[],
+        )
+        mock_chat_agent = MagicMock()
+        mock_chat_agent.resume_query = AsyncMock(return_value=mock_response)
+
+        with (
+            patch("redis_sre_agent.core.docket_tasks.TaskManager", return_value=mock_task_manager),
+            patch(
+                "redis_sre_agent.core.docket_tasks.ThreadManager",
+                return_value=mock_thread_manager,
+            ),
+            patch(
+                "redis_sre_agent.core.docket_tasks.ApprovalManager",
+                return_value=mock_approval_manager,
+            ),
+            patch(
+                "redis_sre_agent.core.docket_tasks._resolve_instance_for_thread",
+                new=AsyncMock(return_value=None),
+            ) as mock_resolve_instance,
+            patch(
+                "redis_sre_agent.core.docket_tasks.add_session_instance",
+                new=AsyncMock(return_value=True),
+            ) as mock_add_session_instance,
+            patch("redis_sre_agent.agent.chat_agent.ChatAgent", return_value=mock_chat_agent),
+            patch(
+                "redis_sre_agent.agent.checkpointing.persist_approval_wait_state",
+                new=AsyncMock(),
+            ),
+        ):
+            result = await resume_task_after_approval(
+                task_id="task-123",
+                approval_id=approval_error.approval_record.approval_id,
+                decision="approved",
+                redis_client=MagicMock(),
+            )
+
+        assert result["response"]["response"] == "approved and completed"
+        mock_resolve_instance.assert_awaited_once_with("redis-session-instance", "thread-456")
+        mock_add_session_instance.assert_awaited_once()
+        rehydrated_instance = mock_add_session_instance.await_args.args[1]
+        assert isinstance(rehydrated_instance, RedisInstance)
+        assert rehydrated_instance.id == "redis-session-instance"
+        assert rehydrated_instance.connection_url.get_secret_value() == "redis://localhost:6379"
+        assert mock_chat_agent.resume_query.await_count == 1
+
 
 class TestRunAgentWithProgress:
     """Test run_agent_with_progress function."""

--- a/tests/unit/core/test_tasks.py
+++ b/tests/unit/core/test_tasks.py
@@ -2872,10 +2872,19 @@ class TestResumeTaskAfterApproval:
 
         task_state = _build_awaiting_task_state(initial_error.pending_approval)
         resumed_task_state = _build_awaiting_task_state(next_error.pending_approval)
+        staged_instance = RedisInstance(
+            id="redis-session-instance",
+            name="session-instance",
+            connection_url="redis://localhost:6379",
+            environment="development",
+            usage="cache",
+            description="Session-scoped instance",
+            instance_type="oss_single",
+        )
         thread = Thread(
             thread_id="thread-456",
             messages=[],
-            context={},
+            context={"instance_id": staged_instance.id},
             metadata=ThreadMetadata(session_id="session-1", user_id="user-1"),
         )
         resume_state = _build_resume_state(initial_error.approval_record)
@@ -2931,6 +2940,10 @@ class TestResumeTaskAfterApproval:
                 "redis_sre_agent.core.docket_tasks.ApprovalManager",
                 return_value=mock_approval_manager,
             ),
+            patch(
+                "redis_sre_agent.core.docket_tasks.get_session_instances",
+                new=AsyncMock(return_value=[staged_instance]),
+            ),
             patch("redis_sre_agent.agent.chat_agent.ChatAgent", return_value=mock_chat_agent),
             patch(
                 "redis_sre_agent.agent.checkpointing.persist_approval_wait_state",
@@ -2958,6 +2971,16 @@ class TestResumeTaskAfterApproval:
         mock_persist_wait_state.assert_awaited_once_with(
             task_id="task-123",
             pending_approval=resumed_task_state.pending_approval,
+        )
+        saved_resume_states = [
+            call.args[0] for call in mock_approval_manager.save_resume_state.await_args_list
+        ]
+        assert saved_resume_states
+        assert any(
+            isinstance(saved_resume_state, GraphResumeState)
+            and saved_resume_state.staged_session_instance is not None
+            and saved_resume_state.staged_session_instance["id"] == staged_instance.id
+            for saved_resume_state in saved_resume_states
         )
         mock_approval_manager.delete_resume_state.assert_not_awaited()
 

--- a/tests/unit/core/test_tasks.py
+++ b/tests/unit/core/test_tasks.py
@@ -2872,19 +2872,10 @@ class TestResumeTaskAfterApproval:
 
         task_state = _build_awaiting_task_state(initial_error.pending_approval)
         resumed_task_state = _build_awaiting_task_state(next_error.pending_approval)
-        staged_instance = RedisInstance(
-            id="redis-session-instance",
-            name="session-instance",
-            connection_url="redis://localhost:6379",
-            environment="development",
-            usage="cache",
-            description="Session-scoped instance",
-            instance_type="oss_single",
-        )
         thread = Thread(
             thread_id="thread-456",
             messages=[],
-            context={"instance_id": staged_instance.id},
+            context={"instance_id": "redis-session-instance"},
             metadata=ThreadMetadata(session_id="session-1", user_id="user-1"),
         )
         resume_state = _build_resume_state(initial_error.approval_record)
@@ -2941,14 +2932,14 @@ class TestResumeTaskAfterApproval:
                 return_value=mock_approval_manager,
             ),
             patch(
-                "redis_sre_agent.core.docket_tasks.get_session_instances",
-                new=AsyncMock(return_value=[staged_instance]),
-            ),
-            patch("redis_sre_agent.agent.chat_agent.ChatAgent", return_value=mock_chat_agent),
-            patch(
                 "redis_sre_agent.agent.checkpointing.persist_approval_wait_state",
                 new=AsyncMock(),
             ) as mock_persist_wait_state,
+            patch(
+                "redis_sre_agent.core.docket_tasks._persist_staged_session_instance_for_resume",
+                new=AsyncMock(),
+            ) as mock_persist_staged_instance,
+            patch("redis_sre_agent.agent.chat_agent.ChatAgent", return_value=mock_chat_agent),
         ):
             result = await resume_task_after_approval(
                 task_id="task-123",
@@ -2972,15 +2963,10 @@ class TestResumeTaskAfterApproval:
             task_id="task-123",
             pending_approval=resumed_task_state.pending_approval,
         )
-        saved_resume_states = [
-            call.args[0] for call in mock_approval_manager.save_resume_state.await_args_list
-        ]
-        assert saved_resume_states
-        assert any(
-            isinstance(saved_resume_state, GraphResumeState)
-            and saved_resume_state.staged_session_instance is not None
-            and saved_resume_state.staged_session_instance["id"] == staged_instance.id
-            for saved_resume_state in saved_resume_states
+        mock_persist_staged_instance.assert_awaited_once_with(
+            task_id="task-123",
+            thread_id="thread-456",
+            redis_client=mock_task_manager._redis,
         )
         mock_approval_manager.delete_resume_state.assert_not_awaited()
 


### PR DESCRIPTION
## Summary
- stop task preflight from persisting Redis instances before approval by staging extracted connection details per thread
- keep freshly staged session instances scoped to the current turn instead of converting them into unresolved handle-backed scope
- add task regressions for staged-instance approval pauses, resume resolution, and same-turn staged-instance handoff

## Validation
- `uv run ruff check redis_sre_agent/core/docket_tasks.py tests/unit/core/test_tasks.py`
- `uv run pytest tests/unit/core/test_tasks.py -k 'staged_session_instance or resume_task_after_approval or freshly_staged_instance'`
- live read-write task verification on a disposable worker pair:
  - no preflight catalog mutation from raw connection details
  - AMS working-memory read/write succeeded with `gpt-5-mini` instead of failing with `422`
  - task-scoped Redis diagnostics ran against the exact staged `redis://redis-demo:6379/0` target

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes task targeting and approval-resume state to carry thread-scoped Redis connection details (with encrypted secrets), which can affect which Redis instance operations run against after an approval pause.
> 
> **Overview**
> Fixes task-scoped Redis instance handoff by **staging user-provided connection details as thread-scoped session instances** instead of creating/persisting global instances during turn preflight.
> 
> Extends durable resume metadata (`GraphResumeState`) with `staged_session_instance` and ensures it’s persisted when transitioning to *awaiting approval*, then rehydrated on resume (including secret encryption/decryption) if the session instance isn’t otherwise resolvable.
> 
> Updates routing to keep freshly staged instances in-memory for the current turn (skipping handle-backed scope materialization / extra Redis lookups), and adds unit tests covering approval pauses, resume resolution, and failure/robustness cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0842f248340dc6d432cb8ecc9a1c83ecaa1455c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->