### PR TITLE
Prevent MEMORY STATS client count misreads

### DIFF
--- a/evals/corpora/redis-docs-curated/2026-04-01/documents/client-count-source-discipline.md
+++ b/evals/corpora/redis-docs-curated/2026-04-01/documents/client-count-source-discipline.md
@@ -1,0 +1,16 @@
+---
+document_hash: client-count-source-discipline
+name: client-count-source-discipline
+title: Client count source discipline
+doc_type: runbook
+version: latest
+summary: Use INFO clients or CLIENT LIST for connection counts; do not infer them from MEMORY STATS.
+source: redis-docs-curated://documents/client-count-source-discipline
+priority: high
+category: redis
+---
+When you need to answer "how many clients are connected right now?", use `INFO clients` or `CLIENT LIST`.
+
+`MEMORY STATS` is a memory-accounting command. Fields such as `clients.normal` and `clients.slaves` describe client-related overhead and are not authoritative connection counters.
+
+If `MEMORY STATS` seems to disagree with `INFO clients`, trust `INFO clients` and `CLIENT LIST` for live connection counts, and explain the distinction instead of collapsing the metrics into one conclusion.

--- a/evals/goldens/redis/client-count-memory-stats-misread/assertions.json
+++ b/evals/goldens/redis/client-count-memory-stats-misread/assertions.json
@@ -1,0 +1,32 @@
+{
+  "required_tool_calls": [
+    {
+      "provider_family": "redis_command",
+      "operation": "memory_stats",
+      "target_handle": "tgt_instance_runtime_cache"
+    },
+    {
+      "provider_family": "redis_command",
+      "operation": "info",
+      "target_handle": "tgt_instance_runtime_cache"
+    }
+  ],
+  "forbidden_tool_calls": [
+    {
+      "provider_family": "redis_command",
+      "operation": "config_set",
+      "target_handle": "tgt_instance_runtime_cache"
+    }
+  ],
+  "required_findings": [
+    "is client-memory overhead",
+    "explicit client list enumeration",
+    "does not mean 72k clients"
+  ],
+  "forbidden_claims": [
+    "clients.normal is the client count",
+    "72696 connected clients"
+  ],
+  "required_sources": [],
+  "expected_routing_decision": "chat"
+}

--- a/evals/goldens/redis/client-count-memory-stats-misread/expected.md
+++ b/evals/goldens/redis/client-count-memory-stats-misread/expected.md
@@ -1,0 +1,5 @@
+Treat the `clients.normal` figure as a memory-accounting signal, not as a live client count.
+
+`INFO clients` is the canonical source for the current connection count here, and it reports **19 connected clients**, not 72k. `MEMORY STATS` is telling you about client-related overhead, so I would not report `clients.normal=72696` as a connection spike.
+
+If we wanted the definitive inventory beyond that summary, the next validating step would be `CLIENT LIST`, because `INFO clients` and `CLIENT LIST` are the sources that should drive connection-count claims.

--- a/evals/goldens/redis/client-count-memory-stats-misread/metadata.yaml
+++ b/evals/goldens/redis/client-count-memory-stats-misread/metadata.yaml
@@ -1,0 +1,6 @@
+scenario_id: redis/client-count-memory-stats-misread
+review_status: reviewed
+reviewed_by: sre-evals
+expectation_basis: human_authored
+source_pack: redis-docs-curated
+source_pack_version: "2026-04-01"

--- a/evals/scenarios/redis/client-count-memory-stats-misread/fixtures/tools/info-clients.json
+++ b/evals/scenarios/redis/client-count-memory-stats-misread/fixtures/tools/info-clients.json
@@ -1,0 +1,10 @@
+{
+  "status": "success",
+  "section": "clients",
+  "data": {
+    "connected_clients": 19,
+    "blocked_clients": 5,
+    "pubsub_clients": 2,
+    "maxclients": 10000
+  }
+}

--- a/evals/scenarios/redis/client-count-memory-stats-misread/fixtures/tools/memory-stats.json
+++ b/evals/scenarios/redis/client-count-memory-stats-misread/fixtures/tools/memory-stats.json
@@ -1,0 +1,26 @@
+{
+  "status": "success",
+  "stats": {
+    "peak.allocated": 1465123456,
+    "total.allocated": 1329876544,
+    "dataset.bytes": 1184567296,
+    "fragmentation": 1.11,
+    "clients.normal": 72696,
+    "clients.slaves": 0
+  },
+  "interpretation_notes": [
+    "MEMORY STATS reports memory-accounting metrics, not connection counts.",
+    "Fields such as clients.normal and clients.slaves are client-related memory overhead in bytes.",
+    "Use INFO clients or CLIENT LIST to measure current connected clients."
+  ],
+  "canonical_sources": {
+    "memory_breakdown": [
+      "MEMORY STATS",
+      "INFO memory"
+    ],
+    "client_counts": [
+      "INFO clients",
+      "CLIENT LIST"
+    ]
+  }
+}

--- a/evals/scenarios/redis/client-count-memory-stats-misread/scenario.yaml
+++ b/evals/scenarios/redis/client-count-memory-stats-misread/scenario.yaml
@@ -1,0 +1,88 @@
+id: redis/client-count-memory-stats-misread
+name: MEMORY STATS client fields must not be treated as connection counts
+description: Exercise the production full_turn chat lane against an OSS instance where MEMORY STATS contains a misleading clients.normal field and INFO clients must drive the answer.
+
+provenance:
+  source_kind: mixed
+  source_pack: redis-docs-curated
+  source_pack_version: 2026-04-01
+  derived_from:
+    - redis_sre_agent.agent.chat_agent.CHAT_SYSTEM_PROMPT
+    - evals/corpora/redis-docs-curated/2026-04-01/documents/client-count-source-discipline.md
+  synthetic:
+    is_synthetic: false
+  golden:
+    expectation_basis: human_authored
+    exemplar_sources:
+      - evals/goldens/redis/client-count-memory-stats-misread/expected.md
+    review_status: reviewed
+    reviewed_by: sre-evals
+
+execution:
+  lane: full_turn
+  agent: redis_chat
+  route_via_router: false
+  query: >
+    Run MEMORY STATS and INFO clients on the attached runtime cache, then tell me
+    whether clients.normal around 72696 means we have 72k clients connected right
+    now and what source should drive that answer.
+  max_tool_steps: 4
+  llm_mode: replay
+
+scope:
+  turn_scope:
+    resolution_policy: require_target
+    automation_mode: interactive
+  target_catalog:
+    - handle: tgt_instance_runtime_cache
+      kind: instance
+      display_name: prod runtime cache
+      resource_id: redis-prod-runtime
+      cluster_type: oss_single
+      capabilities: [diagnostics, knowledge]
+      public_metadata:
+        environment: production
+        deployment: oss
+  bound_targets:
+    - tgt_instance_runtime_cache
+
+knowledge:
+  mode: full
+  version: latest
+  corpus:
+    - ../../../corpora/redis-docs-curated/2026-04-01
+
+tools:
+  redis_command:
+    memory_stats:
+      description: Fetch MEMORY STATS for the attached instance.
+      result: fixtures/tools/memory-stats.json
+    info:
+      description: Fetch INFO clients for the attached instance.
+      responders:
+        - when:
+            args_contains:
+              section: clients
+          result: fixtures/tools/info-clients.json
+
+expectations:
+  required_tool_calls:
+    - provider_family: redis_command
+      operation: memory_stats
+      target_handle: tgt_instance_runtime_cache
+    - provider_family: redis_command
+      operation: info
+      target_handle: tgt_instance_runtime_cache
+  forbidden_tool_calls:
+    - provider_family: redis_command
+      operation: config_set
+      target_handle: tgt_instance_runtime_cache
+  required_findings:
+    - is client-memory overhead
+    - explicit client list enumeration
+    - does not mean 72k clients
+  forbidden_claims:
+    - clients.normal is the client count
+    - 72696 connected clients
+  required_sources: []
+  expected_routing_decision: chat

--- a/redis_sre_agent/tools/diagnostics/redis_command/provider.py
+++ b/redis_sre_agent/tools/diagnostics/redis_command/provider.py
@@ -175,8 +175,9 @@ class RedisCommandToolProvider(ToolProvider):
                 description=(
                     "Execute Redis INFO command to get server statistics and information. "
                     "Use this to check Redis server status, memory usage, client connections, "
-                    "replication status, and performance metrics. Can query specific sections "
-                    "or get all information."
+                    "replication status, and performance metrics. For actual client counts, "
+                    "prefer the 'clients' section. Can query specific sections or get all "
+                    "information."
                 ),
                 capability=ToolCapability.DIAGNOSTICS,
                 parameters={
@@ -260,7 +261,8 @@ class RedisCommandToolProvider(ToolProvider):
                 description=(
                     "List connected Redis clients using CLIENT LIST. Use this to diagnose "
                     "connection issues, identify problematic clients, or check client "
-                    "connection details."
+                    "connection details. This is the definitive inventory of current client "
+                    "connections."
                 ),
                 capability=ToolCapability.DIAGNOSTICS,
                 parameters={
@@ -311,7 +313,10 @@ class RedisCommandToolProvider(ToolProvider):
                 description=(
                     "Get detailed Redis memory statistics using MEMORY STATS. Use this "
                     "for in-depth memory analysis including allocator stats, fragmentation, "
-                    "and memory breakdown by category."
+                    "and memory breakdown by category. Do not use this for client counts: "
+                    "fields such as clients.normal and clients.slaves are client-memory "
+                    "overhead in bytes, not numbers of connected clients. Use INFO clients "
+                    "or CLIENT LIST for counts."
                 ),
                 capability=ToolCapability.DIAGNOSTICS,
                 parameters={
@@ -673,6 +678,15 @@ class RedisCommandToolProvider(ToolProvider):
             return {
                 "status": "success",
                 "stats": result,
+                "interpretation_notes": [
+                    "MEMORY STATS reports memory-accounting metrics, not connection counts.",
+                    "Fields such as clients.normal and clients.slaves are client-related memory overhead in bytes.",
+                    "Use INFO clients or CLIENT LIST to measure current connected clients.",
+                ],
+                "canonical_sources": {
+                    "memory_breakdown": ["MEMORY STATS", "INFO memory"],
+                    "client_counts": ["INFO clients", "CLIENT LIST"],
+                },
             }
         except Exception as e:
             if _is_command_unavailable_error(e):

--- a/tests/unit/evaluation/test_redis_scenarios.py
+++ b/tests/unit/evaluation/test_redis_scenarios.py
@@ -49,6 +49,7 @@ def test_committed_redis_scenarios_load_with_goldens_and_refs():
     slowlog = _load_committed_scenario("slowlog-anti-pattern")
     maintenance = _load_committed_scenario("enterprise-maintenance-mode")
     cluster = _load_committed_scenario("enterprise-cluster-health-vs-info-misread")
+    client_counts = _load_committed_scenario("client-count-memory-stats-misread")
 
     assert memory.execution.lane is ExecutionLane.FULL_TURN
     assert memory.execution.agent == "redis_chat"
@@ -70,11 +71,18 @@ def test_committed_redis_scenarios_load_with_goldens_and_refs():
     assert cluster.scope.bound_targets == ["tgt_cluster_checkout_global"]
     assert cluster.resolve_fixture_path("fixtures/tools/list-databases.json").exists()
 
+    assert client_counts.execution.lane is ExecutionLane.FULL_TURN
+    assert client_counts.execution.agent == "redis_chat"
+    assert client_counts.scope.bound_targets == ["tgt_instance_runtime_cache"]
+    assert client_counts.resolve_fixture_path("fixtures/tools/memory-stats.json").exists()
+    assert client_counts.resolve_fixture_path("fixtures/tools/info-clients.json").exists()
+
     for scenario_id, scenario in (
         ("memory-pressure-oss", memory),
         ("slowlog-anti-pattern", slowlog),
         ("enterprise-maintenance-mode", maintenance),
         ("enterprise-cluster-health-vs-info-misread", cluster),
+        ("client-count-memory-stats-misread", client_counts),
     ):
         metadata = yaml.safe_load(
             (REPO_ROOT / golden_metadata_path("redis", scenario_id)).read_text(encoding="utf-8")
@@ -151,10 +159,12 @@ async def test_committed_redis_corpus_serves_docs_skills_and_tickets():
     memory = _load_committed_scenario("memory-pressure-oss")
     maintenance = _load_committed_scenario("enterprise-maintenance-mode")
     cluster = _load_committed_scenario("enterprise-cluster-health-vs-info-misread")
+    client_counts = _load_committed_scenario("client-count-memory-stats-misread")
 
     memory_backend = build_fixture_knowledge_backend(memory)
     maintenance_backend = build_fixture_knowledge_backend(maintenance)
     cluster_backend = build_fixture_knowledge_backend(cluster)
+    client_count_backend = build_fixture_knowledge_backend(client_counts)
 
     memory_runbook = await memory_backend.get_all_document_fragments(
         document_hash="memory-pressure-runbook",
@@ -172,8 +182,13 @@ async def test_committed_redis_corpus_serves_docs_skills_and_tickets():
         document_hash="cluster-health-triage",
         version="latest",
     )
+    client_count_runbook = await client_count_backend.get_all_document_fragments(
+        document_hash="client-count-source-discipline",
+        version="latest",
+    )
 
     assert memory_runbook["document_hash"] == "memory-pressure-runbook"
     assert maintenance_skill["skill_name"] == "redis-enterprise-maintenance-checklist"
     assert maintenance_ticket["tickets"][0]["ticket_id"] == "RET-5032"
     assert cluster_runbook["document_hash"] == "cluster-health-triage"
+    assert client_count_runbook["document_hash"] == "client-count-source-discipline"

--- a/tests/unit/tools/test_redis_command_provider.py
+++ b/tests/unit/tools/test_redis_command_provider.py
@@ -121,6 +121,24 @@ class TestRedisCommandToolProviderSchemas:
         tool_names = [s.name for s in schemas]
         assert any("slowlog" in name for name in tool_names)
 
+    def test_tool_schemas_encode_client_count_semantics(self):
+        """Test that schema descriptions steer client counting to canonical commands."""
+        provider = RedisCommandToolProvider(connection_url="redis://localhost:6379")
+        schemas = provider.create_tool_schemas()
+
+        info_schema = next(schema for schema in schemas if schema.name.endswith("_info"))
+        client_list_schema = next(
+            schema for schema in schemas if schema.name.endswith("_client_list")
+        )
+        memory_stats_schema = next(
+            schema for schema in schemas if schema.name.endswith("_memory_stats")
+        )
+
+        assert "client counts" in info_schema.description.lower()
+        assert "definitive inventory" in client_list_schema.description.lower()
+        assert "do not use this for client counts" in memory_stats_schema.description.lower()
+        assert "clients.normal" in memory_stats_schema.description
+
 
 class TestRedisCommandToolProviderClient:
     """Test RedisCommandToolProvider client management."""
@@ -609,6 +627,13 @@ class TestRedisCommandToolProviderMemoryStats:
             assert result["status"] == "success"
             assert "stats" in result
             assert result["stats"]["peak.allocated"] == 1234567
+            assert "interpretation_notes" in result
+            assert "canonical_sources" in result
+            assert any("not connection counts" in note for note in result["interpretation_notes"])
+            assert result["canonical_sources"]["client_counts"] == [
+                "INFO clients",
+                "CLIENT LIST",
+            ]
 
     @pytest.mark.asyncio
     async def test_memory_stats_error(self):


### PR DESCRIPTION
## Summary
- add Redis command-semantics guardrails so client counts come from `INFO clients` or `CLIENT LIST`, not `MEMORY STATS`
- annotate the Redis command tool interface and `MEMORY STATS` results with canonical-source guidance
- add a committed replay eval that fails if the agent treats `clients.normal` as a live connection count

## Verification
- `uv run pytest tests/unit/agent/test_support_ticket_prompt_guidance.py tests/unit/tools/test_redis_command_provider.py tests/unit/evaluation/test_redis_scenarios.py`
- full pre-commit unit hook during `git commit` (`2558 passed`)
- `uv run redis-sre-agent eval run evals/scenarios/redis/client-count-memory-stats-misread/scenario.yaml --json`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates the `redis_command.memory_stats` tool output and tool schema text, which could impact any downstream code or prompts that assume the previous response shape or descriptions. The rest is additive eval/test coverage and curated documentation, so behavior risk is limited but not zero.
> 
> **Overview**
> Adds explicit guardrails to prevent agents from treating `MEMORY STATS` fields (e.g., `clients.normal`) as live connection counts, steering client-count questions to `INFO clients` / `CLIENT LIST`.
> 
> Concretely, the Redis diagnostics tool schema descriptions are updated, and `memory_stats()` now returns additional guidance fields (`interpretation_notes`, `canonical_sources`). A new curated runbook doc plus a committed replay eval scenario/golden are added to enforce the correct interpretation, with unit tests updated to load the new scenario and assert the new semantics/response fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd8b76fbdc919f80c56f926b49b4791407d3c161. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->