### PR TITLE
Unblock live QA tool and approval flows

### DIFF
--- a/redis_sre_agent/agent/chat_agent.py
+++ b/redis_sre_agent/agent/chat_agent.py
@@ -472,7 +472,8 @@ class ChatAgent:
 
             from .helpers import build_adapters_for_tooldefs as _build_adapters
 
-            tooldefs = tool_mgr.get_tools()
+            # Reserve one slot for the local expand_evidence helper.
+            tooldefs = tool_mgr.get_tools_for_llm(max_tools=127)
             adapters = await _build_adapters(tool_mgr, tooldefs)
             expand_spec = self._build_expand_evidence_tool(envelopes_container)
             expand_tool = StructuredTool.from_function(

--- a/redis_sre_agent/agent/langgraph_agent.py
+++ b/redis_sre_agent/agent/langgraph_agent.py
@@ -2357,6 +2357,7 @@ For now, I can still perform basic Redis diagnostics using the database connecti
         ) as tool_mgr:
             # Get tools and bind to LLM via StructuredTool adapters
             tools = tool_mgr.get_tools()
+            llm_tools = tool_mgr.get_tools_for_llm()
 
             logger.info(f"Loaded {len(tools)} tools for this query")
             for tool in tools:
@@ -2402,7 +2403,7 @@ For now, I can still perform basic Redis diagnostics using the database connecti
                 ),
             }
 
-            adapters = await _build_adapters(tool_mgr, tools)
+            adapters = await _build_adapters(tool_mgr, llm_tools)
 
             # Rebind LLM with tools for this query
             self.llm_with_tools = self.llm.bind_tools(adapters)
@@ -2838,8 +2839,8 @@ For now, I can still perform basic Redis diagnostics using the database connecti
                 user_id=user_id,
                 graph_type="redis_triage",
             ) as tool_mgr:
-                tools = tool_mgr.get_tools()
-                adapters = await _build_adapters(tool_mgr, tools)
+                llm_tools = tool_mgr.get_tools_for_llm()
+                adapters = await _build_adapters(tool_mgr, llm_tools)
                 self.llm_with_tools = self.llm.bind_tools(adapters)
                 self.workflow = self._build_workflow(tool_mgr, target_instance)
 

--- a/redis_sre_agent/core/config.py
+++ b/redis_sre_agent/core/config.py
@@ -49,7 +49,7 @@ class MCPToolConfig(BaseModel):
     action_kind: Optional[ToolActionKind] = Field(
         default=None,
         description="Optional approval action override for the tool. "
-        "If omitted, MCP tools remain unknown by default.",
+        "If omitted, the agent infers read/write behavior from the tool name and description.",
     )
 
 

--- a/redis_sre_agent/tools/manager.py
+++ b/redis_sre_agent/tools/manager.py
@@ -65,6 +65,7 @@ _SENSITIVE_ARG_KEYS = {
     "secret",
     "token",
 }
+_DEFAULT_LLM_TOOL_LIMIT = 128
 
 
 def interrupt(payload: Any) -> Any:
@@ -971,6 +972,65 @@ class ToolManager:
             List of ToolDefinition objects for LLM binding
         """
         return [t.definition for t in self._tools]
+
+    @staticmethod
+    def _llm_tool_priority(tool: Tool) -> tuple[int, int, str]:
+        """Rank tools for LLM binding when the provider set must be pruned.
+
+        Redis target discovery and live diagnostics stay first, followed by
+        utilities/knowledge, then observability, and finally external MCP
+        connectors. This keeps live Redis investigation functional when a
+        dynamic target attachment would otherwise exceed provider limits.
+        """
+        provider_name = str(tool.metadata.provider_name or "")
+        capability = tool.metadata.capability
+
+        if provider_name == "target_discovery":
+            priority = 0
+        elif provider_name == "redis_command":
+            priority = 1
+        elif provider_name in {"redis_enterprise_admin", "redis_cloud"}:
+            priority = 2
+        elif capability is ToolCapability.UTILITIES:
+            priority = 3
+        elif capability is ToolCapability.KNOWLEDGE:
+            priority = 4
+        elif capability is ToolCapability.DIAGNOSTICS:
+            priority = 5
+        elif capability is ToolCapability.METRICS:
+            priority = 6
+        elif capability is ToolCapability.LOGS:
+            priority = 7
+        elif capability is ToolCapability.TRACES:
+            priority = 8
+        elif capability in {ToolCapability.TICKETS, ToolCapability.REPOS}:
+            priority = 9
+        else:
+            priority = 10
+
+        # When priorities tie, keep built-in providers ahead of external MCP tools.
+        mcp_bias = 1 if provider_name.startswith("mcp_") else 0
+        return (priority, mcp_bias, tool.metadata.name)
+
+    def get_tools_for_llm(
+        self, *, max_tools: int = _DEFAULT_LLM_TOOL_LIMIT
+    ) -> List[ToolDefinition]:
+        """Return a tool list safe for model binding under provider limits."""
+        if max_tools <= 0:
+            return []
+        if len(self._tools) <= max_tools:
+            return self.get_tools()
+
+        prioritized_tools = sorted(self._tools, key=self._llm_tool_priority)
+        selected_tools = prioritized_tools[:max_tools]
+        dropped_tools = prioritized_tools[max_tools:]
+        logger.warning(
+            "Pruned LLM toolset from %s to %s tools; dropped=%s",
+            len(self._tools),
+            len(selected_tools),
+            [tool.metadata.name for tool in dropped_tools[:10]],
+        )
+        return [tool.definition for tool in selected_tools]
 
     def get_tools_by_provider_names(self, provider_names: List[str]) -> List[ToolDefinition]:
         """Return tools belonging to providers with given provider_name values.

--- a/redis_sre_agent/tools/mcp/provider.py
+++ b/redis_sre_agent/tools/mcp/provider.py
@@ -24,6 +24,7 @@ from redis_sre_agent.tools.models import (
     ToolCapability,
     ToolDefinition,
     ToolMetadata,
+    infer_tool_action_kind,
 )
 from redis_sre_agent.tools.protocols import ToolProvider
 
@@ -332,12 +333,22 @@ class MCPToolProvider(ToolProvider):
             return config.description
         return mcp_description
 
-    def _get_action_kind(self, tool_name: str) -> ToolActionKind:
+    def _get_action_kind(
+        self,
+        tool_name: str,
+        description: str,
+        capability: ToolCapability,
+    ) -> ToolActionKind:
         """Get the approval action kind for a tool, with config override support."""
         config = self._get_tool_config(tool_name)
         if config and config.action_kind is not None:
             return config.action_kind
-        return ToolActionKind.UNKNOWN
+        return infer_tool_action_kind(
+            name=tool_name,
+            description=description,
+            capability=capability,
+            provider_name=self.provider_name,
+        )
 
     def create_tool_schemas(self) -> List[ToolDefinition]:
         """Create tool schemas from the MCP server's tools.
@@ -418,7 +429,11 @@ class MCPToolProvider(ToolProvider):
                 capability=schema.capability,
                 provider_name=self.provider_name,
                 requires_instance=False,  # MCP tools typically don't require Redis instance
-                action_kind=self._get_action_kind(mcp_tool_name),
+                action_kind=self._get_action_kind(
+                    mcp_tool_name,
+                    schema.description,
+                    schema.capability,
+                ),
             )
 
             # Create the invoke closure that calls the MCP server

--- a/redis_sre_agent/tools/models.py
+++ b/redis_sre_agent/tools/models.py
@@ -117,9 +117,10 @@ def _extract_operation_name(tool_name: str, provider_name: str) -> str:
     if re.match(prefix_pattern, tool_name):
         return re.sub(prefix_pattern, "", tool_name, count=1)
     # MCP providers sometimes pass the already-resolved operation name (for
-    # example "_create_branch"). Preserve that verb-bearing form instead of
-    # splitting it again and dropping the leading action token.
-    if tool_name.startswith("_"):
+    # example "_create_branch" or "list_pull_requests"). Preserve that
+    # verb-bearing form instead of splitting it again and dropping the action
+    # token.
+    if provider_name.startswith("mcp_") or tool_name.startswith("_"):
         return tool_name
     parts = tool_name.split("_")
     if len(parts) >= 3:

--- a/redis_sre_agent/tools/models.py
+++ b/redis_sre_agent/tools/models.py
@@ -131,14 +131,11 @@ def infer_tool_action_kind(
 ) -> ToolActionKind:
     """Infer the approval-relevant action kind for a tool.
 
-    Built-in providers default to conservative name/description inference.
-    Dynamic MCP tools stay ``unknown`` unless explicitly overridden by callers.
+    Providers default to conservative name/description inference. Callers can
+    still override the result explicitly when a tool needs stricter handling.
     """
 
-    if provider_name.startswith("mcp_"):
-        return ToolActionKind.UNKNOWN
-
-    operation = _extract_operation_name(name, provider_name).lower()
+    operation = _extract_operation_name(name, provider_name).lower().lstrip("_")
     description_lower = description.lower()
 
     if operation in _READ_EXACT:

--- a/redis_sre_agent/tools/models.py
+++ b/redis_sre_agent/tools/models.py
@@ -116,6 +116,11 @@ def _extract_operation_name(tool_name: str, provider_name: str) -> str:
     prefix_pattern = rf"^{re.escape(provider_name)}_[^_]+_"
     if re.match(prefix_pattern, tool_name):
         return re.sub(prefix_pattern, "", tool_name, count=1)
+    # MCP providers sometimes pass the already-resolved operation name (for
+    # example "_create_branch"). Preserve that verb-bearing form instead of
+    # splitting it again and dropping the leading action token.
+    if tool_name.startswith("_"):
+        return tool_name
     parts = tool_name.split("_")
     if len(parts) >= 3:
         return "_".join(parts[2:])

--- a/tests/unit/tools/mcp_provider/test_mcp_provider.py
+++ b/tests/unit/tools/mcp_provider/test_mcp_provider.py
@@ -177,6 +177,20 @@ class TestMCPToolProvider:
             == ToolActionKind.UNKNOWN
         )
 
+    def test_get_action_kind_keeps_leading_verb_for_resolved_mcp_operation_names(self):
+        """Test that already-resolved MCP operation names still infer write intent."""
+        config = MCPServerConfig(command="test")
+        provider = MCPToolProvider(server_name="github", server_config=config)
+
+        assert (
+            provider._get_action_kind(
+                "_update_repository",
+                "Operate on repository settings for the selected repo.",
+                ToolCapability.UTILITIES,
+            )
+            == ToolActionKind.WRITE
+        )
+
     def test_get_tool_config(self):
         """Test getting tool config."""
         tool_config = MCPToolConfig(

--- a/tests/unit/tools/mcp_provider/test_mcp_provider.py
+++ b/tests/unit/tools/mcp_provider/test_mcp_provider.py
@@ -136,9 +136,46 @@ class TestMCPToolProvider:
         )
         provider = MCPToolProvider(server_name="test", server_config=config)
 
-        assert provider._get_action_kind("query_tool") == ToolActionKind.READ
-        assert provider._get_action_kind("mutate_tool") == ToolActionKind.WRITE
-        assert provider._get_action_kind("unknown") == ToolActionKind.UNKNOWN
+        assert (
+            provider._get_action_kind("query_tool", "Read current state.", ToolCapability.UTILITIES)
+            == ToolActionKind.READ
+        )
+        assert (
+            provider._get_action_kind(
+                "mutate_tool", "Write current state.", ToolCapability.UTILITIES
+            )
+            == ToolActionKind.WRITE
+        )
+
+    def test_get_action_kind_infers_from_mcp_tool_name_and_description(self):
+        """Test that MCP tools infer action kinds when no override is configured."""
+        config = MCPServerConfig(command="test")
+        provider = MCPToolProvider(server_name="github", server_config=config)
+
+        assert (
+            provider._get_action_kind(
+                "_create_branch",
+                "Create a new branch in the given repository.",
+                ToolCapability.REPOS,
+            )
+            == ToolActionKind.WRITE
+        )
+        assert (
+            provider._get_action_kind(
+                "_search_repositories",
+                "Search for a repository by name or description.",
+                ToolCapability.REPOS,
+            )
+            == ToolActionKind.READ
+        )
+        assert (
+            provider._get_action_kind(
+                "custom_operation",
+                "Runs a custom operation for the current selection.",
+                ToolCapability.REPOS,
+            )
+            == ToolActionKind.UNKNOWN
+        )
 
     def test_get_tool_config(self):
         """Test getting tool config."""

--- a/tests/unit/tools/mcp_provider/test_mcp_provider.py
+++ b/tests/unit/tools/mcp_provider/test_mcp_provider.py
@@ -191,6 +191,20 @@ class TestMCPToolProvider:
             == ToolActionKind.WRITE
         )
 
+    def test_get_action_kind_keeps_read_verb_for_multi_part_mcp_operation_names(self):
+        """Test that resolved MCP operation names like list_pull_requests stay intact."""
+        config = MCPServerConfig(command="test")
+        provider = MCPToolProvider(server_name="github", server_config=config)
+
+        assert (
+            provider._get_action_kind(
+                "list_pull_requests",
+                "Operate on the selected pull request collection.",
+                ToolCapability.REPOS,
+            )
+            == ToolActionKind.READ
+        )
+
     def test_get_tool_config(self):
         """Test getting tool config."""
         tool_config = MCPToolConfig(

--- a/tests/unit/tools/test_manager.py
+++ b/tests/unit/tools/test_manager.py
@@ -181,6 +181,54 @@ async def test_tool_manager_knowledge_tools():
         assert len(redis_command_tools) == 0
 
 
+def test_get_tools_for_llm_prioritizes_target_discovery_and_redis_diagnostics():
+    mgr = ToolManager()
+
+    _register_tool(
+        mgr,
+        name="mcp_github_deadbe_search_repositories",
+        action_kind=ToolActionKind.READ,
+        invoke=AsyncMock(return_value={"status": "ok"}),
+        description="Search repositories",
+        capability=ToolCapability.REPOS,
+        provider_name="mcp_github",
+    )
+    _register_tool(
+        mgr,
+        name="knowledge_deadbe_search",
+        action_kind=ToolActionKind.READ,
+        invoke=AsyncMock(return_value={"status": "ok"}),
+        description="Search knowledge",
+        capability=ToolCapability.KNOWLEDGE,
+        provider_name="knowledge",
+    )
+    _register_tool(
+        mgr,
+        name="target_discovery_deadbe_resolve_redis_targets",
+        action_kind=ToolActionKind.READ,
+        invoke=AsyncMock(return_value={"status": "ok"}),
+        description="Resolve Redis targets",
+        capability=ToolCapability.UTILITIES,
+        provider_name="target_discovery",
+    )
+    _register_tool(
+        mgr,
+        name="redis_command_deadbe_info",
+        action_kind=ToolActionKind.READ,
+        invoke=AsyncMock(return_value={"status": "ok"}),
+        description="Get Redis INFO",
+        capability=ToolCapability.DIAGNOSTICS,
+        provider_name="redis_command",
+    )
+
+    tool_names = [tool.name for tool in mgr.get_tools_for_llm(max_tools=2)]
+
+    assert tool_names == [
+        "target_discovery_deadbe_resolve_redis_targets",
+        "redis_command_deadbe_info",
+    ]
+
+
 @pytest.mark.asyncio
 async def test_attach_bound_targets_scopes_instance_tools_to_opaque_handle():
     """Attached targets should re-scope providers to the opaque target handle."""

--- a/tests/unit/tools/test_models.py
+++ b/tests/unit/tools/test_models.py
@@ -58,15 +58,26 @@ def test_tool_metadata_infers_write_action_for_builtin_mutating_operations():
     assert metadata.action_kind is ToolActionKind.WRITE
 
 
-def test_tool_metadata_keeps_mcp_tools_unknown_by_default():
+def test_tool_metadata_infers_write_action_for_mcp_mutating_operations():
     metadata = ToolMetadata(
-        name="mcp_atlassian_deadbeef_confluence_update_page",
-        description="Update a Confluence page.",
+        name="mcp_github_deadbeef__create_branch",
+        description="Create a new branch in the repository.",
         capability=ToolCapability.UTILITIES,
-        provider_name="mcp_atlassian",
+        provider_name="mcp_github",
     )
 
-    assert metadata.action_kind is ToolActionKind.UNKNOWN
+    assert metadata.action_kind is ToolActionKind.WRITE
+
+
+def test_tool_metadata_infers_read_action_for_mcp_read_operations():
+    metadata = ToolMetadata(
+        name="mcp_github_deadbeef__search_repositories",
+        description="Search repositories within the user's installations.",
+        capability=ToolCapability.REPOS,
+        provider_name="mcp_github",
+    )
+
+    assert metadata.action_kind is ToolActionKind.READ
 
 
 def test_tool_metadata_respects_explicit_action_override():


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes which tools are exposed to the LLM and how MCP tools are classified as read vs write, which can affect tool availability and HITL approval behavior at runtime. The pruning heuristics and inference logic could unintentionally hide needed tools or misclassify actions if naming/description conventions vary.
> 
> **Overview**
> **Tool binding now respects provider tool-count limits.** `ToolManager.get_tools_for_llm()` was added to cap the number of tools bound to the LLM (default 128) and prune overflow using a priority order that keeps target discovery and Redis live diagnostics first; `ChatAgent` reserves a slot for its local `expand_evidence` tool.
> 
> **MCP tools now infer `READ`/`WRITE` by default.** MCP provider action-kind defaults changed from always `UNKNOWN` to using `infer_tool_action_kind()` based on tool name/description/capability (with config overrides still supported), including fixes to preserve leading verbs for resolved MCP operation names. Unit tests were updated/added to cover pruning priority and the new inference behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c38532e8476e31a4c4cab72f3e65121bad10ae00. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->