### PR TITLE
Publish Docker images on releases

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -77,7 +77,8 @@ jobs:
             ghcr.io/${{ github.repository }}
           tags: |
             type=raw,value=${{ github.event_name == 'release' && github.event.release.tag_name || github.event.inputs.tag }}
-            type=raw,value=latest,enable=${{ github.event_name == 'release' && !github.event.release.prerelease || github.event.inputs.push_latest }}
+            type=raw,value=latest,enable=${{ github.event_name == 'release' && !github.event.release.prerelease }}
+            type=raw,value=latest,enable=${{ github.event_name == 'workflow_dispatch' && github.event.inputs.push_latest == 'true' }}
             type=sha,prefix=sha-
 
       - name: Free Disk Space (Ubuntu)
@@ -145,7 +146,8 @@ jobs:
             ghcr.io/${{ github.repository_owner }}/redis-sre-agent-ui
           tags: |
             type=raw,value=${{ github.event_name == 'release' && github.event.release.tag_name || github.event.inputs.tag }}
-            type=raw,value=latest,enable=${{ github.event_name == 'release' && !github.event.release.prerelease || github.event.inputs.push_latest }}
+            type=raw,value=latest,enable=${{ github.event_name == 'release' && !github.event.release.prerelease }}
+            type=raw,value=latest,enable=${{ github.event_name == 'workflow_dispatch' && github.event.inputs.push_latest == 'true' }}
             type=sha,prefix=sha-
 
       - name: Build and push UI Docker image
@@ -237,7 +239,8 @@ jobs:
             ghcr.io/${{ github.repository }}
           tags: |
             type=raw,value=${{ (github.event_name == 'release' && github.event.release.tag_name || github.event.inputs.tag) }}-airgap
-            type=raw,value=airgap,enable=${{ github.event_name == 'release' && !github.event.release.prerelease || github.event.inputs.push_latest }}
+            type=raw,value=airgap,enable=${{ github.event_name == 'release' && !github.event.release.prerelease }}
+            type=raw,value=airgap,enable=${{ github.event_name == 'workflow_dispatch' && github.event.inputs.push_latest == 'true' }}
 
       - name: Build and push air-gap Docker image
         uses: docker/build-push-action@v5
@@ -294,7 +297,8 @@ jobs:
             ghcr.io/${{ github.repository_owner }}/redis-sre-agent-ui
           tags: |
             type=raw,value=${{ (github.event_name == 'release' && github.event.release.tag_name || github.event.inputs.tag) }}-airgap
-            type=raw,value=airgap,enable=${{ github.event_name == 'release' && !github.event.release.prerelease || github.event.inputs.push_latest }}
+            type=raw,value=airgap,enable=${{ github.event_name == 'release' && !github.event.release.prerelease }}
+            type=raw,value=airgap,enable=${{ github.event_name == 'workflow_dispatch' && github.event.inputs.push_latest == 'true' }}
 
       - name: Build and push air-gap UI Docker image
         uses: docker/build-push-action@v5

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -28,6 +28,7 @@ permissions:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    timeout-minutes: 90
 
     steps:
       - name: Checkout code
@@ -108,6 +109,7 @@ jobs:
 
   publish-ui:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
 
     steps:
       - name: Checkout code
@@ -164,6 +166,7 @@ jobs:
 
   publish-airgap:
     runs-on: ubuntu-latest
+    timeout-minutes: 180
     if: ${{ github.event_name == 'release' || github.event.inputs.build_airgap == 'true' }}
 
     steps:
@@ -254,6 +257,7 @@ jobs:
 
   publish-ui-airgap:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     if: ${{ github.event_name == 'release' || github.event.inputs.build_airgap == 'true' }}
 
     steps:

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -17,6 +17,9 @@ on:
         required: false
         type: boolean
         default: true
+  release:
+    types:
+      - published
 
 permissions:
   contents: read
@@ -72,8 +75,8 @@ jobs:
             redislabs/redis-sre-agent
             ghcr.io/${{ github.repository }}
           tags: |
-            type=raw,value=${{ github.event.inputs.tag }}
-            type=raw,value=latest,enable=${{ github.event.inputs.push_latest }}
+            type=raw,value=${{ github.event_name == 'release' && github.event.release.tag_name || github.event.inputs.tag }}
+            type=raw,value=latest,enable=${{ github.event_name == 'release' && !github.event.release.prerelease || github.event.inputs.push_latest }}
             type=sha,prefix={{branch}}-
 
       - name: Free Disk Space (Ubuntu)
@@ -139,8 +142,8 @@ jobs:
             redislabs/redis-sre-agent-ui
             ghcr.io/${{ github.repository_owner }}/redis-sre-agent-ui
           tags: |
-            type=raw,value=${{ github.event.inputs.tag }}
-            type=raw,value=latest,enable=${{ github.event.inputs.push_latest }}
+            type=raw,value=${{ github.event_name == 'release' && github.event.release.tag_name || github.event.inputs.tag }}
+            type=raw,value=latest,enable=${{ github.event_name == 'release' && !github.event.release.prerelease || github.event.inputs.push_latest }}
             type=sha,prefix={{branch}}-
 
       - name: Build and push UI Docker image
@@ -161,7 +164,7 @@ jobs:
 
   publish-airgap:
     runs-on: ubuntu-latest
-    if: ${{ github.event.inputs.build_airgap == 'true' }}
+    if: ${{ github.event_name == 'release' || github.event.inputs.build_airgap == 'true' }}
 
     steps:
       # Free disk space FIRST before anything else
@@ -230,8 +233,8 @@ jobs:
             redislabs/redis-sre-agent
             ghcr.io/${{ github.repository }}
           tags: |
-            type=raw,value=${{ github.event.inputs.tag }}-airgap
-            type=raw,value=airgap,enable=${{ github.event.inputs.push_latest }}
+            type=raw,value=${{ (github.event_name == 'release' && github.event.release.tag_name || github.event.inputs.tag) }}-airgap
+            type=raw,value=airgap,enable=${{ github.event_name == 'release' && !github.event.release.prerelease || github.event.inputs.push_latest }}
 
       - name: Build and push air-gap Docker image
         uses: docker/build-push-action@v5
@@ -251,7 +254,7 @@ jobs:
 
   publish-ui-airgap:
     runs-on: ubuntu-latest
-    if: ${{ github.event.inputs.build_airgap == 'true' }}
+    if: ${{ github.event_name == 'release' || github.event.inputs.build_airgap == 'true' }}
 
     steps:
       - name: Checkout code
@@ -286,8 +289,8 @@ jobs:
             redislabs/redis-sre-agent-ui
             ghcr.io/${{ github.repository_owner }}/redis-sre-agent-ui
           tags: |
-            type=raw,value=${{ github.event.inputs.tag }}-airgap
-            type=raw,value=airgap,enable=${{ github.event.inputs.push_latest }}
+            type=raw,value=${{ (github.event_name == 'release' && github.event.release.tag_name || github.event.inputs.tag) }}-airgap
+            type=raw,value=airgap,enable=${{ github.event_name == 'release' && !github.event.release.prerelease || github.event.inputs.push_latest }}
 
       - name: Build and push air-gap UI Docker image
         uses: docker/build-push-action@v5

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -78,7 +78,7 @@ jobs:
           tags: |
             type=raw,value=${{ github.event_name == 'release' && github.event.release.tag_name || github.event.inputs.tag }}
             type=raw,value=latest,enable=${{ github.event_name == 'release' && !github.event.release.prerelease || github.event.inputs.push_latest }}
-            type=sha,prefix={{branch}}-
+            type=sha,prefix=sha-
 
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@main
@@ -146,7 +146,7 @@ jobs:
           tags: |
             type=raw,value=${{ github.event_name == 'release' && github.event.release.tag_name || github.event.inputs.tag }}
             type=raw,value=latest,enable=${{ github.event_name == 'release' && !github.event.release.prerelease || github.event.inputs.push_latest }}
-            type=sha,prefix={{branch}}-
+            type=sha,prefix=sha-
 
       - name: Build and push UI Docker image
         uses: docker/build-push-action@v5

--- a/Dockerfile.airgap
+++ b/Dockerfile.airgap
@@ -42,8 +42,12 @@ ENV UV_LINK_MODE=copy
 ENV UV_PYTHON_INSTALL_DIR=/opt/uv/python
 
 # Install build dependencies (no network-fetching scripts)
+# build-essential/pkg-config keep uv installs resilient when a dependency
+# falls back to building a native extension from source.
 RUN apt-get update && apt-get install -y \
+    build-essential \
     git \
+    pkg-config \
     curl \
     && rm -rf /var/lib/apt/lists/*
 

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -1,5 +1,7 @@
 # Multi-stage Dockerfile for Redis SRE Agent UI
-FROM node:20-alpine AS base
+# Use the Debian-based Node image for build stages; the Alpine variant hit
+# arm64/QEMU illegal-instruction failures in CI during npm install.
+FROM node:20-bookworm-slim AS base
 
 # Set working directory
 WORKDIR /app


### PR DESCRIPTION
## Summary
- trigger Docker publishing automatically when a GitHub release is published
- keep manual workflow dispatch support for ad hoc image publishes
- derive normal and air-gap tags from the release tag for release-triggered runs

## Testing
- `make test`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/publish-docker.yml"); puts "YAML OK"'`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the release pipeline and tagging rules for multi-arch Docker publishes; mistakes could push incorrect `latest`/air-gap tags or trigger heavier builds unexpectedly.
> 
> **Overview**
> Adds a `release.published` trigger to the Docker publish workflow so images are built and pushed automatically on GitHub releases, while keeping `workflow_dispatch` for manual runs.
> 
> Updates Docker tag generation to derive the primary tag from the release tag name, only publish `latest`/`airgap` on non-prerelease releases (or when explicitly requested via dispatch), and standardizes SHA tagging to `sha-`.
> 
> Tightens CI reliability by adding job timeouts, running air-gap jobs on releases by default, adding build deps (`build-essential`, `pkg-config`) to `Dockerfile.airgap`, and switching the UI build base image from `node:20-alpine` to `node:20-bookworm-slim` to avoid arm64/QEMU install failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd6b5f83969d681588a3c21a707a2ef0ca258e24. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->