### PR TITLE
Prepare 0.5.0 release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "redis-sre-agent"
-version = "0.4.0"
+version = "0.5.0"
 description = "A LangGraph-based Redis SRE Agent for infrastructure monitoring and incident response"
 readme = "README.md"
 license = {file = "LICENSE.txt"}

--- a/uv.lock
+++ b/uv.lock
@@ -3203,7 +3203,7 @@ wheels = [
 
 [[package]]
 name = "redis-sre-agent"
-version = "0.4.0"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "agent-memory-client" },


### PR DESCRIPTION
## Summary
- bump package metadata to `0.5.0` for the release
- keep `uv.lock` in sync with the project version

## Testing
- `make lint`
- `make docs-gen-check`
- `REDIS_URL=redis://127.0.0.1:1/15 make test`
- `npx gitnexus detect-changes --repo /Users/andrew.brookins/src/redis-sre-agent --scope all`

Note: the first unscoped local `make test` run picked up this checkout's `.env` and found a real local Redis instance inventory, which caused six unit tests to take live-instance branches. The same tests and full suite passed with `REDIS_URL` overridden to an inert local URL.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: metadata-only change that updates the package version in `pyproject.toml` and syncs `uv.lock`, with no runtime logic modifications.
> 
> **Overview**
> Prepares the `0.5.0` release by bumping the project version in `pyproject.toml` from `0.4.0` to `0.5.0`.
> 
> Keeps `uv.lock` in sync by updating the `redis-sre-agent` package entry to `0.5.0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0aee7851cf06f083c2eccf7c423dd739f32f9e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->