### PR TITLE
Fix startup skills TOC and semantic lookup

### DIFF
--- a/redis_sre_agent/agent/chat_agent.py
+++ b/redis_sre_agent/agent/chat_agent.py
@@ -528,14 +528,7 @@ class ChatAgent:
                 if startup_system_prompt is None or (
                     iteration_count == 0 and not startup_prompt_initialized
                 ):
-                    context_query = ""
-                    for message in reversed(messages):
-                        if isinstance(message, HumanMessage):
-                            context_query = str(message.content or "")
-                            break
-
                     startup_context = await build_startup_knowledge_context(
-                        query=context_query,
                         version="latest",
                         available_tools=list(tooldefs_by_name.values()),
                     )
@@ -784,7 +777,6 @@ class ChatAgent:
 
             # Build initial messages with shared startup context (pinned docs, skills, tool usage)
             startup_context = await build_startup_knowledge_context(
-                query=query,
                 version="latest",
                 available_tools=tools,
             )

--- a/redis_sre_agent/agent/knowledge_agent.py
+++ b/redis_sre_agent/agent/knowledge_agent.py
@@ -167,13 +167,7 @@ class KnowledgeOnlyAgent:
                 if startup_system_prompt is None or (
                     iteration_count == 0 and not startup_prompt_initialized
                 ):
-                    context_query = ""
-                    for message in reversed(messages):
-                        if isinstance(message, HumanMessage):
-                            context_query = str(message.content or "")
-                            break
                     startup_context = await build_startup_knowledge_context(
-                        query=context_query,
                         version="latest",
                         available_tools=list(tooldefs_by_name.values()),
                     )
@@ -555,7 +549,6 @@ class KnowledgeOnlyAgent:
 
             # Build startup context once per query and seed initial SystemMessage.
             startup_context = await build_startup_knowledge_context(
-                query=query,
                 version="latest",
                 available_tools=tools,
             )

--- a/redis_sre_agent/agent/knowledge_context.py
+++ b/redis_sre_agent/agent/knowledge_context.py
@@ -50,7 +50,12 @@ def merge_internal_tool_envelopes(
     return merged
 
 
-def _skills_toc_lines(skills: List[Dict[str, Any]]) -> List[str]:
+def _skills_toc_lines(
+    skills: List[Dict[str, Any]],
+    *,
+    total_skills: Optional[int] = None,
+    displayed_limit: Optional[int] = None,
+) -> List[str]:
     """Render the ADR skills table of contents lines."""
     if not skills:
         return []
@@ -62,6 +67,14 @@ def _skills_toc_lines(skills: List[Dict[str, Any]]) -> List[str]:
         "- If a listed skill matches the request, retrieve it with `get_skill` before claiming that you used, followed, or executed it.",
         "- If you use any retrieved skills during your turn, add a note to your answer saying which skill(s) you used.",
     ]
+    if total_skills is not None and total_skills > len(skills):
+        remaining = total_skills - len(skills)
+        shown = displayed_limit if displayed_limit is not None else len(skills)
+        lines.append(
+            "- This startup inventory is truncated: "
+            f"{shown} skill{'s' if shown != 1 else ''} shown, {remaining} more available in the backend. "
+            "If you need a related skill that is not listed here, search for related skills before concluding there is no relevant match."
+        )
     for skill in skills:
         name = str(skill.get("name", "")).strip() or str(skill.get("title", "")).strip()
         summary = str(skill.get("summary", "")).strip() or str(skill.get("description", "")).strip()
@@ -330,11 +343,24 @@ async def build_startup_knowledge_context(
         logger.warning("Failed to run startup skills check: %s", exc)
         skills_result = {"skills": []}
 
-    skills_lines = _skills_toc_lines(skills_result.get("skills") or [])
+    skill_rows = skills_result.get("skills") or []
+    total_skills = skills_result.get("total_fetched")
+    if total_skills is None:
+        total_skills = skills_result.get("total")
+    try:
+        normalized_total_skills = int(total_skills) if total_skills is not None else None
+    except (TypeError, ValueError):
+        normalized_total_skills = None
+
+    skills_lines = _skills_toc_lines(
+        skill_rows,
+        total_skills=normalized_total_skills,
+        displayed_limit=effective_skills_limit,
+    )
     if skills_lines:
         sections.append("\n".join(skills_lines))
         skills_envelope = _build_internal_startup_skills_envelope(
-            skills_result.get("skills") or [],
+            skill_rows,
             query=skills_query or "",
             version=version,
             skills_limit=effective_skills_limit,

--- a/redis_sre_agent/agent/knowledge_context.py
+++ b/redis_sre_agent/agent/knowledge_context.py
@@ -69,7 +69,7 @@ def _skills_toc_lines(
     ]
     if total_skills is not None and total_skills > len(skills):
         remaining = total_skills - len(skills)
-        shown = displayed_limit if displayed_limit is not None else len(skills)
+        shown = len(skills)
         lines.append(
             "- This startup inventory is truncated: "
             f"{shown} skill{'s' if shown != 1 else ''} shown, {remaining} more available in the backend. "

--- a/redis_sre_agent/agent/knowledge_context.py
+++ b/redis_sre_agent/agent/knowledge_context.py
@@ -3,6 +3,7 @@
 import logging
 from typing import Any, Dict, List, Optional
 
+from redis_sre_agent.core.config import settings
 from redis_sre_agent.core.knowledge_helpers import (
     get_pinned_documents_helper,
     skills_check_helper,
@@ -254,7 +255,8 @@ async def build_startup_knowledge_context(
     version: Optional[str] = "latest",
     pinned_limit: int = 20,
     pinned_content_char_budget: int = 12000,
-    skills_limit: int = 20,
+    skills_limit: Optional[int] = None,
+    skills_query: Optional[str] = None,
     available_tools: Optional[List[Any]] = None,
     knowledge_backend: Optional[EvalKnowledgeBackend] = None,
 ) -> str:
@@ -262,6 +264,10 @@ async def build_startup_knowledge_context(
     sections: List[str] = []
     internal_tool_envelopes: List[Dict[str, Any]] = []
     effective_knowledge_backend = knowledge_backend or get_active_knowledge_backend()
+    effective_skills_limit = max(
+        int(skills_limit if skills_limit is not None else settings.startup_skills_toc_limit),
+        1,
+    )
 
     try:
         if effective_knowledge_backend is not None:
@@ -309,15 +315,15 @@ async def build_startup_knowledge_context(
     try:
         if effective_knowledge_backend is not None:
             skills_result = await effective_knowledge_backend.skills_check(
-                query=query,
-                limit=skills_limit,
+                query=skills_query,
+                limit=effective_skills_limit,
                 offset=0,
                 version=version,
             )
         else:
             skills_result = await skills_check_helper(
-                query=query,
-                limit=skills_limit,
+                query=skills_query,
+                limit=effective_skills_limit,
                 offset=0,
                 version=version,
             )
@@ -330,9 +336,9 @@ async def build_startup_knowledge_context(
         sections.append("\n".join(skills_lines))
         skills_envelope = _build_internal_startup_skills_envelope(
             skills_result.get("skills") or [],
-            query=query,
+            query=skills_query or "",
             version=version,
-            skills_limit=skills_limit,
+            skills_limit=effective_skills_limit,
         )
         if skills_envelope:
             internal_tool_envelopes.append(skills_envelope)

--- a/redis_sre_agent/agent/knowledge_context.py
+++ b/redis_sre_agent/agent/knowledge_context.py
@@ -251,7 +251,6 @@ def _build_internal_startup_skills_envelope(
 
 
 async def build_startup_knowledge_context(
-    query: str,
     version: Optional[str] = "latest",
     pinned_limit: int = 20,
     pinned_content_char_budget: int = 12000,

--- a/redis_sre_agent/agent/knowledge_context.py
+++ b/redis_sre_agent/agent/knowledge_context.py
@@ -54,7 +54,6 @@ def _skills_toc_lines(
     skills: List[Dict[str, Any]],
     *,
     total_skills: Optional[int] = None,
-    displayed_limit: Optional[int] = None,
 ) -> List[str]:
     """Render the ADR skills table of contents lines."""
     if not skills:
@@ -355,7 +354,6 @@ async def build_startup_knowledge_context(
     skills_lines = _skills_toc_lines(
         skill_rows,
         total_skills=normalized_total_skills,
-        displayed_limit=effective_skills_limit,
     )
     if skills_lines:
         sections.append("\n".join(skills_lines))

--- a/redis_sre_agent/agent/langgraph_agent.py
+++ b/redis_sre_agent/agent/langgraph_agent.py
@@ -1128,13 +1128,7 @@ Nodes with `accept_servers=false` are in MAINTENANCE MODE and won't accept new s
                 if startup_system_prompt is None or (
                     iteration_count == 0 and not startup_prompt_initialized
                 ):
-                    context_query = ""
-                    for message in reversed(messages):
-                        if isinstance(message, HumanMessage):
-                            context_query = str(message.content or "")
-                            break
                     startup_context = await build_startup_knowledge_context(
-                        query=context_query,
                         version="latest",
                         available_tools=list(tooldefs_by_name.values()),
                     )
@@ -2364,7 +2358,6 @@ For now, I can still perform basic Redis diagnostics using the database connecti
                 logger.debug(f"  - {tool.name}")
 
             startup_context = await build_startup_knowledge_context(
-                query=enhanced_query,
                 version="latest",
                 available_tools=tools,
             )

--- a/redis_sre_agent/core/config.py
+++ b/redis_sre_agent/core/config.py
@@ -562,6 +562,10 @@ class Settings(BaseSettings):
         default=12000,
         description="Character budget for explicit skill resource retrieval responses.",
     )
+    startup_skills_toc_limit: int = Field(
+        default=25,
+        description="Maximum number of skills to inject into the startup prompt TOC.",
+    )
 
     target_integrations: TargetIntegrationsConfig = Field(
         default_factory=TargetIntegrationsConfig,

--- a/redis_sre_agent/core/config.py
+++ b/redis_sre_agent/core/config.py
@@ -563,7 +563,7 @@ class Settings(BaseSettings):
         description="Character budget for explicit skill resource retrieval responses.",
     )
     startup_skills_toc_limit: int = Field(
-        default=25,
+        default=50,
         description="Maximum number of skills to inject into the startup prompt TOC.",
     )
 

--- a/redis_sre_agent/skills/afs_workspace_backend.py
+++ b/redis_sre_agent/skills/afs_workspace_backend.py
@@ -288,9 +288,9 @@ class AFSWorkspaceSkillBackend:
             "GET",
             self._base_path(),
             params={
-                "version": version,
                 "limit": limit,
                 "offset": offset,
+                **({"version": version} if version else {}),
             },
         )
         data = self._data_payload(payload)
@@ -348,9 +348,9 @@ class AFSWorkspaceSkillBackend:
             "GET",
             self._base_path(),
             params={
-                "version": version,
                 "limit": initial_limit,
                 "offset": 0,
+                **({"version": version} if version else {}),
             },
         )
         data = self._data_payload(payload)
@@ -365,9 +365,9 @@ class AFSWorkspaceSkillBackend:
                 "GET",
                 self._base_path(),
                 params={
-                    "version": version,
                     "limit": expanded_limit,
                     "offset": 0,
+                    **({"version": version} if version else {}),
                 },
             )
             data = self._data_payload(payload)

--- a/redis_sre_agent/skills/afs_workspace_backend.py
+++ b/redis_sre_agent/skills/afs_workspace_backend.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import math
 import os
 import re
 from dataclasses import dataclass
@@ -44,6 +45,7 @@ _GATEWAY_QUERY_STOPWORDS = {
     "what",
     "you",
 }
+_SEMANTIC_SKILL_FETCH_LIMIT = 500
 
 
 def _first_non_empty(
@@ -260,61 +262,46 @@ class AFSWorkspaceSkillBackend:
         offset: int,
         version: str | None,
     ) -> dict[str, Any]:
-        path = self._base_path()
-        params: dict[str, Any] = {"version": version} if version else {}
         if query:
-            path = f"{path}/search"
-            params["q"] = query
-            params["limit"] = max(limit + offset, 1)
-        else:
-            params["limit"] = limit
-            params["offset"] = offset
-        payload = await self._request_json("GET", path, params=params)
+            raw_skills = await self._fetch_api_skill_catalog(
+                version=version,
+                minimum_count=max(limit + offset, 1),
+            )
+            ranked_skills = await self._semantic_rank_skills(raw_skills, query=query)
+            paged_skills = ranked_skills[offset : offset + limit]
+            normalized_skills = [
+                self._normalize_skill_summary(skill, matched_path=None)
+                for skill in paged_skills
+                if isinstance(skill, Mapping)
+            ]
+            return {
+                "query": query,
+                "version": version,
+                "offset": offset,
+                "limit": limit,
+                "results_count": len(normalized_skills),
+                "total_fetched": len(ranked_skills),
+                "skills": normalized_skills,
+            }
+
+        payload = await self._request_json(
+            "GET",
+            self._base_path(),
+            params={
+                "version": version,
+                "limit": limit,
+                "offset": offset,
+            },
+        )
         data = self._data_payload(payload)
         raw_skills = data.get("skills", [])
         if not isinstance(raw_skills, list):
             raw_skills = []
-        normalized_skills = (
-            [
-                self._normalize_skill_summary(skill, matched_path=None)
-                for skill in raw_skills[offset : offset + limit]
-                if isinstance(skill, Mapping)
-            ]
-            if query
-            else [
-                self._normalize_skill_summary(skill, matched_path=None)
-                for skill in raw_skills
-                if isinstance(skill, Mapping)
-            ]
-        )
-        if query:
-            matches = data.get("matches", [])
-            if isinstance(matches, list):
-                by_identity = {
-                    (
-                        str(item.get("skillSlug", "")).strip(),
-                        str(item.get("version", "")).strip(),
-                    ): item
-                    for item in matches
-                    if isinstance(item, Mapping)
-                }
-                normalized_skills = [
-                    self._normalize_skill_summary(
-                        skill,
-                        matched_path=str(
-                            by_identity.get(
-                                (
-                                    str(skill.get("skillSlug", "")).strip(),
-                                    str(skill.get("version", "")).strip(),
-                                ),
-                                {},
-                            ).get("path", "")
-                        ).strip()
-                        or None,
-                    )
-                    for skill in raw_skills[offset : offset + limit]
-                    if isinstance(skill, Mapping)
-                ]
+        normalized_skills = [
+            self._normalize_skill_summary(skill, matched_path=None)
+            for skill in raw_skills
+            if isinstance(skill, Mapping)
+        ]
         return {
             "query": query,
             "version": version,
@@ -335,12 +322,7 @@ class AFSWorkspaceSkillBackend:
     ) -> dict[str, Any]:
         raw_skills = await self._gateway_catalog_entries(version=version)
         if query:
-            matched_skills = self._filter_gateway_skills(raw_skills, query=query)
-            # The gateway only exposes catalog reads, not semantic search. When
-            # a free-form prompt does not keyword-match the catalog, fall back to
-            # discovery instead of claiming that no skills exist.
-            if matched_skills:
-                raw_skills = matched_skills
+            raw_skills = await self._semantic_rank_skills(raw_skills, query=query)
         paged = raw_skills[offset : offset + limit]
         normalized_skills = [
             self._normalize_skill_summary(skill, matched_path=None) for skill in paged
@@ -354,6 +336,91 @@ class AFSWorkspaceSkillBackend:
             "total_fetched": len(raw_skills),
             "skills": normalized_skills,
         }
+
+    async def _fetch_api_skill_catalog(
+        self,
+        *,
+        version: str | None,
+        minimum_count: int,
+    ) -> list[Mapping[str, Any]]:
+        initial_limit = min(max(minimum_count, 100), _SEMANTIC_SKILL_FETCH_LIMIT)
+        payload = await self._request_json(
+            "GET",
+            self._base_path(),
+            params={
+                "version": version,
+                "limit": initial_limit,
+                "offset": 0,
+            },
+        )
+        data = self._data_payload(payload)
+        raw_skills = data.get("skills", [])
+        if not isinstance(raw_skills, list):
+            raw_skills = []
+
+        total = int(data.get("total", len(raw_skills)))
+        if total > len(raw_skills) and len(raw_skills) < _SEMANTIC_SKILL_FETCH_LIMIT:
+            expanded_limit = min(total, _SEMANTIC_SKILL_FETCH_LIMIT)
+            payload = await self._request_json(
+                "GET",
+                self._base_path(),
+                params={
+                    "version": version,
+                    "limit": expanded_limit,
+                    "offset": 0,
+                },
+            )
+            data = self._data_payload(payload)
+            raw_skills = data.get("skills", [])
+            if not isinstance(raw_skills, list):
+                raw_skills = []
+
+        return [skill for skill in raw_skills if isinstance(skill, Mapping)]
+
+    async def _semantic_rank_skills(
+        self,
+        skills: list[Mapping[str, Any]],
+        *,
+        query: str,
+    ) -> list[Mapping[str, Any]]:
+        query_text = query.strip()
+        if not query_text:
+            return list(skills)
+
+        fallback_matches = self._filter_gateway_skills(skills, query=query)
+        if not skills:
+            return []
+
+        try:
+            from redis_sre_agent.core.redis import get_vectorizer
+
+            vectorizer = get_vectorizer()
+            ranking_texts = [self._skill_ranking_text(skill) for skill in skills]
+            embeddings = await vectorizer.aembed_many([query_text, *ranking_texts])
+        except Exception:
+            return fallback_matches or list(skills)
+
+        if len(embeddings) != len(skills) + 1:
+            return fallback_matches or list(skills)
+
+        query_embedding = embeddings[0]
+        scored: list[tuple[float, str, str, Mapping[str, Any]]] = []
+        for skill, embedding in zip(skills, embeddings[1:]):
+            semantic_score = self._cosine_similarity(query_embedding, embedding)
+            lexical_score = self._lexical_overlap_score(skill, query_text)
+            combined_score = semantic_score + (0.05 * lexical_score)
+            scored.append(
+                (
+                    -combined_score,
+                    str(skill.get("displayName", skill.get("skillSlug", ""))).strip().lower(),
+                    str(skill.get("version", "")).strip().lower(),
+                    skill,
+                )
+            )
+
+        scored.sort(key=lambda item: item[:3])
+        ranked = [item[3] for item in scored]
+        return ranked or fallback_matches or list(skills)
 
     def _filter_gateway_skills(
         self,
@@ -385,6 +452,57 @@ class AFSWorkspaceSkillBackend:
             if any(token in haystack for token in query_tokens):
                 token_matches.append(skill)
         return token_matches
+
+    def _skill_ranking_text(self, skill: Mapping[str, Any]) -> str:
+        tags = skill.get("tags", [])
+        tag_values = (
+            [str(tag).strip() for tag in tags if str(tag).strip()] if isinstance(tags, list) else []
+        )
+        return "\n".join(
+            part
+            for part in (
+                str(skill.get("displayName", "")).strip(),
+                str(skill.get("skillSlug", "")).strip(),
+                str(skill.get("description", "")).strip(),
+                " ".join(tag_values),
+            )
+            if part
+        )
+
+    def _lexical_overlap_score(self, skill: Mapping[str, Any], query: str) -> float:
+        haystack = self._skill_ranking_text(skill).lower()
+        query_text = query.strip().lower()
+        if not query_text or not haystack:
+            return 0.0
+        if query_text in haystack:
+            return 1.0
+
+        query_tokens = [
+            token
+            for token in _GATEWAY_QUERY_TOKEN_RE.findall(query_text)
+            if len(token) >= 3 and token not in _GATEWAY_QUERY_STOPWORDS
+        ]
+        if not query_tokens:
+            return 0.0
+
+        matched_tokens = sum(1 for token in query_tokens if token in haystack)
+        return matched_tokens / len(query_tokens)
+
+    def _cosine_similarity(self, left: Any, right: Any) -> float:
+        try:
+            left_values = [float(value) for value in left]
+            right_values = [float(value) for value in right]
+        except Exception:
+            return 0.0
+        if not left_values or len(left_values) != len(right_values):
+            return 0.0
+
+        numerator = sum(a * b for a, b in zip(left_values, right_values))
+        left_norm = math.sqrt(sum(a * a for a in left_values))
+        right_norm = math.sqrt(sum(b * b for b in right_values))
+        if left_norm == 0.0 or right_norm == 0.0:
+            return 0.0
+        return numerator / (left_norm * right_norm)
 
     async def _get_skill_via_api(self, *, skill_name: str, version: str | None) -> dict[str, Any]:
         try:

--- a/tests/unit/agent/test_agent.py
+++ b/tests/unit/agent/test_agent.py
@@ -240,7 +240,6 @@ class TestSRELangGraphAgent:
         call_kwargs = mock_build_startup_context.await_args.kwargs
         assert call_kwargs["version"] == "latest"
         assert call_kwargs["available_tools"] == []
-        assert "memory question" in call_kwargs["query"]
 
     @pytest.mark.asyncio
     async def test_process_query_ends_run_cache_when_memory_setup_is_cancelled(
@@ -2665,7 +2664,6 @@ class TestSRELangGraphAgent:
         assert "FRESH_CONTEXT" in sent_messages[0].content
         assert "STALE_CONTEXT" not in sent_messages[0].content
         mock_build_startup_context.assert_awaited_once_with(
-            query="new question",
             version="latest",
             available_tools=[],
         )

--- a/tests/unit/agent/test_chat_agent.py
+++ b/tests/unit/agent/test_chat_agent.py
@@ -709,7 +709,7 @@ class TestChatAgentStartupContext:
 
         mock_startup_context.assert_awaited_once()
         startup_kwargs = mock_startup_context.await_args.kwargs
-        assert startup_kwargs["query"] == "Who runs AOP?"
+        assert startup_kwargs["version"] == "latest"
         assert startup_kwargs["available_tools"] == [mock_tool]
 
     @pytest.mark.asyncio
@@ -2046,7 +2046,6 @@ class TestChatAgentStartupContext:
         assert isinstance(sent_messages[0], SystemMessage)
         assert "STARTUP_CONTEXT" in sent_messages[0].content
         mock_build_startup_context.assert_awaited_once_with(
-            query="follow-up question",
             version="latest",
             available_tools=[],
         )

--- a/tests/unit/agent/test_knowledge_agent.py
+++ b/tests/unit/agent/test_knowledge_agent.py
@@ -131,7 +131,6 @@ class TestKnowledgeAgent:
         assert "STARTUP_CONTEXT" in (initial_state["startup_system_prompt"] or "")
         assert initial_state["tool_call_budget_override"] == 7
         mock_build_startup_context.assert_awaited_once_with(
-            query="who runs AOP?",
             version="latest",
             available_tools=[],
         )
@@ -594,7 +593,6 @@ class TestKnowledgeAgentMethods:
         assert isinstance(sent_messages[0], SystemMessage)
         assert "STARTUP_CONTEXT" in sent_messages[0].content
         mock_build_startup_context.assert_awaited_once_with(
-            query="follow-up question",
             version="latest",
             available_tools=[],
         )
@@ -790,7 +788,6 @@ class TestKnowledgeAgentMethods:
         assert "FRESH_CONTEXT" in sent_messages[0].content
         assert "STALE_CONTEXT" not in sent_messages[0].content
         mock_build_startup_context.assert_awaited_once_with(
-            query="new question",
             version="latest",
             available_tools=[],
         )

--- a/tests/unit/agent/test_knowledge_context.py
+++ b/tests/unit/agent/test_knowledge_context.py
@@ -54,7 +54,7 @@ async def test_startup_context_memorizes_pinned_skills_and_tickets():
             ),
         ),
     ):
-        context = await build_startup_knowledge_context(query="memory issue", version="latest")
+        context = await build_startup_knowledge_context(version="latest")
 
     assert "Pinned documents:" in context
     assert "Pinned Skill" in context
@@ -82,7 +82,7 @@ async def test_startup_context_is_empty_without_pinned_docs_or_skills():
             new=AsyncMock(return_value={"skills": []}),
         ),
     ):
-        context = await build_startup_knowledge_context(query="memory issue", version="latest")
+        context = await build_startup_knowledge_context(version="latest")
 
     assert context == ""
 
@@ -100,7 +100,6 @@ async def test_startup_context_includes_tool_instructions_without_pinned_or_skil
         ),
     ):
         context = await build_startup_knowledge_context(
-            query="memory issue",
             version="latest",
             available_tools=[
                 ToolDefinition(
@@ -152,7 +151,6 @@ async def test_startup_context_extracts_capability_from_tool_definition():
             invoke=AsyncMock(return_value={}),
         )
         context = await build_startup_knowledge_context(
-            query="memory issue",
             version="latest",
             available_tools=[wrapped_tool],
         )
@@ -179,7 +177,6 @@ async def test_startup_context_extracts_capability_from_tool_metadata_only():
         )
         ignored_tool = SimpleNamespace(metadata=SimpleNamespace(), definition=None, capability=None)
         context = await build_startup_knowledge_context(
-            query="memory issue",
             version="latest",
             available_tools=[metadata_only_tool, ignored_tool],
         )
@@ -250,7 +247,7 @@ async def test_startup_context_carries_internal_pinned_context_envelope():
             new=AsyncMock(return_value={"skills": []}),
         ),
     ):
-        context = await build_startup_knowledge_context(query="memory issue", version="latest")
+        context = await build_startup_knowledge_context(version="latest")
 
     envelopes = getattr(context, "internal_tool_envelopes", [])
     assert len(envelopes) == 1
@@ -291,7 +288,7 @@ async def test_startup_context_carries_internal_skill_discovery_envelope():
             ),
         ),
     ):
-        context = await build_startup_knowledge_context(query="memory issue", version="latest")
+        context = await build_startup_knowledge_context(version="latest")
 
     envelopes = getattr(context, "internal_tool_envelopes", [])
     assert len(envelopes) == 1
@@ -328,7 +325,7 @@ async def test_startup_context_continues_when_pinned_document_load_fails():
             ),
         ),
     ):
-        context = await build_startup_knowledge_context(query="memory issue", version="latest")
+        context = await build_startup_knowledge_context(version="latest")
 
     assert "Pinned documents:" not in context
     assert "Iterative Memory Check: Use INFO memory first." in context
@@ -357,7 +354,7 @@ async def test_startup_context_continues_when_skills_check_fails():
             new=AsyncMock(side_effect=RuntimeError("skills index unavailable")),
         ),
     ):
-        context = await build_startup_knowledge_context(query="memory issue", version="latest")
+        context = await build_startup_knowledge_context(version="latest")
 
     assert "Pinned Runbook" in context
     assert "Skills you know:" not in context
@@ -402,7 +399,7 @@ async def test_startup_context_uses_eval_scoped_knowledge_backend():
             new=AsyncMock(side_effect=AssertionError("global skills helper should not run")),
         ),
     ):
-        context = await build_startup_knowledge_context(query="memory issue", version="latest")
+        context = await build_startup_knowledge_context(version="latest")
 
     assert "Scoped Pinned Doc" in context
     assert "Pinned eval content" in context
@@ -434,7 +431,7 @@ async def test_startup_context_keeps_skill_listing_compact():
             ),
         ),
     ):
-        context = await build_startup_knowledge_context(query="maintenance", version="latest")
+        context = await build_startup_knowledge_context(version="latest")
 
     assert "Redis Maintenance Triage: Investigate maintenance mode before failover." in context
     assert "references/maintenance-checklist.md" not in context
@@ -464,9 +461,7 @@ async def test_startup_context_uses_unfiltered_skills_toc_limit_from_settings():
         ),
         patch.object(knowledge_context_module.settings, "startup_skills_toc_limit", 7),
     ):
-        context = await build_startup_knowledge_context(
-            query="run a health check", version="latest"
-        )
+        context = await build_startup_knowledge_context(version="latest")
 
     assert "Redis Maintenance Triage: Investigate maintenance mode before failover." in context
     skills_check.assert_awaited_once_with(query=None, limit=7, offset=0, version="latest")

--- a/tests/unit/agent/test_knowledge_context.py
+++ b/tests/unit/agent/test_knowledge_context.py
@@ -13,6 +13,7 @@ from redis_sre_agent.agent.knowledge_context import (
     merge_internal_tool_envelopes,
 )
 from redis_sre_agent.evaluation.injection import eval_runtime_overrides
+from redis_sre_agent.skills import backend as skill_backend_module
 from redis_sre_agent.tools.models import Tool, ToolCapability, ToolDefinition, ToolMetadata
 
 
@@ -128,6 +129,56 @@ async def test_startup_context_reports_actual_skill_count_when_backend_returns_f
         context = await build_startup_knowledge_context(version="latest", skills_limit=50)
 
     assert "1 skill shown, 99 more available" in context
+
+
+@pytest.mark.asyncio
+async def test_startup_context_uses_default_redis_skill_backend_for_inventory():
+    fake_settings = SimpleNamespace(
+        skill_backend_kind="redis",
+        skill_backend_class="",
+        skill_reference_char_budget=12000,
+    )
+    skills_index = AsyncMock()
+    skills_index.query = AsyncMock(
+        return_value=[
+            {
+                "id": "skill-0",
+                "document_hash": "hash-skill",
+                "chunk_index": 0,
+                "name": "Redis Cluster Health Check",
+                "title": "Redis Cluster Health Check",
+                "summary": "Run a fast health check for the cluster.",
+                "content": "Checklist content",
+                "source": "docs/latest/skill",
+                "doc_type": "skill",
+                "version": "latest",
+                "resource_kind": "entrypoint",
+                "resource_path": "SKILL.md",
+            }
+        ]
+    )
+    original_cache = skill_backend_module._DEFAULT_BACKEND_CACHE
+    skill_backend_module._DEFAULT_BACKEND_CACHE = None
+    try:
+        with (
+            patch(
+                "redis_sre_agent.agent.knowledge_context.get_pinned_documents_helper",
+                new=AsyncMock(return_value={"pinned_documents": []}),
+            ),
+            patch.object(skill_backend_module, "settings", fake_settings),
+            patch(
+                "redis_sre_agent.core.knowledge_helpers.get_skills_index",
+                new=AsyncMock(return_value=skills_index),
+            ) as get_skills_index,
+        ):
+            context = await build_startup_knowledge_context(version="latest", skills_limit=5)
+
+        assert "Skills you know:" in context
+        assert "Redis Cluster Health Check: Run a fast health check for the cluster." in context
+        get_skills_index.assert_awaited_once_with(config=fake_settings)
+        skills_index.query.assert_awaited_once()
+    finally:
+        skill_backend_module._DEFAULT_BACKEND_CACHE = original_cache
 
 
 @pytest.mark.asyncio

--- a/tests/unit/agent/test_knowledge_context.py
+++ b/tests/unit/agent/test_knowledge_context.py
@@ -104,6 +104,33 @@ async def test_startup_context_mentions_truncated_skill_inventory():
 
 
 @pytest.mark.asyncio
+async def test_startup_context_reports_actual_skill_count_when_backend_returns_fewer_rows():
+    with (
+        patch(
+            "redis_sre_agent.agent.knowledge_context.get_pinned_documents_helper",
+            new=AsyncMock(return_value={"pinned_documents": []}),
+        ),
+        patch(
+            "redis_sre_agent.agent.knowledge_context.skills_check_helper",
+            new=AsyncMock(
+                return_value={
+                    "skills": [
+                        {
+                            "name": "Redis Cluster Health Check",
+                            "summary": "Run a fast health check for the cluster.",
+                        }
+                    ],
+                    "total_fetched": 100,
+                }
+            ),
+        ),
+    ):
+        context = await build_startup_knowledge_context(version="latest", skills_limit=50)
+
+    assert "1 skill shown, 99 more available" in context
+
+
+@pytest.mark.asyncio
 async def test_startup_context_is_empty_without_pinned_docs_or_skills():
     with (
         patch(

--- a/tests/unit/agent/test_knowledge_context.py
+++ b/tests/unit/agent/test_knowledge_context.py
@@ -71,6 +71,39 @@ async def test_startup_context_memorizes_pinned_skills_and_tickets():
 
 
 @pytest.mark.asyncio
+async def test_startup_context_mentions_truncated_skill_inventory():
+    with (
+        patch(
+            "redis_sre_agent.agent.knowledge_context.get_pinned_documents_helper",
+            new=AsyncMock(return_value={"pinned_documents": []}),
+        ),
+        patch(
+            "redis_sre_agent.agent.knowledge_context.skills_check_helper",
+            new=AsyncMock(
+                return_value={
+                    "skills": [
+                        {
+                            "name": "Redis Cluster Health Check",
+                            "summary": "Run a fast health check for the cluster.",
+                        },
+                        {
+                            "name": "Redis Memory Triage",
+                            "summary": "Inspect memory pressure and fragmentation.",
+                        },
+                    ],
+                    "total_fetched": 53,
+                }
+            ),
+        ),
+    ):
+        context = await build_startup_knowledge_context(version="latest", skills_limit=2)
+
+    assert "startup inventory is truncated" in context
+    assert "2 skills shown, 51 more available" in context
+    assert "search for related skills" in context
+
+
+@pytest.mark.asyncio
 async def test_startup_context_is_empty_without_pinned_docs_or_skills():
     with (
         patch(
@@ -297,7 +330,7 @@ async def test_startup_context_carries_internal_skill_discovery_envelope():
     assert envelope["name"] == "skills_check"
     assert envelope["args"] == {
         "query": "",
-        "limit": 25,
+        "limit": 50,
         "offset": 0,
         "version": "latest",
     }
@@ -378,7 +411,7 @@ async def test_startup_context_uses_eval_scoped_knowledge_backend():
 
         async def skills_check(self, **kwargs):
             assert kwargs["query"] is None
-            assert kwargs["limit"] == 25
+            assert kwargs["limit"] == 50
             return {
                 "skills": [
                     {

--- a/tests/unit/agent/test_knowledge_context.py
+++ b/tests/unit/agent/test_knowledge_context.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from redis_sre_agent.agent import knowledge_context as knowledge_context_module
 from redis_sre_agent.agent.knowledge_context import (
     _build_internal_pinned_context_envelope,
     _build_internal_startup_skills_envelope,
@@ -298,8 +299,8 @@ async def test_startup_context_carries_internal_skill_discovery_envelope():
     assert envelope["tool_key"] == "knowledge.startup_skills_check"
     assert envelope["name"] == "skills_check"
     assert envelope["args"] == {
-        "query": "memory issue",
-        "limit": 20,
+        "query": "",
+        "limit": 25,
         "offset": 0,
         "version": "latest",
     }
@@ -379,7 +380,8 @@ async def test_startup_context_uses_eval_scoped_knowledge_backend():
             }
 
         async def skills_check(self, **kwargs):
-            assert kwargs["query"] == "memory issue"
+            assert kwargs["query"] is None
+            assert kwargs["limit"] == 25
             return {
                 "skills": [
                     {
@@ -437,3 +439,34 @@ async def test_startup_context_keeps_skill_listing_compact():
     assert "Redis Maintenance Triage: Investigate maintenance mode before failover." in context
     assert "references/maintenance-checklist.md" not in context
     assert "Scripts:" not in context
+
+
+@pytest.mark.asyncio
+async def test_startup_context_uses_unfiltered_skills_toc_limit_from_settings():
+    skills_check = AsyncMock(
+        return_value={
+            "skills": [
+                {
+                    "name": "Redis Maintenance Triage",
+                    "description": "Investigate maintenance mode before failover.",
+                }
+            ]
+        }
+    )
+    with (
+        patch(
+            "redis_sre_agent.agent.knowledge_context.get_pinned_documents_helper",
+            new=AsyncMock(return_value={"pinned_documents": []}),
+        ),
+        patch(
+            "redis_sre_agent.agent.knowledge_context.skills_check_helper",
+            new=skills_check,
+        ),
+        patch.object(knowledge_context_module.settings, "startup_skills_toc_limit", 7),
+    ):
+        context = await build_startup_knowledge_context(
+            query="run a health check", version="latest"
+        )
+
+    assert "Redis Maintenance Triage: Investigate maintenance mode before failover." in context
+    skills_check.assert_awaited_once_with(query=None, limit=7, offset=0, version="latest")

--- a/tests/unit/evaluation/test_injection.py
+++ b/tests/unit/evaluation/test_injection.py
@@ -165,7 +165,6 @@ async def test_knowledge_helpers_dispatch_to_eval_backend():
 async def test_startup_context_uses_eval_knowledge_backend():
     with eval_injection_scope(knowledge_backend=_FakeKnowledgeBackend()):
         context = await build_startup_knowledge_context(
-            query="investigate maintenance mode",
             available_tools=[],
         )
 

--- a/tests/unit/evaluation/test_knowledge_scenarios.py
+++ b/tests/unit/evaluation/test_knowledge_scenarios.py
@@ -122,7 +122,6 @@ async def test_startup_only_scenario_materializes_pinned_doc_and_skill_context()
     backend = build_fixture_knowledge_backend(scenario)
 
     startup_context = await build_startup_knowledge_context(
-        query=scenario.execution.query,
         version=scenario.knowledge.version,
         available_tools=[],
         knowledge_backend=backend,

--- a/tests/unit/evaluation/test_prompt_scenarios.py
+++ b/tests/unit/evaluation/test_prompt_scenarios.py
@@ -219,7 +219,6 @@ async def test_knowledge_agent_prompt_scenario_materializes_startup_context():
     backend = build_fixture_knowledge_backend(scenario)
 
     startup_context = await build_startup_knowledge_context(
-        query=scenario.execution.query,
         version=scenario.knowledge.version,
         available_tools=[],
         knowledge_backend=backend,

--- a/tests/unit/evaluation/test_runtime.py
+++ b/tests/unit/evaluation/test_runtime.py
@@ -1659,7 +1659,6 @@ async def test_run_full_turn_scenario_installs_fixture_knowledge_backend_for_tur
         )
 
         startup_context = await build_startup_knowledge_context(
-            query=kwargs["message"],
             version="latest",
             available_tools=[],
         )

--- a/tests/unit/evaluation/test_scenario_corpus.py
+++ b/tests/unit/evaluation/test_scenario_corpus.py
@@ -82,7 +82,6 @@ async def test_startup_only_knowledge_scenario_materializes_pinned_doc_and_skill
     backend = build_fixture_knowledge_backend(scenario)
 
     startup_context = await build_startup_knowledge_context(
-        query=scenario.execution.query,
         version=scenario.knowledge.version,
         available_tools=[],
         knowledge_backend=backend,

--- a/tests/unit/skills/test_afs_workspace_backend.py
+++ b/tests/unit/skills/test_afs_workspace_backend.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from types import SimpleNamespace
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 import httpx
 import pytest
@@ -133,15 +133,16 @@ async def test_afs_workspace_skill_backend_query_and_error_paths() -> None:
                             "description": "Check maintenance mode first.",
                             "version": "v1",
                             "resources": [],
-                        }
-                    ],
-                    "matches": [
+                        },
                         {
-                            "skillSlug": "redis-maintenance-triage",
+                            "skillSlug": "redis-cluster-health-check",
+                            "displayName": "Redis Cluster Health Check",
+                            "description": "Produce Analyzer-backed cluster findings.",
                             "version": "v1",
-                            "path": "/skills/redis-maintenance-triage/versions/v1/references/checklist.md",
-                        }
+                            "resources": [],
+                        },
                     ],
+                    "total": 2,
                 }
             }
         ),
@@ -158,8 +159,24 @@ async def test_afs_workspace_skill_backend_query_and_error_paths() -> None:
         client_factory=lambda **kwargs: client,  # type: ignore[arg-type]
     )
 
-    queried = await backend.list_skills(query="checklist", limit=10, offset=0, version="v1")
-    assert queried["skills"][0]["matched_resource_kind"] == "reference"
+    vectorizer = AsyncMock()
+    vectorizer.aembed_many = AsyncMock(
+        return_value=[
+            [1.0, 0.0],
+            [0.1, 0.9],
+            [0.9, 0.1],
+        ]
+    )
+    with patch("redis_sre_agent.core.redis.get_vectorizer", return_value=vectorizer):
+        queried = await backend.list_skills(
+            query="run a health check",
+            limit=10,
+            offset=0,
+            version="v1",
+        )
+
+    assert queried["skills"][0]["name"] == "redis-cluster-health-check"
+    assert queried["skills"][0]["matched_resource_kind"] == "entrypoint"
 
     missing_skill = await backend.get_skill(skill_name="missing", version="v1")
     assert missing_skill["error"] == "Skill not found"
@@ -297,6 +314,55 @@ async def test_afs_workspace_skill_backend_list_uses_gateway_when_configured() -
 
     assert result["results_count"] == 1
     assert result["skills"][0]["name"] == "redis-maintenance-triage"
+
+
+@pytest.mark.asyncio
+async def test_afs_workspace_skill_backend_gateway_query_uses_semantic_ranking() -> None:
+    backend = AFSWorkspaceSkillBackend(
+        base_url="https://skills.internal",
+        tenant_id="tenant_a",
+        project_id="proj_1",
+        agent_id="agent_1",
+        gateway_url="https://gateway.internal/mcp",
+        gateway_token="secret",
+        workspace_id="skills-proj-1-agent-1",
+    )
+    backend._gateway_catalog_entries = AsyncMock(  # type: ignore[method-assign]
+        return_value=[
+            {
+                "skillSlug": "redis-maintenance-triage",
+                "displayName": "Redis Maintenance Triage",
+                "description": "Check maintenance mode first.",
+                "version": "v1",
+                "resources": [],
+            },
+            {
+                "skillSlug": "redis-cluster-health-check",
+                "displayName": "Redis Cluster Health Check",
+                "description": "Produce Analyzer-backed cluster findings.",
+                "version": "v1",
+                "resources": [],
+            },
+        ]
+    )
+    vectorizer = AsyncMock()
+    vectorizer.aembed_many = AsyncMock(
+        return_value=[
+            [1.0, 0.0],
+            [0.1, 0.9],
+            [0.95, 0.05],
+        ]
+    )
+
+    with patch("redis_sre_agent.core.redis.get_vectorizer", return_value=vectorizer):
+        result = await backend.list_skills(
+            query="cluster health findings",
+            limit=10,
+            offset=0,
+            version="latest",
+        )
+
+    assert result["skills"][0]["name"] == "redis-cluster-health-check"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/skills/test_afs_workspace_backend.py
+++ b/tests/unit/skills/test_afs_workspace_backend.py
@@ -189,6 +189,34 @@ async def test_afs_workspace_skill_backend_query_and_error_paths() -> None:
     assert missing_resource["error"] == "Skill resource not found"
 
 
+@pytest.mark.asyncio
+async def test_afs_workspace_skill_backend_omits_none_version_from_api_params() -> None:
+    responses = [
+        _FakeResponse({"data": {"skills": [], "total": 0}}),
+        _FakeResponse({"data": {"skills": [], "total": 0}}),
+    ]
+    client = _FakeAsyncClient(responses=responses)
+    backend = AFSWorkspaceSkillBackend(
+        base_url="https://skills.internal",
+        tenant_id="tenant_a",
+        project_id="proj_1",
+        agent_id="agent_1",
+        client_factory=lambda **kwargs: client,  # type: ignore[arg-type]
+    )
+
+    listed = await backend.list_skills(query=None, limit=10, offset=0, version=None)
+    assert listed["skills"] == []
+    assert client.calls[0][2] == {"limit": 10, "offset": 0}
+
+    vectorizer = AsyncMock()
+    vectorizer.aembed_many = AsyncMock(return_value=[[1.0, 0.0]])
+    with patch("redis_sre_agent.core.redis.get_vectorizer", return_value=vectorizer):
+        queried = await backend.list_skills(query="health check", limit=10, offset=0, version=None)
+
+    assert queried["skills"] == []
+    assert client.calls[1][2] == {"limit": 100, "offset": 0}
+
+
 def test_afs_workspace_skill_backend_from_settings_uses_env_fallbacks(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary
- build the startup skills TOC from an unfiltered `skills_check` call instead of reusing the user query
- cap the startup skills TOC with `startup_skills_toc_limit`, now defaulting to `50`
- add truncation guidance so the startup context tells the model to search for related skills when more are available than shown
- rank queried skills semantically in the AFS workspace backend for both API and gateway-backed paths
- cover the startup call shape, truncation behavior, and semantic ranking behavior with unit tests

## Verification
- `./.venv/bin/ruff check redis_sre_agent/agent/knowledge_context.py redis_sre_agent/core/config.py redis_sre_agent/skills/afs_workspace_backend.py tests/unit/agent/test_knowledge_context.py tests/unit/skills/test_afs_workspace_backend.py`
- `./.venv/bin/pytest -q tests/unit/agent/test_knowledge_context.py tests/unit/skills/test_afs_workspace_backend.py`
- `./.venv/bin/pytest -q tests/unit/agent/test_knowledge_context.py tests/unit/evaluation/test_injection.py tests/unit/evaluation/test_prompt_scenarios.py`
- local prompt QA confirmed the startup context emits: `50 skills shown, 23 more available` and instructs the model to search for related skills when the catalog is truncated
- live QA on runtime deployment `dep_20260508_232733` / version `ver_20260508_232733`
  - startup trace showed `skills_check(query="", limit=50, offset=0, version="latest")`
  - `run a health check` retrieved and used `redis-cluster-health-check`
  - semantic queries like `health check skill` and `run a health check` ranked `redis-cluster-health-check` first

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how startup grounding context is constructed and how skills are searched/ranked, which can affect agent behavior and prompt content across chat/knowledge/langgraph flows. Adds semantic embedding-based ranking and larger catalog fetches in the skills backend, introducing performance and dependency risk around the vectorizer.
> 
> **Overview**
> Startup grounding no longer derives the skills TOC from the user query; `build_startup_knowledge_context` now builds an *inventory-style* skills list using `skills_query` (default `None`) and a new `settings.startup_skills_toc_limit` (default `50`), and adds explicit truncation guidance when more skills exist than are shown.
> 
> All agents (`chat_agent`, `knowledge_agent`, `langgraph_agent`) stop passing `query` into startup context building, and internal tool envelopes/tests are updated to match the new call shape and limits.
> 
> `AFSWorkspaceSkillBackend.list_skills` now semantically ranks queried skill results (API and gateway paths) using embeddings + a small lexical overlap term, fetching up to 500 catalog entries when needed; new unit tests cover truncation messaging, default limit behavior, semantic ranking, and API param handling (including omitting `version` when `None`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 092e8a9e4fc9893586df56ab82af3ecd542ad7ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

