### PR TITLE
Add configurable vectorizer factory

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -71,6 +71,11 @@ OPENAI_MODEL_NANO=gpt-5-nano
 # PII_REMEDIATION_CATEGORIES=["private_person","private_address","private_email","private_phone","private_url","private_date","account_number","secret"]
 # PII_REMEDIATION_FAIL_OPEN_FOR_REDACT=false
 
+# Custom vectorizer factory (optional)
+# Set to a dot-path import string to customize embedding/vectorizer creation
+# Example: VECTORIZER_FACTORY=mypackage.embeddings.custom_vectorizer_factory
+# VECTORIZER_FACTORY=
+
 # =============================================================================
 # Embeddings Configuration
 # =============================================================================

--- a/docs/how-to/configuration.md
+++ b/docs/how-to/configuration.md
@@ -371,6 +371,7 @@ The agent uses embeddings for the knowledge base vector search. You can configur
 | `embedding_model` | `EMBEDDING_MODEL` | `text-embedding-3-small` | Model name (provider-specific) |
 | `vector_dim` | `VECTOR_DIM` | `1536` | Vector dimensions (must match model) |
 | `embeddings_cache_ttl` | `EMBEDDINGS_CACHE_TTL` | `604800` (7 days) | Cache TTL in seconds |
+| `vectorizer_factory` | `VECTORIZER_FACTORY` | `None` | Dot-path to a custom vectorizer factory |
 
 #### OpenAI embeddings (default)
 
@@ -408,6 +409,33 @@ Available local models:
 
 !!! warning "Vector dimensions must match"
     The `VECTOR_DIM` setting must match the output dimensions of your chosen model. Mismatched dimensions will cause indexing and search failures.
+
+#### Custom vectorizer factories
+
+If you need to override vectorizer construction entirely, set `VECTORIZER_FACTORY` to a dot-path
+import string:
+
+```bash
+VECTORIZER_FACTORY=mypackage.embeddings.custom_vectorizer_factory
+```
+
+Or in a config file:
+
+```yaml
+vectorizer_factory: mypackage.embeddings.custom_vectorizer_factory
+```
+
+The factory receives:
+
+- `provider`: resolved embedding provider such as `openai` or `local`
+- `model`: embedding model name
+- `config`: effective `Settings` object
+- `cache`: prepared Redis-backed `EmbeddingsCache`
+
+It must return an object implementing the async methods used by the runtime:
+
+- `aembed()`
+- `aembed_many()`
 
 #### Switching providers
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -49,6 +49,7 @@ For configuration precedence, `.env` behavior, config-file discovery order, and 
 | `embedding_model` | `EMBEDDING_MODEL` | `str` | `text-embedding-3-small` | Embedding model name. |
 | `vector_dim` | `VECTOR_DIM` | `int` | `1536` | Must match embedding model output dimensions. |
 | `embeddings_cache_ttl` | `EMBEDDINGS_CACHE_TTL` | `int \| None` | `604800` | Embedding cache TTL in seconds; `None` means no expiration. |
+| `vectorizer_factory` | `VECTORIZER_FACTORY` | `str \| None` | `None` | Dot-path to custom vectorizer factory returning an object with `aembed()`/`aembed_many()`. |
 
 ### Task Queue
 
@@ -88,6 +89,7 @@ For configuration precedence, `.env` behavior, config-file discovery order, and 
 | `llm_timeout` | `LLM_TIMEOUT` | `float` | `180.0` | LLM HTTP timeout in seconds. |
 | `llm_factory` | `LLM_FACTORY` | `str \| None` | `None` | Dot-path to custom LangChain chat model factory. |
 | `async_openai_client_factory` | `ASYNC_OPENAI_CLIENT_FACTORY` | `str \| None` | `None` | Dot-path to custom AsyncOpenAI-compatible client factory. |
+| `vectorizer_factory` | `VECTORIZER_FACTORY` | `str \| None` | `None` | Dot-path to custom embeddings/vectorizer factory. |
 
 ### Monitoring
 

--- a/redis_sre_agent/agent/knowledge_agent.py
+++ b/redis_sre_agent/agent/knowledge_agent.py
@@ -11,8 +11,8 @@ knowledge-related tools (no instance-specific tools like Redis CLI or Prometheus
 import logging
 from typing import Any, Dict, List, NotRequired, Optional, TypedDict
 
+from langchain_core.language_models.chat_models import BaseChatModel
 from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, SystemMessage
-from langchain_openai import ChatOpenAI
 from langgraph.checkpoint.memory import MemorySaver
 from langgraph.graph import END, StateGraph
 from opentelemetry import trace
@@ -132,7 +132,7 @@ class KnowledgeOnlyAgent:
         logger.info("Knowledge-only agent initialized (tools loaded per-query)")
 
     def _build_workflow(
-        self, tool_mgr: ToolManager, llm_with_tools: ChatOpenAI, emitter: ProgressEmitter
+        self, tool_mgr: ToolManager, llm_with_tools: BaseChatModel, emitter: ProgressEmitter
     ) -> StateGraph:
         """Build the LangGraph workflow for knowledge-only queries.
 

--- a/redis_sre_agent/agent/langgraph_agent.py
+++ b/redis_sre_agent/agent/langgraph_agent.py
@@ -14,6 +14,7 @@ from typing import Any, Callable, Dict, List, NotRequired, Optional, TypedDict
 from urllib.parse import urlparse
 from uuid import uuid4
 
+from langchain_core.language_models.chat_models import BaseChatModel
 from langchain_core.messages import (
     AIMessage,
     BaseMessage,
@@ -21,7 +22,6 @@ from langchain_core.messages import (
     SystemMessage,
     ToolMessage,
 )
-from langchain_openai import ChatOpenAI
 from langgraph.errors import GraphInterrupt
 from langgraph.graph import END, StateGraph
 from langgraph.types import Command
@@ -367,7 +367,7 @@ def _mask_redis_url_credentials(url: str) -> str:
 
 async def _detect_instance_type_with_llm(
     instance: Any,
-    llm: Optional[ChatOpenAI] = None,
+    llm: Optional[BaseChatModel] = None,
     memoize: Optional[Callable[[str, Any, List[BaseMessage]], Any]] = None,
 ) -> str:
     """Use LLM to detect Redis instance type from metadata.

--- a/redis_sre_agent/agent/runbook_generator.py
+++ b/redis_sre_agent/agent/runbook_generator.py
@@ -9,22 +9,16 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import Any, Dict, List, Optional, TypedDict
 
-import openai
 from langchain_core.messages import BaseMessage, HumanMessage, SystemMessage
 from langgraph.graph import END, StateGraph
 from opentelemetry import trace
 
-from redis_sre_agent.core.config import settings
 from redis_sre_agent.core.docket_tasks import search_knowledge_base
 from redis_sre_agent.core.llm_helpers import create_llm
 from redis_sre_agent.core.llm_request_guard import guarded_ainvoke
 
 logger = logging.getLogger(__name__)
 tracer = trace.get_tracer(__name__)
-
-
-# Initialize OpenAI client
-openai.api_key = settings.openai_api_key
 
 
 @dataclass

--- a/redis_sre_agent/core/config.py
+++ b/redis_sre_agent/core/config.py
@@ -369,6 +369,16 @@ class Settings(BaseSettings):
         default=86400 * 7,  # 7 days
         description="TTL in seconds for cached embeddings. None means no expiration.",
     )
+    vectorizer_factory: Optional[str] = Field(
+        default=None,
+        description=(
+            "Dot-path to a custom vectorizer factory function. The function must accept "
+            "(provider: str, model: str | None, config: Settings, cache: EmbeddingsCache, "
+            "**kwargs) and return an object implementing aembed()/aembed_many(). "
+            "Example: 'mypackage.embeddings.custom_vectorizer_factory'. "
+            "If not set, uses the default OpenAI or HuggingFace RedisVL vectorizer factory."
+        ),
+    )
 
     # Docket Task Queue
     task_queue_name: str = Field(default="sre_agent_tasks", description="Task queue name")

--- a/redis_sre_agent/core/redis.py
+++ b/redis_sre_agent/core/redis.py
@@ -1,17 +1,18 @@
 """Redis connection management - no caching to avoid event loop issues."""
 
 import logging
-from typing import Any, Optional, Union
+from typing import Any, Optional
 
 from redis.asyncio import Redis
-from redisvl.extensions.cache.embeddings.embeddings import EmbeddingsCache
+from redisvl.extensions.cache.embeddings.embeddings import (
+    EmbeddingsCache as EmbeddingsCache,  # noqa: F401
+)
 from redisvl.index.index import AsyncSearchIndex
-from redisvl.utils.vectorize import HFTextVectorizer, OpenAITextVectorizer
+from redisvl.utils.vectorize import HFTextVectorizer as HFTextVectorizer  # noqa: F401
+from redisvl.utils.vectorize import OpenAITextVectorizer as OpenAITextVectorizer  # noqa: F401
 
 from redis_sre_agent.core.config import Settings, settings
-
-# Type alias for vectorizers
-Vectorizer = Union[OpenAITextVectorizer, HFTextVectorizer]
+from redis_sre_agent.core.vectorizer_helpers import Vectorizer, create_vectorizer
 
 logger = logging.getLogger(__name__)
 
@@ -491,8 +492,10 @@ def get_redis_client(
 def get_vectorizer(config: Optional[Settings] = None) -> Vectorizer:
     """Get vectorizer with Redis-backed embeddings cache.
 
-    Returns either an OpenAI or HuggingFace vectorizer based on settings.embedding_provider.
-    Callers should use aembed/aembed_many for async operations.
+    Returns the configured vectorizer. By default this is either an OpenAI or
+    HuggingFace RedisVL vectorizer based on settings.embedding_provider, but it
+    can be overridden with VECTORIZER_FACTORY. Callers should use aembed/aembed_many
+    for async operations.
 
     Args:
         config: Optional Settings object. If not provided, uses global settings.
@@ -503,47 +506,10 @@ def get_vectorizer(config: Optional[Settings] = None) -> Vectorizer:
         - 'openai': Uses OpenAI API (requires OPENAI_API_KEY and network access)
         - 'local': Uses HuggingFace sentence-transformers (no API needed, air-gap compatible)
 
-    The embeddings cache uses a stable key namespace ("sre_embeddings_cache")
-    so that embeddings are shared across vectorizer instances. Cache keys
-    include the model name, so different models won't conflict.
-
-    TTL is configurable via settings.embeddings_cache_ttl (default: 7 days).
+    The default implementation uses a stable Redis-backed embeddings cache with
+    TTL configured by settings.embeddings_cache_ttl.
     """
-    cfg = config or settings
-    redis_url = cfg.redis_url.get_secret_value()
-
-    # Name the cache to keep a stable key namespace
-    # TTL prevents stale embeddings if model changes
-    cache = EmbeddingsCache(
-        name="sre_embeddings_cache",
-        redis_url=redis_url,
-        ttl=cfg.embeddings_cache_ttl,
-    )
-
-    provider = cfg.embedding_provider.lower()
-
-    if provider == "local":
-        # Use HuggingFace sentence-transformers (air-gap compatible)
-        logger.info(f"Using local HuggingFace vectorizer with model: {cfg.embedding_model}")
-        return HFTextVectorizer(
-            model=cfg.embedding_model,
-            cache=cache,
-        )
-    elif provider == "openai":
-        # Use OpenAI API (default)
-        logger.debug(f"Vectorizer created with embeddings cache (ttl={cfg.embeddings_cache_ttl}s)")
-        return OpenAITextVectorizer(
-            model=cfg.embedding_model,
-            cache=cache,
-            api_config={
-                "api_key": cfg.openai_api_key,
-                **({"base_url": cfg.openai_base_url} if cfg.openai_base_url else {}),
-            },
-        )
-    else:
-        raise ValueError(
-            f"Unknown embedding_provider: '{provider}'. Supported values: 'openai', 'local'"
-        )
+    return create_vectorizer(config=config)
 
 
 async def get_knowledge_index(config: Optional[Settings] = None) -> AsyncSearchIndex:

--- a/redis_sre_agent/core/vectorizer_helpers.py
+++ b/redis_sre_agent/core/vectorizer_helpers.py
@@ -5,7 +5,6 @@ import logging
 from typing import Any, Optional, Protocol
 
 from redisvl.extensions.cache.embeddings.embeddings import EmbeddingsCache
-from redisvl.utils.vectorize import HFTextVectorizer, OpenAITextVectorizer
 
 from redis_sre_agent.core.config import Settings, settings
 
@@ -78,8 +77,10 @@ def _load_factory_from_config() -> Optional[VectorizerFactory]:
 
 def set_vectorizer_factory(factory: Optional[VectorizerFactory]) -> None:
     """Register a custom vectorizer factory function."""
-    global _vectorizer_factory
+    global _vectorizer_factory, _settings_vectorizer_factory, _factory_initialized
     _vectorizer_factory = factory
+    _settings_vectorizer_factory = None
+    _factory_initialized = True
 
 
 def get_vectorizer_factory() -> Optional[VectorizerFactory]:
@@ -107,12 +108,17 @@ def _default_vectorizer_factory(
     **kwargs,
 ) -> Any:
     """Default vectorizer factory using RedisVL's built-in vectorizers."""
+    # Import through core.redis at runtime so existing test patches against
+    # redis_sre_agent.core.redis.{OpenAITextVectorizer,HFTextVectorizer}
+    # continue to intercept construction after the helper refactor.
+    from redis_sre_agent.core import redis as redis_core
+
     resolved_provider = provider.lower()
     resolved_model = model or config.embedding_model
 
     if resolved_provider == "local":
         logger.info("Using local HuggingFace vectorizer with model: %s", resolved_model)
-        return HFTextVectorizer(
+        return redis_core.HFTextVectorizer(
             model=resolved_model,
             cache=cache,
             **kwargs,
@@ -123,7 +129,7 @@ def _default_vectorizer_factory(
             "Vectorizer created with embeddings cache (ttl=%ss)",
             config.embeddings_cache_ttl,
         )
-        return OpenAITextVectorizer(
+        return redis_core.OpenAITextVectorizer(
             model=resolved_model,
             cache=cache,
             api_config={

--- a/redis_sre_agent/core/vectorizer_helpers.py
+++ b/redis_sre_agent/core/vectorizer_helpers.py
@@ -1,0 +1,186 @@
+"""Helper functions for creating vectorizers with consistent configuration."""
+
+import importlib
+import logging
+from typing import Any, Optional, Protocol
+
+from redisvl.extensions.cache.embeddings.embeddings import EmbeddingsCache
+from redisvl.utils.vectorize import HFTextVectorizer, OpenAITextVectorizer
+
+from redis_sre_agent.core.config import Settings, settings
+
+logger = logging.getLogger(__name__)
+
+
+class VectorizerFactory(Protocol):
+    """Protocol for custom vectorizer factory functions."""
+
+    def __call__(
+        self,
+        *,
+        provider: str,
+        model: Optional[str] = None,
+        config: Settings,
+        cache: EmbeddingsCache,
+        **kwargs,
+    ) -> Any: ...
+
+
+class Vectorizer(Protocol):
+    """Minimal runtime contract for vectorizers used by this repo."""
+
+    async def aembed(self, *args, **kwargs) -> Any: ...
+
+    async def aembed_many(self, *args, **kwargs) -> Any: ...
+
+
+_vectorizer_factory: Optional[VectorizerFactory] = None
+_factory_initialized: bool = False
+
+
+def _resolve_factory_from_path(factory_path: str) -> VectorizerFactory:
+    """Resolve a vectorizer factory from a dot-path import string."""
+    module_path, _, func_name = factory_path.rpartition(".")
+    if not module_path:
+        raise ValueError(
+            f"Invalid VECTORIZER_FACTORY path '{factory_path}': "
+            "must be a dot-path like 'mypackage.module.factory_func'"
+        )
+
+    module = importlib.import_module(module_path)
+    factory = getattr(module, func_name)
+    if not callable(factory):
+        raise ValueError(f"VECTORIZER_FACTORY '{factory_path}' is not callable")
+    return factory
+
+
+def _load_factory_from_config() -> None:
+    """Load the vectorizer factory from global settings if specified."""
+    global _vectorizer_factory, _factory_initialized
+
+    if _factory_initialized:
+        return
+
+    _factory_initialized = True
+    factory_path = getattr(settings, "vectorizer_factory", None)
+    if not factory_path or not isinstance(factory_path, str):
+        return
+
+    try:
+        _vectorizer_factory = _resolve_factory_from_path(factory_path)
+        logger.info("Loaded custom vectorizer factory from %s", factory_path)
+    except Exception:
+        logger.exception("Failed to load vectorizer factory from '%s'", factory_path)
+        raise
+
+
+def set_vectorizer_factory(factory: Optional[VectorizerFactory]) -> None:
+    """Register a custom vectorizer factory function."""
+    global _vectorizer_factory, _factory_initialized
+    _vectorizer_factory = factory
+    _factory_initialized = True
+
+
+def get_vectorizer_factory() -> Optional[VectorizerFactory]:
+    """Get the currently registered global vectorizer factory, if any."""
+    return _vectorizer_factory
+
+
+def _build_embeddings_cache(config: Settings) -> EmbeddingsCache:
+    """Build the shared Redis-backed embeddings cache for a vectorizer instance."""
+    return EmbeddingsCache(
+        name="sre_embeddings_cache",
+        redis_url=config.redis_url.get_secret_value(),
+        ttl=config.embeddings_cache_ttl,
+    )
+
+
+def _default_vectorizer_factory(
+    *,
+    provider: str,
+    model: Optional[str] = None,
+    config: Settings,
+    cache: EmbeddingsCache,
+    **kwargs,
+) -> Any:
+    """Default vectorizer factory using RedisVL's built-in vectorizers."""
+    resolved_provider = provider.lower()
+    resolved_model = model or config.embedding_model
+
+    if resolved_provider == "local":
+        logger.info("Using local HuggingFace vectorizer with model: %s", resolved_model)
+        return HFTextVectorizer(
+            model=resolved_model,
+            cache=cache,
+            **kwargs,
+        )
+
+    if resolved_provider == "openai":
+        logger.debug(
+            "Vectorizer created with embeddings cache (ttl=%ss)",
+            config.embeddings_cache_ttl,
+        )
+        return OpenAITextVectorizer(
+            model=resolved_model,
+            cache=cache,
+            api_config={
+                "api_key": config.openai_api_key,
+                **({"base_url": config.openai_base_url} if config.openai_base_url else {}),
+            },
+            **kwargs,
+        )
+
+    raise ValueError(
+        f"Unknown embedding_provider: '{resolved_provider}'. Supported values: 'openai', 'local'"
+    )
+
+
+def _resolve_factory(config: Settings, *, explicit_config: bool) -> Optional[VectorizerFactory]:
+    """Resolve the active factory, respecting explicit per-call config overrides."""
+    if _vectorizer_factory is not None:
+        return _vectorizer_factory
+
+    if explicit_config:
+        factory_path = getattr(config, "vectorizer_factory", None)
+        if factory_path and isinstance(factory_path, str):
+            return _resolve_factory_from_path(factory_path)
+        return None
+
+    _load_factory_from_config()
+    return _vectorizer_factory
+
+
+def _validate_vectorizer_instance(vectorizer: Any) -> Vectorizer:
+    """Validate that the returned object supports the async API used at runtime."""
+    missing_methods = [
+        method_name
+        for method_name in ("aembed", "aembed_many")
+        if not hasattr(vectorizer, method_name)
+    ]
+    if missing_methods:
+        missing = ", ".join(missing_methods)
+        raise TypeError(
+            "Vectorizer factory must return an object that implements "
+            f"the runtime async methods: {missing}"
+        )
+    return vectorizer
+
+
+def create_vectorizer(
+    config: Optional[Settings] = None,
+    model: Optional[str] = None,
+    **kwargs,
+) -> Vectorizer:
+    """Create a vectorizer using the registered factory or the default implementation."""
+    cfg = config or settings
+    factory = _resolve_factory(cfg, explicit_config=config is not None)
+    cache = _build_embeddings_cache(cfg)
+    active_factory = factory if factory is not None else _default_vectorizer_factory
+    vectorizer = active_factory(
+        provider=cfg.embedding_provider,
+        model=model or cfg.embedding_model,
+        config=cfg,
+        cache=cache,
+        **kwargs,
+    )
+    return _validate_vectorizer_instance(vectorizer)

--- a/redis_sre_agent/core/vectorizer_helpers.py
+++ b/redis_sre_agent/core/vectorizer_helpers.py
@@ -35,6 +35,7 @@ class Vectorizer(Protocol):
 
 
 _vectorizer_factory: Optional[VectorizerFactory] = None
+_settings_vectorizer_factory: Optional[VectorizerFactory] = None
 _factory_initialized: bool = False
 
 
@@ -54,36 +55,38 @@ def _resolve_factory_from_path(factory_path: str) -> VectorizerFactory:
     return factory
 
 
-def _load_factory_from_config() -> None:
+def _load_factory_from_config() -> Optional[VectorizerFactory]:
     """Load the vectorizer factory from global settings if specified."""
-    global _vectorizer_factory, _factory_initialized
+    global _settings_vectorizer_factory, _factory_initialized
 
     if _factory_initialized:
-        return
+        return _settings_vectorizer_factory
 
     _factory_initialized = True
     factory_path = getattr(settings, "vectorizer_factory", None)
     if not factory_path or not isinstance(factory_path, str):
-        return
+        return None
 
     try:
-        _vectorizer_factory = _resolve_factory_from_path(factory_path)
+        _settings_vectorizer_factory = _resolve_factory_from_path(factory_path)
         logger.info("Loaded custom vectorizer factory from %s", factory_path)
     except Exception:
         logger.exception("Failed to load vectorizer factory from '%s'", factory_path)
         raise
+    return _settings_vectorizer_factory
 
 
 def set_vectorizer_factory(factory: Optional[VectorizerFactory]) -> None:
     """Register a custom vectorizer factory function."""
-    global _vectorizer_factory, _factory_initialized
+    global _vectorizer_factory
     _vectorizer_factory = factory
-    _factory_initialized = True
 
 
 def get_vectorizer_factory() -> Optional[VectorizerFactory]:
     """Get the currently registered global vectorizer factory, if any."""
-    return _vectorizer_factory
+    if _vectorizer_factory is not None:
+        return _vectorizer_factory
+    return _settings_vectorizer_factory
 
 
 def _build_embeddings_cache(config: Settings) -> EmbeddingsCache:
@@ -137,17 +140,18 @@ def _default_vectorizer_factory(
 
 def _resolve_factory(config: Settings, *, explicit_config: bool) -> Optional[VectorizerFactory]:
     """Resolve the active factory, respecting explicit per-call config overrides."""
-    if _vectorizer_factory is not None:
-        return _vectorizer_factory
-
     if explicit_config:
         factory_path = getattr(config, "vectorizer_factory", None)
         if factory_path and isinstance(factory_path, str):
             return _resolve_factory_from_path(factory_path)
+        if _vectorizer_factory is not None:
+            return _vectorizer_factory
         return None
 
-    _load_factory_from_config()
-    return _vectorizer_factory
+    if _vectorizer_factory is not None:
+        return _vectorizer_factory
+
+    return _load_factory_from_config()
 
 
 def _validate_vectorizer_instance(vectorizer: Any) -> Vectorizer:

--- a/specs/vectorizer-factory-configuration-spec.md
+++ b/specs/vectorizer-factory-configuration-spec.md
@@ -1,0 +1,331 @@
+# Vectorizer Factory Configuration Spec
+
+Status: Proposed
+
+Related:
+- `redis_sre_agent/core/config.py`
+- `redis_sre_agent/core/llm_helpers.py`
+- `redis_sre_agent/core/redis.py`
+- `docs/reference/configuration.md`
+- `docs/how-to/configuration.md`
+
+## Summary
+
+Add a centralized `vectorizer_factory` setting so deployments can override embedding/vectorizer
+construction with a dot-path import string, the same way they can already override chat-model and
+AsyncOpenAI client construction.
+
+The runtime already has two configurable LLM-construction seams:
+
+- `llm_factory` for LangChain chat models
+- `async_openai_client_factory` for OpenAI-compatible async SDK clients
+
+The remaining hard-coded LLM-adjacent seam is embeddings. `get_vectorizer()` still directly
+constructs `OpenAITextVectorizer` or `HFTextVectorizer` inside `redis_sre_agent/core/redis.py`.
+That blocks deployments that need:
+
+- Azure/OpenAI-compatible embedding clients with custom auth or transport
+- alternate RedisVL-compatible vectorizer implementations
+- internal wrapper factories for observability, retries, or policy enforcement
+- a single configuration story for every runtime LLM factory
+
+This spec adds `vectorizer_factory`, keeps current defaults unchanged when it is unset, and treats
+runtime model/vectorizer construction as a centralized configuration concern rather than scattered
+inline imports.
+
+## Problem
+
+Today there is an inconsistent override story:
+
+- chat-model construction is configurable through `Settings.llm_factory`
+- async OpenAI SDK client construction is configurable through
+  `Settings.async_openai_client_factory`
+- vectorizer construction is not configurable through an import path at all
+
+That inconsistency matters because vectorizers are used in multiple runtime paths:
+
+- knowledge search query embeddings
+- document ingestion and deduplication
+- skills search
+- Q&A vector updates
+- startup and health validation paths
+
+Any deployment that must swap embedding behavior currently has to patch code or monkey-patch
+`get_vectorizer()` instead of using the same settings surface that already exists for other LLM
+factories.
+
+## Goals
+
+- Add a `vectorizer_factory` field to the centralized `Settings` model.
+- Support configuration through environment variables and config files using a dot-path import
+  string.
+- Keep `get_vectorizer()` as the stable public entry point so callers do not need to change.
+- Preserve today's default provider behavior when no custom factory is configured.
+- Keep programmatic override support symmetric with existing LLM helpers.
+- Make the repo's runtime LLM/vectorizer construction seams consistently configurable from one
+  place.
+
+## Non-goals
+
+- Replacing `embedding_provider`, `embedding_model`, or `vector_dim`.
+- Redesigning vectorizer usage sites to depend on a different interface.
+- Making test-only direct SDK usage configurable. The scope here is runtime code under
+  `redis_sre_agent/`, not live integration tests that intentionally instantiate SDK clients
+  directly.
+- Introducing per-call vectorizer selection or per-index vectorizer overrides.
+- Migrating away from RedisVL in this change.
+
+## Current-State Observations
+
+### 1. Configuration centralization is already partially in place
+
+`redis_sre_agent/core/config.py` already exposes:
+
+- `llm_factory`
+- `async_openai_client_factory`
+
+Those fields are documented in `.env.example`, `docs/reference/configuration.md`, and
+`docs/how-to/configuration.md`.
+
+### 2. Vectorizer construction is still hard-coded
+
+`redis_sre_agent/core/redis.py:get_vectorizer()` currently:
+
+- builds an `EmbeddingsCache`
+- branches on `settings.embedding_provider`
+- directly returns `HFTextVectorizer(...)` or `OpenAITextVectorizer(...)`
+
+There is no import-path override, no factory registration API, and no validation path parallel to
+`llm_helpers.py`.
+
+### 3. Runtime callers are already funneled through `get_vectorizer()`
+
+The good news is the main runtime paths already converge on `get_vectorizer()`:
+
+- `redis_sre_agent/core/knowledge_helpers.py`
+- `redis_sre_agent/skills/backend.py`
+- `redis_sre_agent/core/docket_tasks.py`
+- `redis_sre_agent/pipelines/ingestion/*`
+- Redis health / infrastructure checks
+
+That means we can add configurability at one seam without broad call-site churn.
+
+### 4. Existing helpers establish the desired pattern
+
+`redis_sre_agent/core/llm_helpers.py` already provides the pattern to mirror:
+
+- load a dot-path factory from settings on first use
+- allow programmatic registration via setter functions
+- fall back to a default factory when no override is configured
+- raise a clear error on invalid import paths or non-callable targets
+
+## Proposed Design
+
+## 1. Add `vectorizer_factory` to centralized settings
+
+Add a new optional field to `Settings`:
+
+- `vectorizer_factory: str | None`
+
+Environment variable:
+
+- `VECTORIZER_FACTORY`
+
+Config-file example:
+
+```yaml
+vectorizer_factory: mypackage.embeddings.custom_vectorizer_factory
+```
+
+Environment example:
+
+```bash
+VECTORIZER_FACTORY=mypackage.embeddings.custom_vectorizer_factory
+```
+
+Description:
+
+- dot-path to a callable that constructs the runtime vectorizer
+- if unset, the default OpenAI/local provider logic remains in effect
+
+## 2. Introduce a vectorizer helper module with the same override model as LLM helpers
+
+Add a new module:
+
+```text
+redis_sre_agent/core/vectorizer_helpers.py
+```
+
+Responsibilities:
+
+- define the vectorizer factory protocol
+- manage one-time loading from `settings.vectorizer_factory`
+- expose programmatic registration helpers
+- provide the default factory implementation that mirrors current behavior
+
+Suggested public helpers:
+
+- `set_vectorizer_factory(factory)`
+- `get_vectorizer_factory()`
+- `create_vectorizer(config: Settings | None = None)`
+
+`redis_sre_agent/core/redis.py:get_vectorizer()` should remain public and delegate to
+`create_vectorizer()` so existing imports continue to work.
+
+### Why a helper module instead of putting more logic in `core/redis.py`
+
+`core/redis.py` already owns Redis clients, schemas, index helpers, and health checks. Import-path
+resolution and factory registration fit the same category as `llm_helpers.py`, not the same
+category as index schema definitions. Separating them keeps the override mechanism easy to test and
+easy to reuse.
+
+## 3. Define the vectorizer factory contract
+
+The factory must receive enough context to reproduce the current default behavior without reaching
+back into globals.
+
+Suggested callable contract:
+
+```python
+def custom_vectorizer_factory(
+    *,
+    provider: str,
+    model: str | None,
+    config: Settings,
+    cache: EmbeddingsCache | None,
+    **kwargs,
+) -> Any:
+    ...
+```
+
+Expected behavior:
+
+- `provider` is the normalized `embedding_provider` value such as `openai` or `local`
+- `model` is the configured embedding model unless explicitly overridden later
+- `config` is the effective `Settings` object used for this call
+- `cache` is the prepared RedisVL `EmbeddingsCache` instance built with current TTL/Redis settings
+- the return value must implement the methods the runtime already uses:
+  - `aembed()`
+  - `aembed_many()`
+- compatibility with `embed_many()` should be preserved because current tests and some workflows
+  rely on it
+
+This contract keeps the override powerful without forcing every custom factory to reconstruct
+shared cache behavior itself.
+
+## 4. Keep the default behavior exactly as it is today
+
+When `vectorizer_factory` is unset:
+
+- `embedding_provider=local` returns `HFTextVectorizer(model=..., cache=...)`
+- `embedding_provider=openai` returns `OpenAITextVectorizer(model=..., cache=..., api_config=...)`
+- unknown providers still raise `ValueError`
+
+This is a compatibility requirement. Adding the new setting must not change the default runtime
+for existing deployments.
+
+## 5. Align failure behavior with other configurable factories
+
+On first vectorizer creation:
+
+- invalid dot-paths should raise `ValueError`
+- non-callable targets should raise `ValueError`
+- import failures should surface clearly with the configured path in the error message
+
+If the factory returns an object missing required methods, the helper should fail early with a
+clear error rather than letting the first indexing or search call fail with an opaque attribute
+error deep in the stack.
+
+The goal is to make configuration mistakes obvious during startup checks, ingestion, or health
+probes.
+
+## 6. Treat runtime factory settings as a single centralized family
+
+This change should also codify the design rule that runtime LLM construction seams live in
+`Settings` and are configured via import-path fields.
+
+After this change, the runtime factory family becomes:
+
+- `llm_factory`
+- `async_openai_client_factory`
+- `vectorizer_factory`
+
+No new runtime LLM/vectorizer factory override should be added later through ad hoc env lookups or
+inline imports elsewhere in the codebase.
+
+## Implementation Outline
+
+1. Add `vectorizer_factory` to `redis_sre_agent/core/config.py`.
+2. Add `VECTORIZER_FACTORY` comments to `.env.example`.
+3. Add the new setting to:
+   - `docs/reference/configuration.md`
+   - `docs/how-to/configuration.md`
+4. Add `redis_sre_agent/core/vectorizer_helpers.py` with:
+   - import-path loading
+   - setter/getter
+   - default factory
+   - optional return-shape validation
+5. Refactor `redis_sre_agent/core/redis.py:get_vectorizer()` to delegate to the helper while
+   preserving its public signature.
+6. Optionally extract the duplicated dot-path loader logic from `llm_helpers.py` and the new
+   vectorizer helper into a small shared utility if that reduces copy-paste without obscuring the
+   code.
+
+## Testing Plan
+
+Add or update unit coverage for these cases:
+
+- default vectorizer behavior still returns OpenAI/local RedisVL vectorizers based on
+  `embedding_provider`
+- `set_vectorizer_factory()` registers and clears a programmatic override
+- configured `vectorizer_factory` is loaded from settings on first use
+- invalid `VECTORIZER_FACTORY` path raises a clear error
+- non-callable configured target raises a clear error
+- custom factory receives:
+  - `provider`
+  - `model`
+  - `config`
+  - `cache`
+- `get_vectorizer()` still returns a fresh instance on each call
+- health / initialization paths still report vectorizer availability correctly when the custom
+  factory is valid
+
+Suggested test files:
+
+- new: `tests/unit/core/test_vectorizer_helpers.py`
+- update: `tests/unit/core/test_redis.py`
+
+## Backward Compatibility
+
+- Existing deployments with no `VECTORIZER_FACTORY` configured are unaffected.
+- Existing callers importing `get_vectorizer()` remain unaffected.
+- Existing `EMBEDDING_PROVIDER`, `EMBEDDING_MODEL`, and `VECTOR_DIM` settings remain supported and
+  continue to drive the default factory.
+
+## Open Questions
+
+### 1. Should the helper validate the full vectorizer interface?
+
+Recommended v1 answer:
+
+- validate the async methods actually used in runtime paths
+- do not try to perfectly model every RedisVL vectorizer method in the type system
+
+That keeps the implementation simple and catches the failures that matter.
+
+### 2. Should we also refactor `llm_helpers.py` to use a shared import-path loader now?
+
+Recommended v1 answer:
+
+- only do this if the extracted utility stays tiny and obviously better than the duplicated code
+- do not expand the scope of this change into a broad helper-framework refactor
+
+The user-visible goal is vectorizer configurability, not helper architecture cleanup.
+
+## Acceptance Criteria
+
+- A deployment can set `VECTORIZER_FACTORY` or `vectorizer_factory` in config and override runtime
+  vectorizer construction without patching code.
+- `get_vectorizer()` remains the stable public API and preserves current behavior by default.
+- The new setting is documented alongside the existing LLM factory settings.
+- Unit tests cover both default and custom-factory paths.

--- a/tests/unit/core/test_redis.py
+++ b/tests/unit/core/test_redis.py
@@ -79,39 +79,31 @@ class TestRedisInfrastructure:
         # from_url should be called TWICE (no caching)
         assert mock_redis.from_url.call_count == 2
 
-    @patch("redis_sre_agent.core.redis.EmbeddingsCache")
-    @patch("redis_sre_agent.core.redis.HFTextVectorizer")
-    @patch("redis_sre_agent.core.redis.OpenAITextVectorizer")
-    def test_get_vectorizer(self, mock_openai_vectorizer, mock_hf_vectorizer, mock_cache):
-        """Test vectorizer creation (no caching - creates fresh each time)."""
-        from redis_sre_agent.core.config import settings
-
-        mock_cache_instance = Mock()
-        mock_cache.return_value = mock_cache_instance
-
+    @patch("redis_sre_agent.core.redis.create_vectorizer")
+    def test_get_vectorizer(self, mock_create_vectorizer):
+        """Test vectorizer creation delegates to the helper on each call."""
         mock_vectorizer_instance = Mock()
-        # Set return value for whichever vectorizer is used based on settings
-        mock_openai_vectorizer.return_value = mock_vectorizer_instance
-        mock_hf_vectorizer.return_value = mock_vectorizer_instance
+        mock_create_vectorizer.return_value = mock_vectorizer_instance
 
-        # Determine which mock to check based on settings
-        if settings.embedding_provider.lower() == "local":
-            expected_vectorizer_mock = mock_hf_vectorizer
-        else:
-            expected_vectorizer_mock = mock_openai_vectorizer
-
-        # First call creates vectorizer
         vectorizer1 = get_vectorizer()
         assert vectorizer1 == mock_vectorizer_instance
-        mock_cache.assert_called_once()
-        expected_vectorizer_mock.assert_called_once()
+        mock_create_vectorizer.assert_called_once_with(config=None)
 
-        # Second call creates NEW instance (no caching to avoid event loop issues)
         vectorizer2 = get_vectorizer()
         assert vectorizer2 == mock_vectorizer_instance
-        # Should be called TWICE (no caching)
-        assert mock_cache.call_count == 2
-        assert expected_vectorizer_mock.call_count == 2
+        assert mock_create_vectorizer.call_count == 2
+
+    @patch("redis_sre_agent.core.redis.create_vectorizer")
+    def test_get_vectorizer_passes_explicit_config(self, mock_create_vectorizer):
+        """Test get_vectorizer forwards explicit config for dependency injection."""
+        mock_vectorizer_instance = Mock()
+        mock_create_vectorizer.return_value = mock_vectorizer_instance
+        config = Mock()
+
+        result = get_vectorizer(config=config)
+
+        assert result is mock_vectorizer_instance
+        mock_create_vectorizer.assert_called_once_with(config=config)
 
     @pytest.mark.asyncio
     async def test_get_knowledge_index(self):

--- a/tests/unit/core/test_vectorizer_helpers.py
+++ b/tests/unit/core/test_vectorizer_helpers.py
@@ -16,6 +16,7 @@ class TestVectorizerHelpers:
     def teardown_method(self):
         """Reset vectorizer factory state after each test."""
         vectorizer_helpers._vectorizer_factory = None
+        vectorizer_helpers._settings_vectorizer_factory = None
         vectorizer_helpers._factory_initialized = False
 
     def test_get_vectorizer_factory_returns_none_by_default(self):
@@ -190,6 +191,49 @@ class TestVectorizerHelpers:
         assert kwargs["provider"] == "local"
         assert kwargs["model"] == "sentence-transformers/all-mpnet-base-v2"
         assert kwargs["config"] is config
+
+    def test_explicit_config_factory_wins_after_global_factory_was_loaded(self):
+        """Explicit config factory paths should win even after global settings were initialized."""
+        mock_cache = Mock()
+        settings_vectorizer = Mock(aembed=Mock(), aembed_many=Mock())
+        explicit_vectorizer = Mock(aembed=Mock(), aembed_many=Mock())
+        settings_factory = MagicMock(return_value=settings_vectorizer)
+        explicit_factory = MagicMock(return_value=explicit_vectorizer)
+        config = MagicMock()
+        config.redis_url.get_secret_value.return_value = "redis://localhost:6379/0"
+        config.embeddings_cache_ttl = 45
+        config.embedding_provider = "local"
+        config.embedding_model = "sentence-transformers/all-mpnet-base-v2"
+        config.vectorizer_factory = "custom.explicit_factory"
+
+        def resolve_factory_side_effect(factory_path):
+            if factory_path == "global.settings_factory":
+                return settings_factory
+            if factory_path == "custom.explicit_factory":
+                return explicit_factory
+            raise AssertionError(f"Unexpected factory path: {factory_path}")
+
+        with (
+            patch("redis_sre_agent.core.vectorizer_helpers.settings") as mock_settings,
+            patch(
+                "redis_sre_agent.core.vectorizer_helpers._resolve_factory_from_path",
+                side_effect=resolve_factory_side_effect,
+            ),
+            patch(
+                "redis_sre_agent.core.vectorizer_helpers.EmbeddingsCache", return_value=mock_cache
+            ),
+        ):
+            mock_settings.redis_url.get_secret_value.return_value = "redis://localhost:6379/0"
+            mock_settings.embeddings_cache_ttl = 30
+            mock_settings.embedding_provider = "openai"
+            mock_settings.embedding_model = "text-embedding-3-small"
+            mock_settings.vectorizer_factory = "global.settings_factory"
+
+            assert create_vectorizer() is settings_vectorizer
+            assert create_vectorizer(config=config) is explicit_vectorizer
+
+        settings_factory.assert_called_once()
+        explicit_factory.assert_called_once()
 
     def test_invalid_factory_path_raises(self):
         """Invalid dot-paths should fail with a clear error."""

--- a/tests/unit/core/test_vectorizer_helpers.py
+++ b/tests/unit/core/test_vectorizer_helpers.py
@@ -1,0 +1,247 @@
+"""Unit tests for vectorizer helper functions."""
+
+from unittest.mock import MagicMock, Mock, patch
+
+import redis_sre_agent.core.vectorizer_helpers as vectorizer_helpers
+from redis_sre_agent.core.vectorizer_helpers import (
+    create_vectorizer,
+    get_vectorizer_factory,
+    set_vectorizer_factory,
+)
+
+
+class TestVectorizerHelpers:
+    """Test vectorizer helper functionality."""
+
+    def teardown_method(self):
+        """Reset vectorizer factory state after each test."""
+        vectorizer_helpers._vectorizer_factory = None
+        vectorizer_helpers._factory_initialized = False
+
+    def test_get_vectorizer_factory_returns_none_by_default(self):
+        """Factory getter should return None when nothing is registered."""
+        set_vectorizer_factory(None)
+        assert get_vectorizer_factory() is None
+
+    def test_set_vectorizer_factory_registers_factory(self):
+        """Programmatic registration should be observable."""
+        mock_factory = MagicMock()
+        set_vectorizer_factory(mock_factory)
+        assert get_vectorizer_factory() is mock_factory
+
+    def test_set_vectorizer_factory_none_clears_factory(self):
+        """Resetting the programmatic factory should restore the default path."""
+        set_vectorizer_factory(MagicMock())
+        set_vectorizer_factory(None)
+        assert get_vectorizer_factory() is None
+
+    def test_create_vectorizer_openai_defaults(self):
+        """Default factory should create an OpenAI RedisVL vectorizer."""
+        mock_cache = Mock()
+        mock_vectorizer = Mock(aembed=Mock(), aembed_many=Mock())
+
+        with (
+            patch("redis_sre_agent.core.vectorizer_helpers.settings") as mock_settings,
+            patch(
+                "redis_sre_agent.core.vectorizer_helpers.EmbeddingsCache", return_value=mock_cache
+            ),
+            patch(
+                "redis_sre_agent.core.vectorizer_helpers.OpenAITextVectorizer",
+                return_value=mock_vectorizer,
+            ) as mock_openai_vectorizer,
+        ):
+            mock_settings.redis_url.get_secret_value.return_value = "redis://localhost:6379/0"
+            mock_settings.embeddings_cache_ttl = 60
+            mock_settings.embedding_provider = "openai"
+            mock_settings.embedding_model = "text-embedding-3-small"
+            mock_settings.openai_api_key = "test-key"
+            mock_settings.openai_base_url = "https://proxy.example.com/v1"
+            mock_settings.vectorizer_factory = None
+
+            result = create_vectorizer()
+
+        assert result is mock_vectorizer
+        mock_openai_vectorizer.assert_called_once_with(
+            model="text-embedding-3-small",
+            cache=mock_cache,
+            api_config={
+                "api_key": "test-key",
+                "base_url": "https://proxy.example.com/v1",
+            },
+        )
+
+    def test_create_vectorizer_local_defaults(self):
+        """Default factory should create a HuggingFace RedisVL vectorizer."""
+        mock_cache = Mock()
+        mock_vectorizer = Mock(aembed=Mock(), aembed_many=Mock())
+
+        with (
+            patch("redis_sre_agent.core.vectorizer_helpers.settings") as mock_settings,
+            patch(
+                "redis_sre_agent.core.vectorizer_helpers.EmbeddingsCache", return_value=mock_cache
+            ),
+            patch(
+                "redis_sre_agent.core.vectorizer_helpers.HFTextVectorizer",
+                return_value=mock_vectorizer,
+            ) as mock_hf_vectorizer,
+        ):
+            mock_settings.redis_url.get_secret_value.return_value = "redis://localhost:6379/0"
+            mock_settings.embeddings_cache_ttl = 120
+            mock_settings.embedding_provider = "local"
+            mock_settings.embedding_model = "sentence-transformers/all-MiniLM-L6-v2"
+            mock_settings.vectorizer_factory = None
+
+            result = create_vectorizer()
+
+        assert result is mock_vectorizer
+        mock_hf_vectorizer.assert_called_once_with(
+            model="sentence-transformers/all-MiniLM-L6-v2",
+            cache=mock_cache,
+        )
+
+    def test_custom_factory_receives_provider_model_config_and_cache(self):
+        """Programmatic factory should receive the effective vectorizer inputs."""
+        mock_cache = Mock()
+        mock_vectorizer = Mock(aembed=Mock(), aembed_many=Mock())
+        mock_factory = MagicMock(return_value=mock_vectorizer)
+        set_vectorizer_factory(mock_factory)
+
+        with (
+            patch("redis_sre_agent.core.vectorizer_helpers.settings") as mock_settings,
+            patch(
+                "redis_sre_agent.core.vectorizer_helpers.EmbeddingsCache", return_value=mock_cache
+            ),
+        ):
+            mock_settings.redis_url.get_secret_value.return_value = "redis://localhost:6379/0"
+            mock_settings.embeddings_cache_ttl = 300
+            mock_settings.embedding_provider = "openai"
+            mock_settings.embedding_model = "text-embedding-3-large"
+            mock_settings.vectorizer_factory = None
+
+            result = create_vectorizer()
+
+        assert result is mock_vectorizer
+        mock_factory.assert_called_once()
+        kwargs = mock_factory.call_args.kwargs
+        assert kwargs["provider"] == "openai"
+        assert kwargs["model"] == "text-embedding-3-large"
+        assert kwargs["config"] is not None
+        assert kwargs["cache"] is mock_cache
+
+    def test_load_factory_from_config_success(self):
+        """Configured factory path should be imported and used."""
+        mock_cache = Mock()
+        mock_vectorizer = Mock(aembed=Mock(), aembed_many=Mock())
+        module = MagicMock()
+        module.custom_factory = MagicMock(return_value=mock_vectorizer)
+
+        with (
+            patch("redis_sre_agent.core.vectorizer_helpers.settings") as mock_settings,
+            patch(
+                "redis_sre_agent.core.vectorizer_helpers.importlib.import_module",
+                return_value=module,
+            ),
+            patch(
+                "redis_sre_agent.core.vectorizer_helpers.EmbeddingsCache", return_value=mock_cache
+            ),
+        ):
+            mock_settings.redis_url.get_secret_value.return_value = "redis://localhost:6379/0"
+            mock_settings.embeddings_cache_ttl = 30
+            mock_settings.embedding_provider = "openai"
+            mock_settings.embedding_model = "text-embedding-3-small"
+            mock_settings.vectorizer_factory = "my.factories.custom_factory"
+
+            result = create_vectorizer()
+
+        assert result is mock_vectorizer
+        module.custom_factory.assert_called_once()
+        kwargs = module.custom_factory.call_args.kwargs
+        assert kwargs["provider"] == "openai"
+        assert kwargs["model"] == "text-embedding-3-small"
+        assert kwargs["cache"] is not None
+
+    def test_explicit_config_uses_its_own_factory_path(self):
+        """Explicit config injection should resolve the factory from that config object."""
+        mock_cache = Mock()
+        mock_vectorizer = Mock(aembed=Mock(), aembed_many=Mock())
+        module = MagicMock()
+        module.custom_factory = MagicMock(return_value=mock_vectorizer)
+        config = MagicMock()
+        config.redis_url.get_secret_value.return_value = "redis://localhost:6379/0"
+        config.embeddings_cache_ttl = 45
+        config.embedding_provider = "local"
+        config.embedding_model = "sentence-transformers/all-mpnet-base-v2"
+        config.vectorizer_factory = "my.factories.custom_factory"
+
+        with (
+            patch(
+                "redis_sre_agent.core.vectorizer_helpers.importlib.import_module",
+                return_value=module,
+            ),
+            patch(
+                "redis_sre_agent.core.vectorizer_helpers.EmbeddingsCache", return_value=mock_cache
+            ),
+        ):
+            result = create_vectorizer(config=config)
+
+        assert result is mock_vectorizer
+        module.custom_factory.assert_called_once()
+        kwargs = module.custom_factory.call_args.kwargs
+        assert kwargs["provider"] == "local"
+        assert kwargs["model"] == "sentence-transformers/all-mpnet-base-v2"
+        assert kwargs["config"] is config
+
+    def test_invalid_factory_path_raises(self):
+        """Invalid dot-paths should fail with a clear error."""
+        with patch("redis_sre_agent.core.vectorizer_helpers.settings") as mock_settings:
+            mock_settings.vectorizer_factory = "invalid_path_without_dot"
+
+            try:
+                create_vectorizer()
+            except ValueError as exc:
+                assert "Invalid VECTORIZER_FACTORY path" in str(exc)
+            else:
+                raise AssertionError("Expected ValueError for invalid VECTORIZER_FACTORY path")
+
+    def test_non_callable_factory_raises(self):
+        """Resolved targets must be callable."""
+        module = MagicMock()
+        module.not_callable = object()
+
+        with (
+            patch("redis_sre_agent.core.vectorizer_helpers.settings") as mock_settings,
+            patch(
+                "redis_sre_agent.core.vectorizer_helpers.importlib.import_module",
+                return_value=module,
+            ),
+        ):
+            mock_settings.vectorizer_factory = "my.factories.not_callable"
+
+            try:
+                create_vectorizer()
+            except ValueError as exc:
+                assert "VECTORIZER_FACTORY 'my.factories.not_callable' is not callable" in str(exc)
+            else:
+                raise AssertionError(
+                    "Expected ValueError for non-callable VECTORIZER_FACTORY target"
+                )
+
+    def test_factory_result_must_support_runtime_async_methods(self):
+        """Returned objects should fail fast when missing the runtime async API."""
+        mock_factory = MagicMock(return_value=object())
+        set_vectorizer_factory(mock_factory)
+
+        with patch("redis_sre_agent.core.vectorizer_helpers.settings") as mock_settings:
+            mock_settings.redis_url.get_secret_value.return_value = "redis://localhost:6379/0"
+            mock_settings.embeddings_cache_ttl = 60
+            mock_settings.embedding_provider = "openai"
+            mock_settings.embedding_model = "text-embedding-3-small"
+            mock_settings.vectorizer_factory = None
+
+            try:
+                create_vectorizer()
+            except TypeError as exc:
+                assert "aembed" in str(exc)
+                assert "aembed_many" in str(exc)
+            else:
+                raise AssertionError("Expected TypeError for invalid vectorizer interface")

--- a/tests/unit/core/test_vectorizer_helpers.py
+++ b/tests/unit/core/test_vectorizer_helpers.py
@@ -36,6 +36,32 @@ class TestVectorizerHelpers:
         set_vectorizer_factory(None)
         assert get_vectorizer_factory() is None
 
+    def test_set_vectorizer_factory_none_suppresses_settings_factory_loading(self):
+        """Clearing a programmatic factory should also suppress later settings loading."""
+        with patch("redis_sre_agent.core.vectorizer_helpers.settings") as mock_settings:
+            mock_settings.redis_url.get_secret_value.return_value = "redis://localhost:6379/0"
+            mock_settings.embeddings_cache_ttl = 60
+            mock_settings.embedding_provider = "openai"
+            mock_settings.embedding_model = "text-embedding-3-small"
+            mock_settings.openai_api_key = "test-key"
+            mock_settings.openai_base_url = None
+            mock_settings.vectorizer_factory = "my.factories.custom_factory"
+
+            set_vectorizer_factory(None)
+
+            with (
+                patch(
+                    "redis_sre_agent.core.vectorizer_helpers._resolve_factory_from_path"
+                ) as mock_resolve,
+                patch(
+                    "redis_sre_agent.core.redis.OpenAITextVectorizer",
+                    return_value=Mock(aembed=Mock(), aembed_many=Mock()),
+                ),
+            ):
+                create_vectorizer()
+
+        mock_resolve.assert_not_called()
+
     def test_create_vectorizer_openai_defaults(self):
         """Default factory should create an OpenAI RedisVL vectorizer."""
         mock_cache = Mock()
@@ -47,7 +73,7 @@ class TestVectorizerHelpers:
                 "redis_sre_agent.core.vectorizer_helpers.EmbeddingsCache", return_value=mock_cache
             ),
             patch(
-                "redis_sre_agent.core.vectorizer_helpers.OpenAITextVectorizer",
+                "redis_sre_agent.core.redis.OpenAITextVectorizer",
                 return_value=mock_vectorizer,
             ) as mock_openai_vectorizer,
         ):
@@ -82,7 +108,7 @@ class TestVectorizerHelpers:
                 "redis_sre_agent.core.vectorizer_helpers.EmbeddingsCache", return_value=mock_cache
             ),
             patch(
-                "redis_sre_agent.core.vectorizer_helpers.HFTextVectorizer",
+                "redis_sre_agent.core.redis.HFTextVectorizer",
                 return_value=mock_vectorizer,
             ) as mock_hf_vectorizer,
         ):
@@ -191,6 +217,34 @@ class TestVectorizerHelpers:
         assert kwargs["provider"] == "local"
         assert kwargs["model"] == "sentence-transformers/all-mpnet-base-v2"
         assert kwargs["config"] is config
+
+    def test_default_factory_honors_legacy_redis_patch_seam(self):
+        """Patches against core.redis vectorizer aliases should still intercept creation."""
+        mock_cache = Mock()
+        mock_vectorizer = Mock(aembed=Mock(), aembed_many=Mock())
+
+        with (
+            patch("redis_sre_agent.core.vectorizer_helpers.settings") as mock_settings,
+            patch(
+                "redis_sre_agent.core.vectorizer_helpers.EmbeddingsCache", return_value=mock_cache
+            ),
+            patch(
+                "redis_sre_agent.core.redis.OpenAITextVectorizer",
+                return_value=mock_vectorizer,
+            ) as mock_openai_vectorizer,
+        ):
+            mock_settings.redis_url.get_secret_value.return_value = "redis://localhost:6379/0"
+            mock_settings.embeddings_cache_ttl = 60
+            mock_settings.embedding_provider = "openai"
+            mock_settings.embedding_model = "text-embedding-3-small"
+            mock_settings.openai_api_key = "test-key"
+            mock_settings.openai_base_url = None
+            mock_settings.vectorizer_factory = None
+
+            result = create_vectorizer()
+
+        assert result is mock_vectorizer
+        mock_openai_vectorizer.assert_called_once()
 
     def test_explicit_config_factory_wins_after_global_factory_was_loaded(self):
         """Explicit config factory paths should win even after global settings were initialized."""


### PR DESCRIPTION
## Summary
- add a centralized `vectorizer_factory` setting so vectorizer construction can be overridden by import path
- route `core.redis.get_vectorizer()` through a new helper module while preserving the public seam and Redis-backed cache defaults
- document `VECTORIZER_FACTORY`, add focused vectorizer helper coverage, and audit remaining runtime LLM call sites

## Verification
- `uv run ruff check redis_sre_agent/core/vectorizer_helpers.py redis_sre_agent/core/config.py redis_sre_agent/core/redis.py redis_sre_agent/agent/knowledge_agent.py redis_sre_agent/agent/langgraph_agent.py redis_sre_agent/agent/runbook_generator.py tests/unit/core/test_vectorizer_helpers.py tests/unit/core/test_redis.py`
- `uv run pytest tests/unit/core/test_vectorizer_helpers.py tests/unit/core/test_redis.py tests/unit/core/test_llm_helpers.py tests/unit/agent/test_temperature_removal.py tests/unit/pipelines/scraper/test_runbook_generator.py tests/unit/agent/test_knowledge_agent.py tests/unit/agent/test_langgraph_agent_compose.py`
- pre-commit hooks during `git commit` including unit tests and `mkdocs build --strict`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new import-path based extension point for embeddings/vectorizer construction and routes `get_vectorizer()` through it, which can affect indexing/search behavior if misconfigured. Default behavior is preserved, but incorrect factory paths or incompatible return objects will now fail at runtime/startup.
> 
> **Overview**
> Adds a new configurable `vectorizer_factory` setting (env: `VECTORIZER_FACTORY`) so deployments can override embeddings/vectorizer creation via a dot-path factory function.
> 
> Refactors `core.redis.get_vectorizer()` to delegate to a new `core/vectorizer_helpers.py` factory/validation layer (including Redis-backed `EmbeddingsCache` setup and required `aembed()`/`aembed_many()` interface checks), and updates agent typing away from `ChatOpenAI` toward `BaseChatModel`.
> 
> Updates `.env.example` and configuration docs to document the new option, and adds/adjusts unit tests to cover default behavior, custom factories, import-path loading errors, and explicit config injection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57b3d20a8550050695a434464b2c0bd93c661471. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->