### PR TITLE
fix(target-discovery): confirm fuzzy live matches

### DIFF
--- a/redis_sre_agent/agent/chat_agent.py
+++ b/redis_sre_agent/agent/chat_agent.py
@@ -105,20 +105,23 @@ For metrics/logs:
 For target discovery:
 - If the user asks what Redis targets you know about, call `list_known_redis_targets`
 - If the user describes a target but has not given `instance_id` or `cluster_id`, call `resolve_redis_targets` before making live-state claims
+- Only treat target discovery as confirmed when it returns an exact live match. If the match is fuzzy, partial, or ambiguous, ask the user to confirm the target before you attach tools or describe live state
 - If the user asks to compare or investigate multiple targets, call `resolve_redis_targets` with `allow_multiple=true`, keep the attached target set, and gather evidence per target before comparing
 - If the user asks both "what do you know about?" and asks to drill into one target in the same turn, list first, then resolve the chosen target and continue with the attached live tools
-- A hostname mention by itself is not proof that live diagnostics ran; resolve or attach the target first
+- A hostname or hostname fragment is not enough to assume a live Redis target. If target discovery does not return an exact live match, do not attach or describe a different Redis deployment as if it were that hostname
 
 For historical incident context (if `tickets` tools are available):
 - Use tickets tools instead of general knowledge search because general knowledge search excludes support tickets
 - Search support tickets with concrete identifiers (cluster name/host, error strings)
 - Fetch the most relevant ticket record for full details
 
-For skills, runbooks, and evidence-backed workflows:
+For skills, runbooks, and Analyzer-backed workflows:
 - A skill name shown in startup context is inventory only, not proof that you retrieved or executed that skill
-- If a listed or requested skill is relevant, fetch it with `get_skill` before claiming you followed it
+- If a listed or requested skill is relevant, fetch it with `get_skill` before claiming you followed it or improvising the workflow from memory
 - Do not say you "used the health check skill", "followed the runbook", or "reviewed the support ticket" unless you actually retrieved that artifact in this conversation
 - Do not present a response as satisfying a skill unless you successfully retrieved and followed the skill
+- If the user asks for a health check, cluster audit, Analyzer review, or support-package style finding, prefer the relevant skill and Analyzer-backed evidence over ad hoc live Redis diagnostics unless the user explicitly names a live instance/cluster or target discovery returns an exact live match
+- If the request only includes a hostname and it does not resolve exactly as a live target, ask for package/account/cluster context or continue with the Analyzer/skill workflow instead of guessing
 - Support-package findings describe captured package contents, not the current live state of a hostname or cluster
 
 Only call categories that are available in your current tool list.

--- a/redis_sre_agent/core/targets.py
+++ b/redis_sre_agent/core/targets.py
@@ -1183,13 +1183,21 @@ def _score_target_doc(
     for alias in doc.search_aliases:
         alias_tokens.update(_tokenize(alias))
 
+    exact_target_mentioned = _query_mentions_exact_target(doc, hints)
     if hostname_terms:
         exact_terms = _exact_target_terms(doc)
         exact_hostname_matches = sorted(hostname_terms & exact_terms)
-        if not exact_hostname_matches:
+        if not exact_hostname_matches and not exact_target_mentioned:
             return 0.0, []
-        score += 8.5
-        reasons.append(f"matched hostname={exact_hostname_matches[0]}")
+        if exact_hostname_matches:
+            score += 8.5
+            reasons.append(f"matched hostname={exact_hostname_matches[0]}")
+    else:
+        exact_hostname_matches = []
+
+    if exact_target_mentioned and not exact_hostname_matches:
+        score += 7.5
+        reasons.append("matched exact target reference")
 
     if normalized and normalized in {_normalize(doc.display_name), _normalize(doc.name)}:
         score += 8.0

--- a/redis_sre_agent/core/targets.py
+++ b/redis_sre_agent/core/targets.py
@@ -46,6 +46,9 @@ from redis_sre_agent.targets.contracts import (
 logger = logging.getLogger(__name__)
 
 _TOKEN_RE = re.compile(r"[a-z0-9]+")
+_HOSTNAME_RE = re.compile(
+    r"\b[a-z0-9](?:[a-z0-9-]*[a-z0-9])?(?:\.[a-z0-9](?:[a-z0-9-]*[a-z0-9])?)+\b"
+)
 _ENV_ALIASES = {
     "prod": "production",
     "production": "production",
@@ -1089,6 +1092,11 @@ def _parse_query_hints(query: str) -> Dict[str, Any]:
     if tokens & _CLUSTER_HINTS:
         preferred_kinds.add("cluster")
     target_types = {_TYPE_HINTS[token] for token in tokens if token in _TYPE_HINTS}
+    hostname_terms = {
+        _normalize(match.group(0))
+        for match in _HOSTNAME_RE.finditer(normalized)
+        if "." in match.group(0)
+    }
     return {
         "normalized": normalized,
         "tokens": tokens,
@@ -1096,7 +1104,22 @@ def _parse_query_hints(query: str) -> Dict[str, Any]:
         "usages": usages,
         "preferred_kinds": preferred_kinds,
         "target_types": target_types,
+        "hostname_terms": hostname_terms,
     }
+
+
+def _exact_target_terms(doc: TargetCatalogDoc) -> set[str]:
+    """Return exact-match-safe identifiers for high-confidence discovery."""
+    values = {
+        doc.display_name,
+        doc.name,
+        doc.resource_id,
+        doc.monitoring_identifier,
+        doc.logging_identifier,
+        doc.redis_cloud_database_name,
+    }
+    values.update(doc.search_aliases)
+    return {normalized for value in values if (normalized := _normalize(value))}
 
 
 def _score_target_doc(
@@ -1109,6 +1132,7 @@ def _score_target_doc(
     hints = hints or _parse_query_hints(query)
     normalized = hints["normalized"]
     query_tokens = hints["tokens"]
+    hostname_terms = set(hints.get("hostname_terms") or [])
     reasons: List[str] = []
     score = 0.0
 
@@ -1116,6 +1140,14 @@ def _score_target_doc(
     alias_tokens = set()
     for alias in doc.search_aliases:
         alias_tokens.update(_tokenize(alias))
+
+    if hostname_terms:
+        exact_terms = _exact_target_terms(doc)
+        exact_hostname_matches = sorted(hostname_terms & exact_terms)
+        if not exact_hostname_matches:
+            return 0.0, []
+        score += 8.5
+        reasons.append(f"matched hostname={exact_hostname_matches[0]}")
 
     if normalized and normalized in {_normalize(doc.display_name), _normalize(doc.name)}:
         score += 8.0

--- a/redis_sre_agent/core/targets.py
+++ b/redis_sre_agent/core/targets.py
@@ -1083,7 +1083,8 @@ async def list_known_targets(
 
 def _parse_query_hints(query: str) -> Dict[str, Any]:
     normalized = _normalize(query)
-    tokens = set(_tokenize(normalized))
+    token_list = _tokenize(normalized)
+    tokens = set(token_list)
     environments = {_ENV_ALIASES[token] for token in tokens if token in _ENV_ALIASES}
     usages = {token for token in tokens if token in _USAGE_TERMS}
     preferred_kinds = set()
@@ -1095,10 +1096,11 @@ def _parse_query_hints(query: str) -> Dict[str, Any]:
     hostname_terms = {
         _normalize(match.group(0))
         for match in _HOSTNAME_RE.finditer(normalized)
-        if "." in match.group(0)
+        if _looks_like_hostname_term(match.group(0))
     }
     return {
         "normalized": normalized,
+        "token_list": token_list,
         "tokens": tokens,
         "environments": environments,
         "usages": usages,
@@ -1120,6 +1122,46 @@ def _exact_target_terms(doc: TargetCatalogDoc) -> set[str]:
     }
     values.update(doc.search_aliases)
     return {normalized for value in values if (normalized := _normalize(value))}
+
+
+def _looks_like_hostname_term(value: str) -> bool:
+    """Accept dotted hostnames while ignoring version-like dotted tokens."""
+    labels = [label for label in _normalize(value).split(".") if label]
+    if len(labels) < 2 or all(label.isdigit() for label in labels):
+        return False
+    if labels[-1].isdigit():
+        return False
+    if len(labels) >= 3:
+        return True
+    return any("-" in label or any(ch.isdigit() for ch in label) for label in labels)
+
+
+def _contains_token_sequence(haystack: Sequence[str], needle: Sequence[str]) -> bool:
+    """Return True when `needle` appears contiguously inside `haystack`."""
+    if not needle or len(needle) > len(haystack):
+        return False
+    needle_list = list(needle)
+    window = len(needle_list)
+    for index in range(len(haystack) - window + 1):
+        if list(haystack[index : index + window]) == needle_list:
+            return True
+    return False
+
+
+def _query_mentions_exact_target(doc: TargetCatalogDoc, hints: Dict[str, Any]) -> bool:
+    """Detect exact target mentions embedded inside a larger user query."""
+    normalized = hints["normalized"]
+    query_token_list = hints.get("token_list") or _tokenize(normalized)
+    exact_terms = _exact_target_terms(doc)
+    if normalized and normalized in exact_terms:
+        return True
+    for term in exact_terms:
+        term_tokens = _tokenize(term)
+        if len(term_tokens) < 2:
+            continue
+        if _contains_token_sequence(query_token_list, term_tokens):
+            return True
+    return False
 
 
 def _score_target_doc(

--- a/redis_sre_agent/targets/redis_catalog.py
+++ b/redis_sre_agent/targets/redis_catalog.py
@@ -19,6 +19,7 @@ class RedisCatalogDiscoveryBackend:
             _exact_target_terms,
             _normalize,
             _parse_query_hints,
+            _query_mentions_exact_target,
             _score_target_doc,
             build_public_match_from_doc,
             get_target_catalog,
@@ -58,7 +59,10 @@ class RedisCatalogDiscoveryBackend:
                 confidence=public_match.confidence,
             )
             ranked.append(candidate)
-            if normalized_query and normalized_query in _exact_target_terms(doc):
+            exact_query_match = normalized_query and normalized_query in _exact_target_terms(doc)
+            if exact_query_match or (
+                request.allow_multiple and _query_mentions_exact_target(doc, hints)
+            ):
                 exact_ranked.append(candidate)
 
         ranked.sort(key=lambda candidate: (candidate.score, candidate.confidence), reverse=True)

--- a/redis_sre_agent/targets/redis_catalog.py
+++ b/redis_sre_agent/targets/redis_catalog.py
@@ -62,7 +62,9 @@ class RedisCatalogDiscoveryBackend:
                 exact_ranked.append(candidate)
 
         ranked.sort(key=lambda candidate: (candidate.score, candidate.confidence), reverse=True)
-        exact_ranked.sort(key=lambda candidate: (candidate.score, candidate.confidence), reverse=True)
+        exact_ranked.sort(
+            key=lambda candidate: (candidate.score, candidate.confidence), reverse=True
+        )
         limited = ranked[: max(1, min(request.max_results, 10))]
         if not limited:
             return DiscoveryResponse(status="no_match")

--- a/redis_sre_agent/targets/redis_catalog.py
+++ b/redis_sre_agent/targets/redis_catalog.py
@@ -8,6 +8,27 @@ from .contracts import DiscoveryCandidate, DiscoveryRequest, DiscoveryResponse
 from .registry import get_target_integration_registry
 
 
+def _select_catalog_candidates(
+    limited: List[DiscoveryCandidate],
+    exact_ranked: List[DiscoveryCandidate],
+    *,
+    allow_multiple: bool,
+    max_results: int,
+) -> tuple[List[DiscoveryCandidate], bool]:
+    selection_limit = min(3, max_results)
+
+    if exact_ranked:
+        if allow_multiple:
+            return exact_ranked[:selection_limit], False
+
+        top_exact = exact_ranked[0]
+        if len(exact_ranked) > 1 and exact_ranked[1].score >= top_exact.score - 0.75:
+            return exact_ranked[:selection_limit], True
+        return [top_exact], False
+
+    return limited[:selection_limit], True
+
+
 class RedisCatalogDiscoveryBackend:
     """Resolve Redis targets from the built-in target catalog."""
 
@@ -73,26 +94,12 @@ class RedisCatalogDiscoveryBackend:
         if not limited:
             return DiscoveryResponse(status="no_match")
 
-        selected: List[DiscoveryCandidate] = []
-        clarification_required = False
-
-        if exact_ranked:
-            top_exact = exact_ranked[0]
-            if request.allow_multiple:
-                # Auto-binding multiple live targets is only safe when each target is
-                # explicitly named in the query; descriptive comparisons stay in
-                # clarification mode to avoid silent misbinding.
-                selected = exact_ranked[: min(3, request.max_results)]
-            elif len(exact_ranked) > 1 and exact_ranked[1].score >= top_exact.score - 0.75:
-                clarification_required = True
-                selected = exact_ranked[: min(3, request.max_results)]
-            else:
-                selected = [top_exact]
-        else:
-            # Suggest the strongest candidates, but do not auto-bind live targets from
-            # fuzzy or partial text, including descriptive multi-target requests.
-            clarification_required = True
-            selected = limited[: min(3, request.max_results)]
+        selected, clarification_required = _select_catalog_candidates(
+            limited,
+            exact_ranked,
+            allow_multiple=request.allow_multiple,
+            max_results=request.max_results,
+        )
 
         return DiscoveryResponse(
             status=(

--- a/redis_sre_agent/targets/redis_catalog.py
+++ b/redis_sre_agent/targets/redis_catalog.py
@@ -79,6 +79,9 @@ class RedisCatalogDiscoveryBackend:
         if exact_ranked:
             top_exact = exact_ranked[0]
             if request.allow_multiple:
+                # Auto-binding multiple live targets is only safe when each target is
+                # explicitly named in the query; descriptive comparisons stay in
+                # clarification mode to avoid silent misbinding.
                 selected = exact_ranked[: min(3, request.max_results)]
             elif len(exact_ranked) > 1 and exact_ranked[1].score >= top_exact.score - 0.75:
                 clarification_required = True
@@ -86,6 +89,8 @@ class RedisCatalogDiscoveryBackend:
             else:
                 selected = [top_exact]
         else:
+            # Suggest the strongest candidates, but do not auto-bind live targets from
+            # fuzzy or partial text, including descriptive multi-target requests.
             clarification_required = True
             selected = limited[: min(3, request.max_results)]
 

--- a/redis_sre_agent/targets/redis_catalog.py
+++ b/redis_sre_agent/targets/redis_catalog.py
@@ -16,6 +16,8 @@ class RedisCatalogDiscoveryBackend:
     async def resolve(self, request: DiscoveryRequest) -> DiscoveryResponse:
         from redis_sre_agent.core.targets import (
             _confidence_from_score,
+            _exact_target_terms,
+            _normalize,
             _parse_query_hints,
             _score_target_doc,
             build_public_match_from_doc,
@@ -27,8 +29,10 @@ class RedisCatalogDiscoveryBackend:
             return DiscoveryResponse(status="no_match")
 
         registry = get_target_integration_registry()
+        normalized_query = _normalize(request.query)
         hints = _parse_query_hints(request.query)
         ranked: List[DiscoveryCandidate] = []
+        exact_ranked: List[DiscoveryCandidate] = []
         for doc in docs:
             score, reasons = _score_target_doc(
                 request.query,
@@ -44,37 +48,40 @@ class RedisCatalogDiscoveryBackend:
                 match_reasons=reasons,
                 score=score,
             )
-            ranked.append(
-                DiscoveryCandidate(
-                    public_match=public_match,
-                    binding_strategy=registry.default_binding_strategy,
-                    binding_subject=doc.resource_id,
-                    private_binding_ref={"target_kind": doc.target_kind},
-                    discovery_backend=self.backend_name,
-                    score=score,
-                    confidence=public_match.confidence,
-                )
+            candidate = DiscoveryCandidate(
+                public_match=public_match,
+                binding_strategy=registry.default_binding_strategy,
+                binding_subject=doc.resource_id,
+                private_binding_ref={"target_kind": doc.target_kind},
+                discovery_backend=self.backend_name,
+                score=score,
+                confidence=public_match.confidence,
             )
+            ranked.append(candidate)
+            if normalized_query and normalized_query in _exact_target_terms(doc):
+                exact_ranked.append(candidate)
 
         ranked.sort(key=lambda candidate: (candidate.score, candidate.confidence), reverse=True)
+        exact_ranked.sort(key=lambda candidate: (candidate.score, candidate.confidence), reverse=True)
         limited = ranked[: max(1, min(request.max_results, 10))]
         if not limited:
             return DiscoveryResponse(status="no_match")
 
-        top = limited[0]
         selected: List[DiscoveryCandidate] = []
         clarification_required = False
 
-        if request.allow_multiple:
-            selected = [
-                candidate for candidate in limited if candidate.score >= max(3.0, top.score - 1.5)
-            ][: min(3, request.max_results)]
-        else:
-            if len(limited) > 1 and limited[1].score >= top.score - 0.75:
+        if exact_ranked:
+            top_exact = exact_ranked[0]
+            if request.allow_multiple:
+                selected = exact_ranked[: min(3, request.max_results)]
+            elif len(exact_ranked) > 1 and exact_ranked[1].score >= top_exact.score - 0.75:
                 clarification_required = True
-                selected = limited[: min(3, request.max_results)]
+                selected = exact_ranked[: min(3, request.max_results)]
             else:
-                selected = [top]
+                selected = [top_exact]
+        else:
+            clarification_required = True
+            selected = limited[: min(3, request.max_results)]
 
         return DiscoveryResponse(
             status=(

--- a/redis_sre_agent/tools/target_discovery/provider.py
+++ b/redis_sre_agent/tools/target_discovery/provider.py
@@ -175,7 +175,7 @@ class TargetDiscoveryToolProvider(ToolProvider):
         scope = None
         toolset_generation = manager.get_toolset_generation() if manager else 0
 
-        if attach_tools and manager and result.selected_matches:
+        if attach_tools and manager and result.status == "resolved" and result.selected_matches:
             scope = await bind_target_matches(
                 matches=result.selected_matches,
                 thread_id=thread_id,

--- a/tests/unit/agent/test_chat_agent.py
+++ b/tests/unit/agent/test_chat_agent.py
@@ -251,6 +251,14 @@ class TestChatAgentSystemPrompt:
         assert "allow_multiple=true" in CHAT_SYSTEM_PROMPT
         assert "what redis targets you know about" in prompt_lower
 
+    def test_system_prompt_requires_skill_fetch_and_hostname_caution(self):
+        """Skill-backed health checks must fetch the skill and avoid hostname guessing."""
+        prompt_lower = CHAT_SYSTEM_PROMPT.lower()
+        assert "get_skill" in CHAT_SYSTEM_PROMPT
+        assert "exact live match" in prompt_lower
+        assert "hostname or hostname fragment" in prompt_lower
+        assert "analyzer-backed evidence" in prompt_lower
+
     def test_system_prompt_warns_about_managed_redis(self):
         """Test that the system prompt has Redis Enterprise/Cloud notes."""
         assert "Enterprise" in CHAT_SYSTEM_PROMPT or "Cloud" in CHAT_SYSTEM_PROMPT

--- a/tests/unit/agent/test_support_ticket_prompt_guidance.py
+++ b/tests/unit/agent/test_support_ticket_prompt_guidance.py
@@ -63,7 +63,8 @@ def test_chat_prompt_requires_explicit_skill_retrieval_and_scope_evidence():
     assert "health check skill" in prompt
     assert "response as satisfying a skill" in prompt
     assert "captured package contents" in prompt
-    assert "hostname mention by itself is not proof" in prompt
+    assert "hostname or hostname fragment is not enough" in prompt
+    assert "exact live match" in prompt
 
 
 def test_knowledge_prompt_mentions_support_tickets():

--- a/tests/unit/core/test_targets.py
+++ b/tests/unit/core/test_targets.py
@@ -409,6 +409,53 @@ async def test_resolve_target_query_allow_multiple_requires_confirmation_for_des
 
 
 @pytest.mark.asyncio
+async def test_resolve_target_query_allow_multiple_keeps_exact_non_hostname_match_with_hostname():
+    host_target = TargetCatalogDoc(
+        target_id="instance:redis-prod-router",
+        target_kind="instance",
+        resource_id="redis-prod-router",
+        display_name="router-prod",
+        name="router-prod",
+        environment="production",
+        usage="cache",
+        target_type="oss_single",
+        capabilities=["redis", "diagnostics"],
+        monitoring_identifier="redis-1.prod.example.com",
+        search_text="router prod production cache",
+        search_aliases=[],
+    )
+    cache_target = TargetCatalogDoc(
+        target_id="instance:redis-prod-checkout-cache",
+        target_kind="instance",
+        resource_id="redis-prod-checkout-cache",
+        display_name="checkout-cache-prod",
+        name="checkout-cache-prod",
+        environment="production",
+        usage="cache",
+        target_type="oss_single",
+        capabilities=["redis", "diagnostics"],
+        search_text="checkout cache prod production cache",
+        search_aliases=["checkout"],
+    )
+
+    with patch(
+        "redis_sre_agent.core.targets.get_target_catalog",
+        new=AsyncMock(return_value=[host_target, cache_target]),
+    ):
+        resolved = await resolve_target_query(
+            query="compare redis-1.prod.example.com with checkout-cache-prod",
+            allow_multiple=True,
+        )
+
+    assert resolved.status == "resolved"
+    assert resolved.clarification_required is False
+    assert {match.resource_id for match in resolved.selected_matches} == {
+        "redis-prod-router",
+        "redis-prod-checkout-cache",
+    }
+
+
+@pytest.mark.asyncio
 async def test_resolve_target_query_keeps_token_overlap_from_all_aliases():
     target = TargetCatalogDoc(
         target_id="instance:prod-cache",

--- a/tests/unit/core/test_targets.py
+++ b/tests/unit/core/test_targets.py
@@ -363,6 +363,52 @@ async def test_resolve_target_query_allow_multiple_uses_exact_mentions_inside_co
 
 
 @pytest.mark.asyncio
+async def test_resolve_target_query_allow_multiple_requires_confirmation_for_descriptive_query():
+    prod = TargetCatalogDoc(
+        target_id="instance:redis-prod-checkout-cache",
+        target_kind="instance",
+        resource_id="redis-prod-checkout-cache",
+        display_name="checkout-cache-prod",
+        name="checkout-cache-prod",
+        environment="production",
+        usage="cache",
+        target_type="oss_single",
+        capabilities=["redis", "diagnostics"],
+        search_text="checkout cache prod production cache",
+        search_aliases=["checkout"],
+    )
+    stage = TargetCatalogDoc(
+        target_id="instance:redis-stage-checkout-cache",
+        target_kind="instance",
+        resource_id="redis-stage-checkout-cache",
+        display_name="checkout-cache-stage",
+        name="checkout-cache-stage",
+        environment="staging",
+        usage="cache",
+        target_type="oss_single",
+        capabilities=["redis", "diagnostics"],
+        search_text="checkout cache stage staging cache",
+        search_aliases=["checkout"],
+    )
+
+    with patch(
+        "redis_sre_agent.core.targets.get_target_catalog",
+        new=AsyncMock(return_value=[prod, stage]),
+    ):
+        resolved = await resolve_target_query(
+            query="compare prod checkout against stage checkout",
+            allow_multiple=True,
+        )
+
+    assert resolved.status == "clarification_required"
+    assert resolved.clarification_required is True
+    assert [match.resource_id for match in resolved.selected_matches] == [
+        "redis-prod-checkout-cache",
+        "redis-stage-checkout-cache",
+    ]
+
+
+@pytest.mark.asyncio
 async def test_resolve_target_query_keeps_token_overlap_from_all_aliases():
     target = TargetCatalogDoc(
         target_id="instance:prod-cache",

--- a/tests/unit/core/test_targets.py
+++ b/tests/unit/core/test_targets.py
@@ -289,6 +289,80 @@ async def test_resolve_target_query_hostname_like_queries_require_exact_identifi
 
 
 @pytest.mark.asyncio
+async def test_resolve_target_query_dotted_version_terms_do_not_trigger_hostname_gate():
+    candidate = TargetCatalogDoc(
+        target_id="instance:checkout-cache-prod",
+        target_kind="instance",
+        resource_id="checkout-cache-prod",
+        display_name="checkout-cache-prod",
+        name="checkout-cache-prod",
+        environment="production",
+        usage="cache",
+        target_type="oss_single",
+        capabilities=["redis"],
+        search_text="checkout cache prod production cache",
+        search_aliases=["checkout cache"],
+    )
+
+    hints = target_module._parse_query_hints("checkout cache prod v7.2")
+    score, reasons = target_module._score_target_doc(
+        "checkout cache prod v7.2",
+        candidate,
+        hints=hints,
+    )
+
+    assert hints["hostname_terms"] == set()
+    assert score > 0
+    assert all(not reason.startswith("matched hostname=") for reason in reasons)
+
+
+@pytest.mark.asyncio
+async def test_resolve_target_query_allow_multiple_uses_exact_mentions_inside_compound_query():
+    prod = TargetCatalogDoc(
+        target_id="instance:redis-prod-checkout-cache",
+        target_kind="instance",
+        resource_id="redis-prod-checkout-cache",
+        display_name="checkout-cache-prod",
+        name="checkout-cache-prod",
+        environment="production",
+        usage="cache",
+        target_type="oss_single",
+        capabilities=["redis", "diagnostics"],
+        search_text="checkout cache prod production cache",
+        search_aliases=["checkout"],
+    )
+    stage = TargetCatalogDoc(
+        target_id="instance:redis-stage-checkout-cache",
+        target_kind="instance",
+        resource_id="redis-stage-checkout-cache",
+        display_name="checkout-cache-stage",
+        name="checkout-cache-stage",
+        environment="staging",
+        usage="cache",
+        target_type="oss_single",
+        capabilities=["redis", "diagnostics"],
+        search_text="checkout cache stage staging cache",
+        search_aliases=["checkout"],
+    )
+
+    with patch(
+        "redis_sre_agent.core.targets.get_target_catalog",
+        new=AsyncMock(return_value=[prod, stage]),
+    ):
+        resolved = await resolve_target_query(
+            query="compare checkout-cache-prod with checkout-cache-stage",
+            allow_multiple=True,
+        )
+
+    assert resolved.status == "resolved"
+    assert resolved.clarification_required is False
+    assert [match.resource_id for match in resolved.selected_matches] == [
+        "redis-prod-checkout-cache",
+        "redis-stage-checkout-cache",
+    ]
+
+
+@pytest.mark.asyncio
 async def test_resolve_target_query_keeps_token_overlap_from_all_aliases():
     target = TargetCatalogDoc(
         target_id="instance:prod-cache",

--- a/tests/unit/core/test_targets.py
+++ b/tests/unit/core/test_targets.py
@@ -97,7 +97,7 @@ def test_build_target_doc_from_cluster_includes_base_capabilities():
 
 
 @pytest.mark.asyncio
-async def test_resolve_target_query_ranks_matching_environment_and_detects_ambiguity():
+async def test_resolve_target_query_requires_confirmation_for_fuzzy_queries():
     prod = TargetCatalogDoc(
         target_id="instance:redis-prod-checkout-cache",
         target_kind="instance",
@@ -129,7 +129,7 @@ async def test_resolve_target_query_ranks_matching_environment_and_detects_ambig
         "redis_sre_agent.core.targets.get_target_catalog",
         new=AsyncMock(return_value=[prod, stage]),
     ):
-        resolved = await resolve_target_query(query="prod checkout cache", allow_multiple=False)
+        resolved = await resolve_target_query(query="checkout-cache-prod", allow_multiple=False)
         ambiguous = await resolve_target_query(query="checkout cache", allow_multiple=False)
 
     assert resolved.status == "resolved"
@@ -148,7 +148,7 @@ async def test_resolve_target_query_ranks_matching_environment_and_detects_ambig
 
 
 @pytest.mark.asyncio
-async def test_resolve_target_query_resolves_single_included_candidate_below_three_points():
+async def test_resolve_target_query_requires_confirmation_for_single_fuzzy_candidate():
     low_score_match = TargetCatalogDoc(
         target_id="instance:redis-prod-checkout-cache",
         target_kind="instance",
@@ -169,8 +169,8 @@ async def test_resolve_target_query_resolves_single_included_candidate_below_thr
     ):
         resolved = await resolve_target_query(query="cache", allow_multiple=False)
 
-    assert resolved.status == "resolved"
-    assert resolved.clarification_required is False
+    assert resolved.status == "clarification_required"
+    assert resolved.clarification_required is True
     assert len(resolved.selected_matches) == 1
     assert resolved.selected_matches[0].resource_id == "redis-prod-checkout-cache"
 
@@ -217,10 +217,75 @@ async def test_resolve_target_query_parses_hints_once_and_avoids_alias_substring
         resolved = await resolve_target_query(query="checkout cache", allow_multiple=False)
 
     assert parse_hints.call_count == 1
-    assert resolved.status == "resolved"
+    assert resolved.status == "clarification_required"
+    assert resolved.clarification_required is True
     assert len(resolved.selected_matches) == 1
     assert resolved.selected_matches[0].resource_id == "checkout-cache"
     assert all(match.resource_id != "alias-only" for match in resolved.matches)
+
+
+@pytest.mark.asyncio
+async def test_resolve_target_query_does_not_fuzzy_match_hostname_like_queries():
+    fuzzy_candidate = TargetCatalogDoc(
+        target_id="instance:fedex-redis-cache",
+        target_kind="instance",
+        resource_id="fedex-redis-cache",
+        display_name="fedex redis bo cache",
+        name="fedex-redis-bo-cache",
+        environment="test",
+        usage="cache",
+        target_type="oss_single",
+        capabilities=["redis"],
+        search_text="fedex redis bo cache",
+        search_aliases=[],
+    )
+
+    with patch(
+        "redis_sre_agent.core.targets.get_target_catalog",
+        new=AsyncMock(return_value=[fuzzy_candidate]),
+    ):
+        resolved = await resolve_target_query(
+            query="qas12-edc-bo.redis.fedex.com",
+            allow_multiple=False,
+        )
+
+    assert resolved.status == "no_match"
+    assert resolved.clarification_required is False
+    assert resolved.matches == []
+    assert resolved.selected_matches == []
+
+
+@pytest.mark.asyncio
+async def test_resolve_target_query_hostname_like_queries_require_exact_identifier_match():
+    exact_candidate = TargetCatalogDoc(
+        target_id="instance:fedex-node",
+        target_kind="instance",
+        resource_id="fedex-node",
+        display_name="fedex redis node",
+        name="fedex-redis-node",
+        environment="test",
+        usage="cache",
+        target_type="oss_single",
+        capabilities=["redis", "diagnostics"],
+        monitoring_identifier="qas12-edc-bo.redis.fedex.com",
+        search_text="fedex redis node",
+        search_aliases=[],
+    )
+
+    with patch(
+        "redis_sre_agent.core.targets.get_target_catalog",
+        new=AsyncMock(return_value=[exact_candidate]),
+    ):
+        resolved = await resolve_target_query(
+            query="qas12-edc-bo.redis.fedex.com",
+            allow_multiple=False,
+        )
+
+    assert resolved.status == "resolved"
+    assert resolved.clarification_required is False
+    assert len(resolved.selected_matches) == 1
+    assert resolved.selected_matches[0].resource_id == "fedex-node"
+    assert resolved.matches[0].match_reasons[0] == "matched hostname=qas12-edc-bo.redis.fedex.com"
 
 
 @pytest.mark.asyncio
@@ -277,7 +342,8 @@ async def test_resolve_target_query_excludes_hint_tokens_from_token_overlap():
             allow_multiple=False,
         )
 
-    assert resolved.status == "resolved"
+    assert resolved.status == "clarification_required"
+    assert resolved.clarification_required is True
     assert resolved.selected_matches[0].resource_id == "enterprise-cache"
     assert all(
         not reason.startswith("matched tokens=")

--- a/tests/unit/tools/test_target_discovery_provider.py
+++ b/tests/unit/tools/test_target_discovery_provider.py
@@ -38,6 +38,7 @@ async def test_resolve_redis_targets_uses_shared_binding_contract():
     provider._manager = manager
 
     resolution = MagicMock()
+    resolution.status = "resolved"
     resolution.selected_matches = [
         ResolvedTargetMatch(
             target_kind="instance",
@@ -167,6 +168,60 @@ async def test_resolve_redis_targets_without_attachment_uses_existing_toolset_ge
     mock_bind.assert_not_awaited()
     assert payload["attached_target_handles"] == []
     assert payload["toolset_generation"] == 4
+
+
+@pytest.mark.asyncio
+async def test_resolve_redis_targets_does_not_attach_when_confirmation_is_required():
+    provider = TargetDiscoveryToolProvider()
+    manager = MagicMock()
+    manager.thread_id = "thread-1"
+    manager.task_id = "task-1"
+    manager.user_id = "user-1"
+    manager.get_toolset_generation.return_value = 6
+    provider._manager = manager
+
+    resolution = MagicMock()
+    resolution.status = "clarification_required"
+    resolution.selected_matches = [
+        ResolvedTargetMatch(
+            target_kind="instance",
+            resource_id="redis-prod-checkout-cache",
+            display_name="checkout-cache-prod",
+            environment="production",
+            target_type="oss_single",
+            capabilities=["redis", "diagnostics"],
+            confidence=0.72,
+            match_reasons=["matched tokens=checkout,cache"],
+        )
+    ]
+    resolution.model_dump.return_value = {
+        "status": "clarification_required",
+        "clarification_required": True,
+        "matches": [],
+        "attached_target_handles": [],
+        "toolset_generation": 0,
+    }
+
+    with (
+        patch(
+            "redis_sre_agent.tools.target_discovery.provider.resolve_target_query",
+            new=AsyncMock(return_value=resolution),
+        ) as mock_resolve,
+        patch(
+            "redis_sre_agent.tools.target_discovery.provider.bind_target_matches",
+            new=AsyncMock(),
+        ) as mock_bind,
+    ):
+        payload = await provider.resolve_redis_targets(
+            query="checkout cache",
+            attach_tools=True,
+        )
+
+    mock_resolve.assert_awaited_once()
+    mock_bind.assert_not_awaited()
+    assert payload["status"] == "clarification_required"
+    assert payload["attached_target_handles"] == []
+    assert payload["toolset_generation"] == 6
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- require explicit confirmation before fuzzy target discovery can attach live Redis tools
- keep exact live target matches auto-resolving, including exact hostname/identifier matches
- add regression coverage for fuzzy single-candidate clarification and non-attachment behavior

## Testing
- `.venv/bin/python -m pytest tests/unit/core/test_targets.py tests/unit/tools/test_target_discovery_provider.py tests/unit/agent/test_chat_agent.py -q`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes target discovery scoring/selection and when live tools get attached, which can alter resolution behavior and user workflows. Main risk is false negatives or increased clarification prompts for previously auto-resolved queries (especially hostname-like inputs).
> 
> **Overview**
> **Target discovery is now stricter about auto-resolving/attaching live tools.** Hostname-like queries are detected and will only match when the hostname/identifier is an *exact* catalog term; otherwise they return `no_match` to avoid guessing.
> 
> **Fuzzy matches now require explicit confirmation.** Catalog candidate selection prefers exact identifier/name mentions (including exact mentions embedded in compound queries for `allow_multiple=true`) and otherwise returns `clarification_required`; the tool provider only calls `bind_target_matches` when the resolution `status` is `resolved`.
> 
> Prompts and tests are updated to reinforce hostname caution and skill/Analyzer-first guidance, with new unit coverage for hostname gating, fuzzy single-candidate clarification, and non-attachment when confirmation is required.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 350deb556cccd4b6e4fb8b19e96dc9f7b46e95ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->