### PR TITLE
fix(skills): ground startup inventory semantically

### DIFF
--- a/redis_sre_agent/agent/knowledge_context.py
+++ b/redis_sre_agent/agent/knowledge_context.py
@@ -3,6 +3,7 @@
 import logging
 from typing import Any, Dict, List, Optional
 
+from redis_sre_agent.core.config import settings
 from redis_sre_agent.core.knowledge_helpers import (
     get_pinned_documents_helper,
     skills_check_helper,
@@ -254,7 +255,8 @@ async def build_startup_knowledge_context(
     version: Optional[str] = "latest",
     pinned_limit: int = 20,
     pinned_content_char_budget: int = 12000,
-    skills_limit: int = 20,
+    skills_limit: Optional[int] = None,
+    skills_query: Optional[str] = None,
     available_tools: Optional[List[Any]] = None,
     knowledge_backend: Optional[EvalKnowledgeBackend] = None,
 ) -> str:
@@ -262,6 +264,10 @@ async def build_startup_knowledge_context(
     sections: List[str] = []
     internal_tool_envelopes: List[Dict[str, Any]] = []
     effective_knowledge_backend = knowledge_backend or get_active_knowledge_backend()
+    effective_skills_limit = max(
+        int(skills_limit if skills_limit is not None else settings.startup_skills_toc_limit),
+        1,
+    )
 
     try:
         if effective_knowledge_backend is not None:
@@ -309,15 +315,15 @@ async def build_startup_knowledge_context(
     try:
         if effective_knowledge_backend is not None:
             skills_result = await effective_knowledge_backend.skills_check(
-                query=query,
-                limit=skills_limit,
+                query=skills_query,
+                limit=effective_skills_limit,
                 offset=0,
                 version=version,
             )
         else:
             skills_result = await skills_check_helper(
-                query=query,
-                limit=skills_limit,
+                query=skills_query,
+                limit=effective_skills_limit,
                 offset=0,
                 version=version,
             )
@@ -330,9 +336,9 @@ async def build_startup_knowledge_context(
         sections.append("\n".join(skills_lines))
         skills_envelope = _build_internal_startup_skills_envelope(
             skills_result.get("skills") or [],
-            query=query,
+            query=skills_query or "",
             version=version,
-            skills_limit=skills_limit,
+            skills_limit=effective_skills_limit,
         )
         if skills_envelope:
             internal_tool_envelopes.append(skills_envelope)

--- a/redis_sre_agent/core/config.py
+++ b/redis_sre_agent/core/config.py
@@ -562,6 +562,10 @@ class Settings(BaseSettings):
         default=12000,
         description="Character budget for explicit skill resource retrieval responses.",
     )
+    startup_skills_toc_limit: int = Field(
+        default=25,
+        description="Maximum number of skills to inject into the startup prompt TOC.",
+    )
 
     target_integrations: TargetIntegrationsConfig = Field(
         default_factory=TargetIntegrationsConfig,

--- a/redis_sre_agent/skills/afs_workspace_backend.py
+++ b/redis_sre_agent/skills/afs_workspace_backend.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import math
 import os
 import re
 from dataclasses import dataclass
@@ -44,6 +45,7 @@ _GATEWAY_QUERY_STOPWORDS = {
     "what",
     "you",
 }
+_SEMANTIC_SKILL_FETCH_LIMIT = 500
 
 
 def _first_non_empty(
@@ -260,61 +262,46 @@ class AFSWorkspaceSkillBackend:
         offset: int,
         version: str | None,
     ) -> dict[str, Any]:
-        path = self._base_path()
-        params: dict[str, Any] = {"version": version} if version else {}
         if query:
-            path = f"{path}/search"
-            params["q"] = query
-            params["limit"] = max(limit + offset, 1)
-        else:
-            params["limit"] = limit
-            params["offset"] = offset
-        payload = await self._request_json("GET", path, params=params)
+            raw_skills = await self._fetch_api_skill_catalog(
+                version=version,
+                minimum_count=max(limit + offset, 1),
+            )
+            ranked_skills = await self._semantic_rank_skills(raw_skills, query=query)
+            paged_skills = ranked_skills[offset : offset + limit]
+            normalized_skills = [
+                self._normalize_skill_summary(skill, matched_path=None)
+                for skill in paged_skills
+                if isinstance(skill, Mapping)
+            ]
+            return {
+                "query": query,
+                "version": version,
+                "offset": offset,
+                "limit": limit,
+                "results_count": len(normalized_skills),
+                "total_fetched": len(ranked_skills),
+                "skills": normalized_skills,
+            }
+
+        payload = await self._request_json(
+            "GET",
+            self._base_path(),
+            params={
+                "version": version,
+                "limit": limit,
+                "offset": offset,
+            },
+        )
         data = self._data_payload(payload)
         raw_skills = data.get("skills", [])
         if not isinstance(raw_skills, list):
             raw_skills = []
-        normalized_skills = (
-            [
-                self._normalize_skill_summary(skill, matched_path=None)
-                for skill in raw_skills[offset : offset + limit]
-                if isinstance(skill, Mapping)
-            ]
-            if query
-            else [
-                self._normalize_skill_summary(skill, matched_path=None)
-                for skill in raw_skills
-                if isinstance(skill, Mapping)
-            ]
-        )
-        if query:
-            matches = data.get("matches", [])
-            if isinstance(matches, list):
-                by_identity = {
-                    (
-                        str(item.get("skillSlug", "")).strip(),
-                        str(item.get("version", "")).strip(),
-                    ): item
-                    for item in matches
-                    if isinstance(item, Mapping)
-                }
-                normalized_skills = [
-                    self._normalize_skill_summary(
-                        skill,
-                        matched_path=str(
-                            by_identity.get(
-                                (
-                                    str(skill.get("skillSlug", "")).strip(),
-                                    str(skill.get("version", "")).strip(),
-                                ),
-                                {},
-                            ).get("path", "")
-                        ).strip()
-                        or None,
-                    )
-                    for skill in raw_skills[offset : offset + limit]
-                    if isinstance(skill, Mapping)
-                ]
+        normalized_skills = [
+            self._normalize_skill_summary(skill, matched_path=None)
+            for skill in raw_skills
+            if isinstance(skill, Mapping)
+        ]
         return {
             "query": query,
             "version": version,
@@ -335,12 +322,7 @@ class AFSWorkspaceSkillBackend:
     ) -> dict[str, Any]:
         raw_skills = await self._gateway_catalog_entries(version=version)
         if query:
-            matched_skills = self._filter_gateway_skills(raw_skills, query=query)
-            # The gateway only exposes catalog reads, not semantic search. When
-            # a free-form prompt does not keyword-match the catalog, fall back to
-            # discovery instead of claiming that no skills exist.
-            if matched_skills:
-                raw_skills = matched_skills
+            raw_skills = await self._semantic_rank_skills(raw_skills, query=query)
         paged = raw_skills[offset : offset + limit]
         normalized_skills = [
             self._normalize_skill_summary(skill, matched_path=None) for skill in paged
@@ -354,6 +336,91 @@ class AFSWorkspaceSkillBackend:
             "total_fetched": len(raw_skills),
             "skills": normalized_skills,
         }
+
+    async def _fetch_api_skill_catalog(
+        self,
+        *,
+        version: str | None,
+        minimum_count: int,
+    ) -> list[Mapping[str, Any]]:
+        initial_limit = min(max(minimum_count, 100), _SEMANTIC_SKILL_FETCH_LIMIT)
+        payload = await self._request_json(
+            "GET",
+            self._base_path(),
+            params={
+                "version": version,
+                "limit": initial_limit,
+                "offset": 0,
+            },
+        )
+        data = self._data_payload(payload)
+        raw_skills = data.get("skills", [])
+        if not isinstance(raw_skills, list):
+            raw_skills = []
+
+        total = int(data.get("total", len(raw_skills)))
+        if total > len(raw_skills) and len(raw_skills) < _SEMANTIC_SKILL_FETCH_LIMIT:
+            expanded_limit = min(total, _SEMANTIC_SKILL_FETCH_LIMIT)
+            payload = await self._request_json(
+                "GET",
+                self._base_path(),
+                params={
+                    "version": version,
+                    "limit": expanded_limit,
+                    "offset": 0,
+                },
+            )
+            data = self._data_payload(payload)
+            raw_skills = data.get("skills", [])
+            if not isinstance(raw_skills, list):
+                raw_skills = []
+
+        return [skill for skill in raw_skills if isinstance(skill, Mapping)]
+
+    async def _semantic_rank_skills(
+        self,
+        skills: list[Mapping[str, Any]],
+        *,
+        query: str,
+    ) -> list[Mapping[str, Any]]:
+        query_text = query.strip()
+        if not query_text:
+            return list(skills)
+
+        fallback_matches = self._filter_gateway_skills(skills, query=query)
+        if not skills:
+            return []
+
+        try:
+            from redis_sre_agent.core.redis import get_vectorizer
+
+            vectorizer = get_vectorizer()
+            ranking_texts = [self._skill_ranking_text(skill) for skill in skills]
+            embeddings = await vectorizer.aembed_many([query_text, *ranking_texts])
+        except Exception:
+            return fallback_matches or list(skills)
+
+        if len(embeddings) != len(skills) + 1:
+            return fallback_matches or list(skills)
+
+        query_embedding = embeddings[0]
+        scored: list[tuple[float, str, str, Mapping[str, Any]]] = []
+        for skill, embedding in zip(skills, embeddings[1:]):
+            semantic_score = self._cosine_similarity(query_embedding, embedding)
+            lexical_score = self._lexical_overlap_score(skill, query_text)
+            combined_score = semantic_score + (0.05 * lexical_score)
+            scored.append(
+                (
+                    -combined_score,
+                    str(skill.get("displayName", skill.get("skillSlug", ""))).strip().lower(),
+                    str(skill.get("version", "")).strip().lower(),
+                    skill,
+                )
+            )
+
+        scored.sort(key=lambda item: item[:3])
+        ranked = [item[3] for item in scored]
+        return ranked or fallback_matches or list(skills)
 
     def _filter_gateway_skills(
         self,
@@ -385,6 +452,57 @@ class AFSWorkspaceSkillBackend:
             if any(token in haystack for token in query_tokens):
                 token_matches.append(skill)
         return token_matches
+
+    def _skill_ranking_text(self, skill: Mapping[str, Any]) -> str:
+        tags = skill.get("tags", [])
+        tag_values = (
+            [str(tag).strip() for tag in tags if str(tag).strip()] if isinstance(tags, list) else []
+        )
+        return "\n".join(
+            part
+            for part in (
+                str(skill.get("displayName", "")).strip(),
+                str(skill.get("skillSlug", "")).strip(),
+                str(skill.get("description", "")).strip(),
+                " ".join(tag_values),
+            )
+            if part
+        )
+
+    def _lexical_overlap_score(self, skill: Mapping[str, Any], query: str) -> float:
+        haystack = self._skill_ranking_text(skill).lower()
+        query_text = query.strip().lower()
+        if not query_text or not haystack:
+            return 0.0
+        if query_text in haystack:
+            return 1.0
+
+        query_tokens = [
+            token
+            for token in _GATEWAY_QUERY_TOKEN_RE.findall(query_text)
+            if len(token) >= 3 and token not in _GATEWAY_QUERY_STOPWORDS
+        ]
+        if not query_tokens:
+            return 0.0
+
+        matched_tokens = sum(1 for token in query_tokens if token in haystack)
+        return matched_tokens / len(query_tokens)
+
+    def _cosine_similarity(self, left: Any, right: Any) -> float:
+        try:
+            left_values = [float(value) for value in left]
+            right_values = [float(value) for value in right]
+        except Exception:
+            return 0.0
+        if not left_values or len(left_values) != len(right_values):
+            return 0.0
+
+        numerator = sum(a * b for a, b in zip(left_values, right_values))
+        left_norm = math.sqrt(sum(a * a for a in left_values))
+        right_norm = math.sqrt(sum(b * b for b in right_values))
+        if left_norm == 0.0 or right_norm == 0.0:
+            return 0.0
+        return numerator / (left_norm * right_norm)
 
     async def _get_skill_via_api(self, *, skill_name: str, version: str | None) -> dict[str, Any]:
         try:

--- a/tests/unit/agent/test_knowledge_context.py
+++ b/tests/unit/agent/test_knowledge_context.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from redis_sre_agent.agent import knowledge_context as knowledge_context_module
 from redis_sre_agent.agent.knowledge_context import (
     _build_internal_pinned_context_envelope,
     _build_internal_startup_skills_envelope,
@@ -298,8 +299,8 @@ async def test_startup_context_carries_internal_skill_discovery_envelope():
     assert envelope["tool_key"] == "knowledge.startup_skills_check"
     assert envelope["name"] == "skills_check"
     assert envelope["args"] == {
-        "query": "memory issue",
-        "limit": 20,
+        "query": "",
+        "limit": 25,
         "offset": 0,
         "version": "latest",
     }
@@ -379,7 +380,8 @@ async def test_startup_context_uses_eval_scoped_knowledge_backend():
             }
 
         async def skills_check(self, **kwargs):
-            assert kwargs["query"] == "memory issue"
+            assert kwargs["query"] is None
+            assert kwargs["limit"] == 25
             return {
                 "skills": [
                     {
@@ -437,3 +439,34 @@ async def test_startup_context_keeps_skill_listing_compact():
     assert "Redis Maintenance Triage: Investigate maintenance mode before failover." in context
     assert "references/maintenance-checklist.md" not in context
     assert "Scripts:" not in context
+
+
+@pytest.mark.asyncio
+async def test_startup_context_uses_unfiltered_skills_toc_limit_from_settings():
+    skills_check = AsyncMock(
+        return_value={
+            "skills": [
+                {
+                    "name": "Redis Maintenance Triage",
+                    "description": "Investigate maintenance mode before failover.",
+                }
+            ]
+        }
+    )
+    with (
+        patch(
+            "redis_sre_agent.agent.knowledge_context.get_pinned_documents_helper",
+            new=AsyncMock(return_value={"pinned_documents": []}),
+        ),
+        patch(
+            "redis_sre_agent.agent.knowledge_context.skills_check_helper",
+            new=skills_check,
+        ),
+        patch.object(knowledge_context_module.settings, "startup_skills_toc_limit", 7),
+    ):
+        context = await build_startup_knowledge_context(
+            query="run a health check", version="latest"
+        )
+
+    assert "Redis Maintenance Triage: Investigate maintenance mode before failover." in context
+    skills_check.assert_awaited_once_with(query=None, limit=7, offset=0, version="latest")

--- a/tests/unit/skills/test_afs_workspace_backend.py
+++ b/tests/unit/skills/test_afs_workspace_backend.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from types import SimpleNamespace
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 import httpx
 import pytest
@@ -133,15 +133,16 @@ async def test_afs_workspace_skill_backend_query_and_error_paths() -> None:
                             "description": "Check maintenance mode first.",
                             "version": "v1",
                             "resources": [],
-                        }
-                    ],
-                    "matches": [
+                        },
                         {
-                            "skillSlug": "redis-maintenance-triage",
+                            "skillSlug": "redis-cluster-health-check",
+                            "displayName": "Redis Cluster Health Check",
+                            "description": "Produce Analyzer-backed cluster findings.",
                             "version": "v1",
-                            "path": "/skills/redis-maintenance-triage/versions/v1/references/checklist.md",
-                        }
+                            "resources": [],
+                        },
                     ],
+                    "total": 2,
                 }
             }
         ),
@@ -158,8 +159,24 @@ async def test_afs_workspace_skill_backend_query_and_error_paths() -> None:
         client_factory=lambda **kwargs: client,  # type: ignore[arg-type]
     )
 
-    queried = await backend.list_skills(query="checklist", limit=10, offset=0, version="v1")
-    assert queried["skills"][0]["matched_resource_kind"] == "reference"
+    vectorizer = AsyncMock()
+    vectorizer.aembed_many = AsyncMock(
+        return_value=[
+            [1.0, 0.0],
+            [0.1, 0.9],
+            [0.9, 0.1],
+        ]
+    )
+    with patch("redis_sre_agent.core.redis.get_vectorizer", return_value=vectorizer):
+        queried = await backend.list_skills(
+            query="run a health check",
+            limit=10,
+            offset=0,
+            version="v1",
+        )
+
+    assert queried["skills"][0]["name"] == "redis-cluster-health-check"
+    assert queried["skills"][0]["matched_resource_kind"] == "entrypoint"
 
     missing_skill = await backend.get_skill(skill_name="missing", version="v1")
     assert missing_skill["error"] == "Skill not found"
@@ -297,6 +314,55 @@ async def test_afs_workspace_skill_backend_list_uses_gateway_when_configured() -
 
     assert result["results_count"] == 1
     assert result["skills"][0]["name"] == "redis-maintenance-triage"
+
+
+@pytest.mark.asyncio
+async def test_afs_workspace_skill_backend_gateway_query_uses_semantic_ranking() -> None:
+    backend = AFSWorkspaceSkillBackend(
+        base_url="https://skills.internal",
+        tenant_id="tenant_a",
+        project_id="proj_1",
+        agent_id="agent_1",
+        gateway_url="https://gateway.internal/mcp",
+        gateway_token="secret",
+        workspace_id="skills-proj-1-agent-1",
+    )
+    backend._gateway_catalog_entries = AsyncMock(  # type: ignore[method-assign]
+        return_value=[
+            {
+                "skillSlug": "redis-maintenance-triage",
+                "displayName": "Redis Maintenance Triage",
+                "description": "Check maintenance mode first.",
+                "version": "v1",
+                "resources": [],
+            },
+            {
+                "skillSlug": "redis-cluster-health-check",
+                "displayName": "Redis Cluster Health Check",
+                "description": "Produce Analyzer-backed cluster findings.",
+                "version": "v1",
+                "resources": [],
+            },
+        ]
+    )
+    vectorizer = AsyncMock()
+    vectorizer.aembed_many = AsyncMock(
+        return_value=[
+            [1.0, 0.0],
+            [0.1, 0.9],
+            [0.95, 0.05],
+        ]
+    )
+
+    with patch("redis_sre_agent.core.redis.get_vectorizer", return_value=vectorizer):
+        result = await backend.list_skills(
+            query="cluster health findings",
+            limit=10,
+            offset=0,
+            version="latest",
+        )
+
+    assert result["skills"][0]["name"] == "redis-cluster-health-check"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Moderate risk: changes startup skill TOC retrieval parameters and adds semantic ranking that can alter which skills are surfaced; also increases API fetches (up to 500) and depends on embedding/vectorizer behavior with fallbacks.
> 
> **Overview**
> Improves startup grounding by **decoupling the startup skill TOC from the user query** and making the injected inventory size configurable via new `settings.startup_skills_toc_limit` (default `25`). `build_startup_knowledge_context` now uses an optional `skills_query` (often `None`) plus a settings-backed limit, and records those effective args in the internal envelope.
> 
> Updates `AFSWorkspaceSkillBackend.list_skills` so query-based listing is **semantically ranked** using embeddings (with lexical fallback), including gateway-backed catalogs; API search now fetches a larger catalog slice (capped at `500`) before ranking/paging. Tests were updated/added to validate the new defaults, settings override, and semantic ordering behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e6629da664e13b69c2edc63f2473be73b52ae895. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->