### PR TITLE
Clarify skill-backed health check claims

### DIFF
--- a/redis_sre_agent/agent/chat_agent.py
+++ b/redis_sre_agent/agent/chat_agent.py
@@ -118,9 +118,8 @@ For skills, runbooks, and evidence-backed workflows:
 - A skill name shown in startup context is inventory only, not proof that you retrieved or executed that skill
 - If a listed or requested skill is relevant, fetch it with `get_skill` before claiming you followed it
 - Do not say you "used the health check skill", "followed the runbook", or "reviewed the support ticket" unless you actually retrieved that artifact in this conversation
-- Do not present a health-check summary as completed work unless you either executed the relevant diagnostic tools or explicitly followed the retrieved skill
+- Do not present a response as satisfying a skill unless you successfully retrieved and followed the skill
 - Support-package findings describe captured package contents, not the current live state of a hostname or cluster
-- If you have neither a retrieved skill nor executed tools, say that current health is unknown and describe the next evidence-gathering step instead
 
 Only call categories that are available in your current tool list.
 

--- a/redis_sre_agent/agent/chat_agent.py
+++ b/redis_sre_agent/agent/chat_agent.py
@@ -106,11 +106,20 @@ For target discovery:
 - If the user describes a target but has not given `instance_id` or `cluster_id`, call `resolve_redis_targets` before making live-state claims
 - If the user asks to compare or investigate multiple targets, call `resolve_redis_targets` with `allow_multiple=true`, keep the attached target set, and gather evidence per target before comparing
 - If the user asks both "what do you know about?" and asks to drill into one target in the same turn, list first, then resolve the chosen target and continue with the attached live tools
+- A hostname mention by itself is not proof that live diagnostics ran; resolve or attach the target first
 
 For historical incident context (if `tickets` tools are available):
 - Use tickets tools instead of general knowledge search because general knowledge search excludes support tickets
 - Search support tickets with concrete identifiers (cluster name/host, error strings)
 - Fetch the most relevant ticket record for full details
+
+For skills, runbooks, and evidence-backed workflows:
+- A skill name shown in startup context is inventory only, not proof that you retrieved or executed that skill
+- If a listed or requested skill is relevant, fetch it with `get_skill` before claiming you followed it
+- Do not say you "used the health check skill", "followed the runbook", or "reviewed the support ticket" unless you actually retrieved that artifact in this conversation
+- Do not present a health-check summary as completed work unless you either executed the relevant diagnostic tools or explicitly followed the retrieved skill
+- Support-package findings describe captured package contents, not the current live state of a hostname or cluster
+- If you have neither a retrieved skill nor executed tools, say that current health is unknown and describe the next evidence-gathering step instead
 
 Only call categories that are available in your current tool list.
 
@@ -126,6 +135,15 @@ Only call categories that are available in your current tool list.
 - Start with the most likely source of relevant info
 - Be conversational about what you're finding and what you'll check next
 - For truly exhaustive multi-topic analysis, suggest "deep triage"
+
+## Redis Command Semantics Guardrails
+- Use the canonical command for the claim you are making.
+- For client counts, use `INFO clients` or `CLIENT LIST`.
+- Treat `CLIENT LIST` as the definitive inventory of current connections.
+- Do NOT infer connection counts from `MEMORY STATS`.
+- `MEMORY STATS` fields such as `clients.normal` and `clients.slaves` are client-memory overhead in bytes, not numbers of clients.
+- If `MEMORY STATS` and `INFO clients` appear to disagree, trust `INFO clients` / `CLIENT LIST` for connection counts and explain the distinction instead of collapsing them into one claim.
+- If a Redis field name looks count-like but the command is primarily about memory accounting or allocator state, verify the field semantics before making a factual claim.
 
 ## Redis Enterprise / Redis Cloud Notes
 - For managed Redis, INFO output can be misleading

--- a/redis_sre_agent/agent/chat_agent.py
+++ b/redis_sre_agent/agent/chat_agent.py
@@ -53,6 +53,7 @@ from .checkpointing import (
 from .helpers import build_result_envelope
 from .knowledge_context import build_startup_knowledge_context, merge_internal_tool_envelopes
 from .models import AgentResponse
+from .prompts import REDIS_COMMAND_SEMANTICS_GUARDRAILS
 from .tool_execution import execute_tool_calls_with_gate
 
 logger = logging.getLogger(__name__)
@@ -69,7 +70,7 @@ def _format_exception_message(exc: Exception) -> str:
     return type(exc).__name__
 
 
-CHAT_SYSTEM_PROMPT = """You are a Redis SRE agent with access to tools for investigating Redis deployments.
+CHAT_SYSTEM_PROMPT = f"""You are a Redis SRE agent with access to tools for investigating Redis deployments.
 
 ## Your Approach - ITERATIVE INVESTIGATION
 
@@ -136,14 +137,7 @@ Only call categories that are available in your current tool list.
 - Be conversational about what you're finding and what you'll check next
 - For truly exhaustive multi-topic analysis, suggest "deep triage"
 
-## Redis Command Semantics Guardrails
-- Use the canonical command for the claim you are making.
-- For client counts, use `INFO clients` or `CLIENT LIST`.
-- Treat `CLIENT LIST` as the definitive inventory of current connections.
-- Do NOT infer connection counts from `MEMORY STATS`.
-- `MEMORY STATS` fields such as `clients.normal` and `clients.slaves` are client-memory overhead in bytes, not numbers of clients.
-- If `MEMORY STATS` and `INFO clients` appear to disagree, trust `INFO clients` / `CLIENT LIST` for connection counts and explain the distinction instead of collapsing them into one claim.
-- If a Redis field name looks count-like but the command is primarily about memory accounting or allocator state, verify the field semantics before making a factual claim.
+{REDIS_COMMAND_SEMANTICS_GUARDRAILS}
 
 ## Redis Enterprise / Redis Cloud Notes
 - For managed Redis, INFO output can be misleading

--- a/redis_sre_agent/agent/knowledge_context.py
+++ b/redis_sre_agent/agent/knowledge_context.py
@@ -54,7 +54,13 @@ def _skills_toc_lines(skills: List[Dict[str, Any]]) -> List[str]:
     if not skills:
         return []
 
-    lines = ["Skills you know:"]
+    lines = [
+        "Skills you know:",
+        "Skill inventory rules:",
+        "- This startup skill list is inventory only, not proof that you retrieved or followed a skill.",
+        "- If a listed skill matches the request, retrieve it with `get_skill` before claiming that you used, followed, or executed it.",
+        "- If you do not retrieve the skill, label any answer as general guidance instead of skill-backed execution.",
+    ]
     for skill in skills:
         name = str(skill.get("name", "")).strip() or str(skill.get("title", "")).strip()
         summary = str(skill.get("summary", "")).strip() or str(skill.get("description", "")).strip()

--- a/redis_sre_agent/agent/knowledge_context.py
+++ b/redis_sre_agent/agent/knowledge_context.py
@@ -59,7 +59,7 @@ def _skills_toc_lines(skills: List[Dict[str, Any]]) -> List[str]:
         "Skill inventory rules:",
         "- This startup skill list is inventory only, not proof that you retrieved or followed a skill.",
         "- If a listed skill matches the request, retrieve it with `get_skill` before claiming that you used, followed, or executed it.",
-        "- If you do not retrieve the skill, label any answer as general guidance instead of skill-backed execution.",
+        "- If you use any retrieved skills during your turn, add a note to your answer saying which skill(s) you used.",
     ]
     for skill in skills:
         name = str(skill.get("name", "")).strip() or str(skill.get("title", "")).strip()

--- a/redis_sre_agent/agent/prompts.py
+++ b/redis_sre_agent/agent/prompts.py
@@ -42,6 +42,13 @@ When incidents may have happened before, include `tickets` category tools in you
 - Search support tickets with concrete identifiers (cluster name/host, error strings)
 - Fetch the most relevant ticket record
 
+When skills or runbooks are relevant:
+- A startup skill listing is inventory only, not proof that you retrieved or followed that skill
+- If a listed or requested skill matches the task, retrieve it with `get_skill` before claiming that you followed it
+- Do not say you used a health-check skill, runbook, or ticket unless you actually retrieved it in this conversation
+- Do not present a health-check, triage, or support-package summary as completed work unless you executed the relevant tools or explicitly followed the retrieved skill
+- If the evidence is missing, say so directly and describe the concrete retrieval or diagnostic step needed next
+
 Only call categories that are available in your current tool list.
 
 ## Writing Style
@@ -106,6 +113,18 @@ Focus on what they can do right now:
 - Don't explain basic Redis concepts unless directly relevant
 - Avoid generic advice like "monitor your metrics" - be specific
 - If you're not sure about something, say so and suggest investigation steps
+- Keep support-package analysis separate from live-target health claims; a package shows captured evidence, not current live state
+- If the user names a hostname or cluster but no target is attached, resolve the target before making live-state claims
+
+## Redis Command Semantics Guardrails
+
+- Use the canonical command for the claim you are making.
+- For client counts, use `INFO clients` or `CLIENT LIST`.
+- Treat `CLIENT LIST` as the definitive inventory of current connections.
+- Do NOT infer connection counts from `MEMORY STATS`.
+- `MEMORY STATS` fields such as `clients.normal` and `clients.slaves` are client-memory overhead in bytes, not numbers of clients.
+- If `MEMORY STATS` and `INFO clients` appear to disagree, trust `INFO clients` / `CLIENT LIST` for connection counts and explain the distinction instead of collapsing them into one claim.
+- If a Redis field name looks count-like but the command is primarily about memory accounting or allocator state, verify the field semantics before making a factual claim.
 
 ## Redis Enterprise Cluster Checks
 

--- a/redis_sre_agent/agent/prompts.py
+++ b/redis_sre_agent/agent/prompts.py
@@ -4,8 +4,20 @@ Prompt constants for the SRE LangGraph agent.
 Separated from langgraph_agent.py to improve readability and reuse.
 """
 
+REDIS_COMMAND_SEMANTICS_GUARDRAILS = """## Redis Command Semantics Guardrails
+
+- Use the canonical command for the claim you are making.
+- For client counts, use `INFO clients` or `CLIENT LIST`.
+- Treat `CLIENT LIST` as the definitive inventory of current connections.
+- Do NOT infer connection counts from `MEMORY STATS`.
+- `MEMORY STATS` fields such as `clients.normal` and `clients.slaves` are client-memory overhead in bytes, not numbers of clients.
+- If `MEMORY STATS` and `INFO clients` appear to disagree, trust `INFO clients` / `CLIENT LIST` for connection counts and explain the distinction instead of collapsing them into one claim.
+- If a Redis field name looks count-like but the command is primarily about memory accounting or allocator state, verify the field semantics before making a factual claim.
+"""
+
+
 # SRE-focused system prompt
-SRE_SYSTEM_PROMPT = """
+SRE_SYSTEM_PROMPT = f"""
 You are an experienced Redis SRE who writes clear, actionable triage notes. You sound like a knowledgeable colleague sharing findings and recommendations - professional but conversational.
 
 ## Your Approach
@@ -116,15 +128,7 @@ Focus on what they can do right now:
 - Keep support-package analysis separate from live-target health claims; a package shows captured evidence, not current live state
 - If the user names a hostname or cluster but no target is attached, resolve the target before making live-state claims
 
-## Redis Command Semantics Guardrails
-
-- Use the canonical command for the claim you are making.
-- For client counts, use `INFO clients` or `CLIENT LIST`.
-- Treat `CLIENT LIST` as the definitive inventory of current connections.
-- Do NOT infer connection counts from `MEMORY STATS`.
-- `MEMORY STATS` fields such as `clients.normal` and `clients.slaves` are client-memory overhead in bytes, not numbers of clients.
-- If `MEMORY STATS` and `INFO clients` appear to disagree, trust `INFO clients` / `CLIENT LIST` for connection counts and explain the distinction instead of collapsing them into one claim.
-- If a Redis field name looks count-like but the command is primarily about memory accounting or allocator state, verify the field semantics before making a factual claim.
+{REDIS_COMMAND_SEMANTICS_GUARDRAILS}
 
 ## Redis Enterprise Cluster Checks
 

--- a/redis_sre_agent/agent/prompts.py
+++ b/redis_sre_agent/agent/prompts.py
@@ -12,7 +12,7 @@ REDIS_COMMAND_SEMANTICS_GUARDRAILS = """## Redis Command Semantics Guardrails
 - Do NOT infer connection counts from `MEMORY STATS`.
 - `MEMORY STATS` fields such as `clients.normal` and `clients.slaves` are client-memory overhead in bytes, not numbers of clients.
 - If `MEMORY STATS` and `INFO clients` appear to disagree, trust `INFO clients` / `CLIENT LIST` for connection counts and explain the distinction instead of collapsing them into one claim.
-- If a Redis field name looks count-like but the command is primarily about memory accounting or allocator state, verify the field semantics before making a factual claim.
+- If a Redis field name looks count-like but the command is primarily about memory accounting or allocator state, use knowledge search to verify the field semantics before making a factual claim.
 """
 
 
@@ -58,8 +58,7 @@ When skills or runbooks are relevant:
 - A startup skill listing is inventory only, not proof that you retrieved or followed that skill
 - If a listed or requested skill matches the task, retrieve it with `get_skill` before claiming that you followed it
 - Do not say you used a health-check skill, runbook, or ticket unless you actually retrieved it in this conversation
-- Do not present a health-check, triage, or support-package summary as completed work unless you executed the relevant tools or explicitly followed the retrieved skill
-- If the evidence is missing, say so directly and describe the concrete retrieval or diagnostic step needed next
+- Do not present a response as satisfying a skill unless you successfully retrieved and followed the skill
 
 Only call categories that are available in your current tool list.
 

--- a/tests/unit/agent/test_knowledge_context.py
+++ b/tests/unit/agent/test_knowledge_context.py
@@ -63,6 +63,9 @@ async def test_startup_context_memorizes_pinned_skills_and_tickets():
     assert "Memorize this pinned support ticket by heart" in context
     assert "Ticket finding: cluster-a had memory pressure" in context
     assert "Skills you know:" in context
+    assert "Skill inventory rules:" in context
+    assert "inventory only" in context
+    assert "`get_skill`" in context
     assert "General Memory Investigation: Use diagnostics then confirm workload." in context
 
 

--- a/tests/unit/agent/test_support_ticket_prompt_guidance.py
+++ b/tests/unit/agent/test_support_ticket_prompt_guidance.py
@@ -56,6 +56,16 @@ def test_chat_prompt_mentions_support_ticket_usage():
     assert "general knowledge search excludes support tickets" in prompt
 
 
+def test_chat_prompt_requires_explicit_skill_retrieval_and_scope_evidence():
+    prompt = CHAT_SYSTEM_PROMPT.lower()
+    assert "inventory only" in prompt
+    assert "`get_skill`" in CHAT_SYSTEM_PROMPT
+    assert "health check skill" in prompt
+    assert "current health is unknown" in prompt
+    assert "captured package contents" in prompt
+    assert "hostname mention by itself is not proof" in prompt
+
+
 def test_knowledge_prompt_mentions_support_tickets():
     prompt = KNOWLEDGE_SYSTEM_PROMPT.lower()
     assert "support ticket" in prompt
@@ -67,3 +77,29 @@ def test_sre_prompt_mentions_support_ticket_usage():
     assert "category tools in your batch" in prompt
     assert "support tickets" in prompt
     assert "general knowledge search excludes support tickets" in prompt
+
+
+def test_sre_prompt_requires_explicit_skill_retrieval_and_scope_evidence():
+    prompt = SRE_SYSTEM_PROMPT.lower()
+    assert "inventory only" in prompt
+    assert "`get_skill`" in SRE_SYSTEM_PROMPT
+    assert "health-check skill" in prompt
+    assert "support-package summary as completed work" in prompt
+    assert "captured evidence, not current live state" in prompt
+    assert "resolve the target before making live-state claims" in prompt
+
+
+def test_chat_prompt_includes_command_semantics_guardrails():
+    prompt = CHAT_SYSTEM_PROMPT.lower()
+    assert "do not infer connection counts from `memory stats`".lower() in prompt
+    assert "`info clients`" in prompt
+    assert "`client list`" in prompt
+    assert "clients.normal" in prompt
+
+
+def test_sre_prompt_includes_command_semantics_guardrails():
+    prompt = SRE_SYSTEM_PROMPT.lower()
+    assert "do not infer connection counts from `memory stats`".lower() in prompt
+    assert "`info clients`" in prompt
+    assert "`client list`" in prompt
+    assert "clients.normal" in prompt

--- a/tests/unit/agent/test_support_ticket_prompt_guidance.py
+++ b/tests/unit/agent/test_support_ticket_prompt_guidance.py
@@ -3,7 +3,7 @@
 from redis_sre_agent.agent.chat_agent import CHAT_SYSTEM_PROMPT
 from redis_sre_agent.agent.knowledge_agent import KNOWLEDGE_SYSTEM_PROMPT
 from redis_sre_agent.agent.knowledge_context import _tool_instruction_lines_for_categories
-from redis_sre_agent.agent.prompts import SRE_SYSTEM_PROMPT
+from redis_sre_agent.agent.prompts import REDIS_COMMAND_SEMANTICS_GUARDRAILS, SRE_SYSTEM_PROMPT
 from redis_sre_agent.tools.models import ToolCapability, ToolDefinition
 
 
@@ -103,3 +103,9 @@ def test_sre_prompt_includes_command_semantics_guardrails():
     assert "`info clients`" in prompt
     assert "`client list`" in prompt
     assert "clients.normal" in prompt
+
+
+def test_chat_and_sre_prompts_share_guardrails_constant():
+    shared = REDIS_COMMAND_SEMANTICS_GUARDRAILS.strip()
+    assert shared in CHAT_SYSTEM_PROMPT
+    assert shared in SRE_SYSTEM_PROMPT

--- a/tests/unit/agent/test_support_ticket_prompt_guidance.py
+++ b/tests/unit/agent/test_support_ticket_prompt_guidance.py
@@ -61,7 +61,7 @@ def test_chat_prompt_requires_explicit_skill_retrieval_and_scope_evidence():
     assert "inventory only" in prompt
     assert "`get_skill`" in CHAT_SYSTEM_PROMPT
     assert "health check skill" in prompt
-    assert "current health is unknown" in prompt
+    assert "response as satisfying a skill" in prompt
     assert "captured package contents" in prompt
     assert "hostname mention by itself is not proof" in prompt
 
@@ -84,7 +84,7 @@ def test_sre_prompt_requires_explicit_skill_retrieval_and_scope_evidence():
     assert "inventory only" in prompt
     assert "`get_skill`" in SRE_SYSTEM_PROMPT
     assert "health-check skill" in prompt
-    assert "support-package summary as completed work" in prompt
+    assert "response as satisfying a skill" in prompt
     assert "captured evidence, not current live state" in prompt
     assert "resolve the target before making live-state claims" in prompt
 


### PR DESCRIPTION
## Summary
- treat startup skill listings as inventory only until the agent explicitly retrieves the skill
- require the chat and triage prompts to distinguish skill-backed execution, support-package evidence, and live-target claims
- add regression tests for the prompt guidance and startup knowledge context

## Testing
- `uv run pytest tests/unit/agent/test_chat_agent.py tests/unit/agent/test_knowledge_context.py tests/unit/agent/test_support_ticket_prompt_guidance.py`
- pre-commit hooks during `git commit` (`ruff format check`, `ruff check`, `pytest unit tests`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to prompt text/constants and unit tests, so runtime risk is low; main impact is altered LLM behavior/wording (e.g., requiring explicit `get_skill` retrieval and using correct Redis commands for client counts).
> 
> **Overview**
> **Tightens agent prompt guardrails around evidence and skill usage.** The chat and SRE system prompts now explicitly require retrieving skills via `get_skill` before claiming a skill/runbook/ticket was followed, and clarify boundaries between *startup skill inventory*, *support-package evidence*, and *live-target claims* (including requiring target resolution before hostname-based live assertions).
> 
> **Adds shared Redis command semantics guidance.** Introduces `REDIS_COMMAND_SEMANTICS_GUARDRAILS` and injects it into both prompts to prevent incorrect client-count inferences (e.g., forbidding deriving client counts from `MEMORY STATS` vs using `INFO clients`/`CLIENT LIST`).
> 
> **Updates startup context and tests.** Startup skill TOC output now includes explicit “inventory only” rules, and new/updated unit tests assert the presence of these prompt/context guardrails.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9990f42fd7ca33d984cf7a49ce75a22160ba3132. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->