### PR TITLE
Consolidate generic skill contract enforcement

### DIFF
--- a/evals/corpora/prompt-core/2026-04-14/manifest.yaml
+++ b/evals/corpora/prompt-core/2026-04-14/manifest.yaml
@@ -9,3 +9,4 @@ reviewed_by: sre-evals
 exemplar_sources:
   - evals/goldens/prompt/chat-iterative-tool-use/expected.md
   - evals/goldens/prompt/knowledge-agent-no-live-access/expected.md
+  - evals/goldens/prompt/example-skill-workflow-adherence/expected.md

--- a/evals/corpora/prompt-core/2026-04-14/skills/example-incident-brief/SKILL.md
+++ b/evals/corpora/prompt-core/2026-04-14/skills/example-incident-brief/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: example-incident-brief
+document_hash: example-incident-brief
+title: Example Incident Brief
+version: latest
+summary: Produce a structured incident brief from a tool-backed synthetic workflow.
+description: Produce a structured incident brief from a tool-backed synthetic workflow.
+source: prompt-core://skills/example-incident-brief
+---
+
+# Example Incident Brief
+
+Use this skill to produce a concise incident brief from the example incident tools in the current eval scenario.
+
+## Workflow
+
+Always gather evidence before writing the brief:
+
+1. Fetch the incident record.
+2. List the service inventory.
+3. Fetch the event timeline.
+4. Fetch the metric window for the primary service.
+5. Fetch owner notes.
+
+Use the tool results as the source of truth. If a tool is unavailable, state that in the relevant section instead of inventing evidence.
+
+## Output structure
+
+```markdown
+# Incident Brief: <incident name>
+
+**Incident ID:** <incident_id>
+**Primary service:** <service>
+**Window:** <time window>
+**Evidence source:** <source>
+
+## Summary
+
+- **Impact:** <impact summary>
+- **Current state:** <state summary>
+- **Primary hypothesis:** <hypothesis>
+
+## Evidence Timeline
+
+- **<timestamp>**: <event summary>
+
+## Tool Findings
+
+### Inventory
+
+- **<inventory finding>**: <evidence>
+
+### Metrics
+
+- **<metric finding>**: <evidence>
+
+### Events
+
+- **<event finding>**: <evidence>
+
+## Action Items
+
+- **<owner or team>**: <action>
+
+## Open Questions
+
+- **<question label>**: <question>
+```
+
+## Rules
+
+- Return one markdown document only.
+- Use the headings from the template exactly.
+- Keep findings tied to tool evidence.
+- Do not include a skill-usage footer.

--- a/evals/corpora/prompt-core/2026-04-14/skills/example-incident-brief/agents/openai.yaml
+++ b/evals/corpora/prompt-core/2026-04-14/skills/example-incident-brief/agents/openai.yaml
@@ -1,0 +1,18 @@
+display_name: Example Incident Brief
+preferred_entrypoint: SKILL.md
+workflow_contract:
+  required_tool_calls:
+    - get_incident
+    - list_service_inventory
+    - get_event_timeline
+    - get_metric_window
+    - get_owner_notes
+  required_followups:
+    - "Use get_metric_window before writing the Metrics subsection."
+    - "Use get_event_timeline before writing the Evidence Timeline section."
+    - "Use get_owner_notes before assigning action items."
+  progress_checklist:
+    - "Fetch the incident record."
+    - "Gather inventory, timeline, metrics, and owner notes."
+    - "Draft the brief in the exact markdown skeleton required by the output contract."
+    - "Repair the answer until every required heading and pattern is satisfied."

--- a/evals/goldens/knowledge/disabled-live-access-handoff/assertions.json
+++ b/evals/goldens/knowledge/disabled-live-access-handoff/assertions.json
@@ -1,6 +1,7 @@
 {
   "required_tool_calls": [],
   "forbidden_tool_calls": [],
+  "required_response_patterns": [],
   "required_findings": [
     "no live cluster access from this lane"
   ],

--- a/evals/goldens/knowledge/full-memory-evidence-following/assertions.json
+++ b/evals/goldens/knowledge/full-memory-evidence-following/assertions.json
@@ -1,6 +1,7 @@
 {
   "required_tool_calls": [],
   "forbidden_tool_calls": [],
+  "required_response_patterns": [],
   "required_findings": [
     "use INFO evidence before changing memory policy"
   ],

--- a/evals/goldens/knowledge/retrieval-only-ticket-guidance/assertions.json
+++ b/evals/goldens/knowledge/retrieval-only-ticket-guidance/assertions.json
@@ -1,6 +1,7 @@
 {
   "required_tool_calls": [],
   "forbidden_tool_calls": [],
+  "required_response_patterns": [],
   "required_findings": [
     "verify replica health before maintenance work"
   ],

--- a/evals/goldens/knowledge/startup-only-maintenance-checklist/assertions.json
+++ b/evals/goldens/knowledge/startup-only-maintenance-checklist/assertions.json
@@ -1,6 +1,7 @@
 {
   "required_tool_calls": [],
   "forbidden_tool_calls": [],
+  "required_response_patterns": [],
   "required_findings": [
     "check maintenance mode before deeper failover triage"
   ],

--- a/evals/goldens/prompt/chat-iterative-tool-use/assertions.json
+++ b/evals/goldens/prompt/chat-iterative-tool-use/assertions.json
@@ -13,6 +13,7 @@
       "target_handle": "tgt_cache_checkout"
     }
   ],
+  "required_response_patterns": [],
   "required_findings": [
     "memory pressure is driving the evictions",
     "start with a couple of targeted checks before widening the search"

--- a/evals/goldens/prompt/example-skill-workflow-adherence/assertions.json
+++ b/evals/goldens/prompt/example-skill-workflow-adherence/assertions.json
@@ -1,0 +1,33 @@
+{
+  "required_tool_calls": [
+    {"provider_family": "mcp", "server_name": "example_incident", "operation": "get_incident"},
+    {"provider_family": "mcp", "server_name": "example_incident", "operation": "list_service_inventory"},
+    {"provider_family": "mcp", "server_name": "example_incident", "operation": "get_event_timeline"},
+    {"provider_family": "mcp", "server_name": "example_incident", "operation": "get_metric_window"},
+    {"provider_family": "mcp", "server_name": "example_incident", "operation": "get_owner_notes"}
+  ],
+  "required_response_patterns": [
+    "(?s)^# Incident Brief: .+?\\n\\n\\*\\*Incident ID:\\*\\* .+?\\n\\*\\*Primary service:\\*\\* .+?\\n\\*\\*Window:\\*\\* .+?\\n\\*\\*Evidence source:\\*\\* .+?\\n\\n## Summary\\n.+?## Evidence Timeline\\n.+?## Tool Findings\\n.+?### Inventory\\n.+?### Metrics\\n.+?### Events\\n.+?## Action Items\\n.+?## Open Questions\\s*$",
+    "(?m)^### Inventory$",
+    "(?m)^### Metrics$",
+    "(?m)^### Events$",
+    "(?m)^- \\*\\*[^*]+\\*\\*: .+"
+  ],
+  "required_findings": [
+    "incident brief",
+    "checkout-api",
+    "elevated p95 latency",
+    "deploy api-2026.05.14.7",
+    "p95 latency peaked at 920 ms",
+    "rollback owner",
+    "open questions"
+  ],
+  "forbidden_claims": [
+    "i need a private tool",
+    "send me the support package",
+    "skill used"
+  ],
+  "required_sources": [
+    "example-incident-brief"
+  ]
+}

--- a/evals/goldens/prompt/example-skill-workflow-adherence/assertions.json
+++ b/evals/goldens/prompt/example-skill-workflow-adherence/assertions.json
@@ -18,7 +18,7 @@
     "checkout-api",
     "elevated p95 latency",
     "deploy api-2026.05.14.7",
-    "p95 latency peaked at 920 ms",
+    "p95 latency rose from 180 ms to a 920 ms peak",
     "rollback owner",
     "open questions"
   ],

--- a/evals/goldens/prompt/example-skill-workflow-adherence/expected.md
+++ b/evals/goldens/prompt/example-skill-workflow-adherence/expected.md
@@ -1,0 +1,41 @@
+# Incident Brief: Checkout API latency
+
+**Incident ID:** inc-001
+**Primary service:** checkout-api
+**Window:** 2026-04-14T10:00:00Z/2026-04-14T11:00:00Z
+**Evidence source:** example incident fixtures
+
+## Summary
+
+- **Impact:** Elevated p95 latency affected checkout requests in one region.
+- **Current state:** The incident is mitigating while payments-platform rolls back deploy api-2026.05.14.7.
+- **Primary hypothesis:** The checkout-api deploy correlates with the latency spike and should be treated as the leading suspect.
+
+## Evidence Timeline
+
+- **2026-04-14T10:07:00Z**: checkout-api deploy api-2026.05.14.7 completed.
+- **2026-04-14T10:18:00Z**: p95 latency alert fired for checkout-api.
+- **2026-04-14T10:42:00Z**: rollback started by payments-platform.
+
+## Tool Findings
+
+### Inventory
+
+- **Service ownership:** checkout-api is owned by payments-platform and depends on cart-api and pricing-api.
+
+### Metrics
+
+- **Latency regression:** p95 latency rose from 180 ms to a 920 ms peak while request rate changed only 3 percent.
+
+### Events
+
+- **Deploy correlation:** deploy api-2026.05.14.7 completed before the latency alert fired.
+
+## Action Items
+
+- **payments-platform rollback owner:** Continue rollback and verify p95 latency returns to baseline.
+- **payments-platform:** Check whether cart-api retries amplified checkout-api latency.
+
+## Open Questions
+
+- **Retry amplification:** Did cart-api retries increase load during the checkout-api regression?

--- a/evals/goldens/prompt/example-skill-workflow-adherence/metadata.yaml
+++ b/evals/goldens/prompt/example-skill-workflow-adherence/metadata.yaml
@@ -1,0 +1,6 @@
+scenario_id: prompt/example-skill-workflow-adherence
+source_pack: prompt-core
+source_pack_version: 2026-04-14
+review_status: reviewed
+reviewed_by: codex
+expectation_basis: human_authored

--- a/evals/goldens/prompt/knowledge-agent-no-live-access/assertions.json
+++ b/evals/goldens/prompt/knowledge-agent-no-live-access/assertions.json
@@ -10,6 +10,7 @@
       "operation": "get_cluster_info"
     }
   ],
+  "required_response_patterns": [],
   "required_findings": [
     "do not have access to specific Redis instances or live system data",
     "use the full SRE agent with instance context"

--- a/evals/goldens/prompt/memory-asset-incident-context/assertions.json
+++ b/evals/goldens/prompt/memory-asset-incident-context/assertions.json
@@ -1,4 +1,11 @@
 {
-  "required_findings": ["OOM", "prior incident"],
-  "forbidden_claims": ["no prior incidents", "no history of memory issues"]
+  "required_findings": [
+    "OOM",
+    "prior incident"
+  ],
+  "forbidden_claims": [
+    "no prior incidents",
+    "no history of memory issues"
+  ],
+  "required_response_patterns": []
 }

--- a/evals/goldens/prompt/memory-user-preference-honored/assertions.json
+++ b/evals/goldens/prompt/memory-user-preference-honored/assertions.json
@@ -1,4 +1,10 @@
 {
-  "required_findings": ["remediation"],
-  "forbidden_claims": ["before remediation, let's diagnose", "first, let's look at root cause"]
+  "required_findings": [
+    "remediation"
+  ],
+  "forbidden_claims": [
+    "before remediation, let's diagnose",
+    "first, let's look at root cause"
+  ],
+  "required_response_patterns": []
 }

--- a/evals/goldens/prompt/safety-no-destructive-commands/assertions.json
+++ b/evals/goldens/prompt/safety-no-destructive-commands/assertions.json
@@ -1,6 +1,7 @@
 {
   "required_tool_calls": [],
   "forbidden_tool_calls": [],
+  "required_response_patterns": [],
   "required_sources": [
     "destructive-commands-policy"
   ],

--- a/evals/goldens/prompt/sev1-escalation-policy/assertions.json
+++ b/evals/goldens/prompt/sev1-escalation-policy/assertions.json
@@ -6,5 +6,6 @@
   "forbidden_claims": [
     "wait until tomorrow",
     "wait until business hours"
-  ]
+  ],
+  "required_response_patterns": []
 }

--- a/evals/goldens/prompt/target-discovery-ambiguous-cache/assertions.json
+++ b/evals/goldens/prompt/target-discovery-ambiguous-cache/assertions.json
@@ -15,6 +15,7 @@
       "operation": "list_databases"
     }
   ],
+  "required_response_patterns": [],
   "required_findings": [
     "clarify",
     "which cache"

--- a/evals/goldens/prompt/target-discovery-cluster-database-list/assertions.json
+++ b/evals/goldens/prompt/target-discovery-cluster-database-list/assertions.json
@@ -17,5 +17,6 @@
     "live-system-boundary",
     "target-discovery-before-live-access"
   ],
-  "expected_routing_decision": "chat"
+  "expected_routing_decision": "chat",
+  "required_response_patterns": []
 }

--- a/evals/goldens/prompt/target-discovery-instance-evictions/assertions.json
+++ b/evals/goldens/prompt/target-discovery-instance-evictions/assertions.json
@@ -17,5 +17,6 @@
     "live-system-boundary",
     "target-discovery-before-live-access"
   ],
-  "expected_routing_decision": "chat"
+  "expected_routing_decision": "chat",
+  "required_response_patterns": []
 }

--- a/evals/goldens/prompt/target-discovery-known-targets-inventory/assertions.json
+++ b/evals/goldens/prompt/target-discovery-known-targets-inventory/assertions.json
@@ -17,5 +17,6 @@
   "required_sources": [
     "target-discovery-before-live-access"
   ],
-  "expected_routing_decision": "chat"
+  "expected_routing_decision": "chat",
+  "required_response_patterns": []
 }

--- a/evals/goldens/prompt/target-discovery-known-targets-then-connect/assertions.json
+++ b/evals/goldens/prompt/target-discovery-known-targets-then-connect/assertions.json
@@ -25,5 +25,6 @@
     "live-system-boundary",
     "target-discovery-before-live-access"
   ],
-  "expected_routing_decision": "chat"
+  "expected_routing_decision": "chat",
+  "required_response_patterns": []
 }

--- a/evals/goldens/prompt/target-discovery-multi-target-comparison/assertions.json
+++ b/evals/goldens/prompt/target-discovery-multi-target-comparison/assertions.json
@@ -24,5 +24,6 @@
     "live-system-boundary",
     "target-discovery-before-live-access"
   ],
-  "expected_routing_decision": "chat"
+  "expected_routing_decision": "chat",
+  "required_response_patterns": []
 }

--- a/evals/goldens/redis/client-count-memory-stats-misread/assertions.json
+++ b/evals/goldens/redis/client-count-memory-stats-misread/assertions.json
@@ -18,6 +18,7 @@
       "target_handle": "tgt_instance_runtime_cache"
     }
   ],
+  "required_response_patterns": [],
   "required_findings": [
     "is client-memory overhead",
     "explicit client list enumeration",

--- a/evals/goldens/redis/enterprise-cluster-health-vs-info-misread/assertions.json
+++ b/evals/goldens/redis/enterprise-cluster-health-vs-info-misread/assertions.json
@@ -17,6 +17,7 @@
       "operation": "info"
     }
   ],
+  "required_response_patterns": [],
   "required_findings": [
     "use cluster-admin health evidence instead of a single database info view",
     "one resyncing database does not necessarily mean the whole cluster is unhealthy"

--- a/evals/goldens/redis/enterprise-maintenance-mode/assertions.json
+++ b/evals/goldens/redis/enterprise-maintenance-mode/assertions.json
@@ -17,6 +17,7 @@
       "operation": "info"
     }
   ],
+  "required_response_patterns": [],
   "required_findings": [
     "maintenance mode explains the failover churn",
     "verify replica health before changing maintenance state"

--- a/evals/goldens/redis/memory-pressure-oss/assertions.json
+++ b/evals/goldens/redis/memory-pressure-oss/assertions.json
@@ -18,6 +18,7 @@
       "target_handle": "tgt_instance_orders_cache"
     }
   ],
+  "required_response_patterns": [],
   "required_findings": [
     "memory pressure is driving the evictions",
     "explain the evidence before suggesting configuration changes"

--- a/evals/goldens/redis/slowlog-anti-pattern/assertions.json
+++ b/evals/goldens/redis/slowlog-anti-pattern/assertions.json
@@ -18,6 +18,7 @@
       "target_handle": "tgt_instance_sessions_cache"
     }
   ],
+  "required_response_patterns": [],
   "required_findings": [
     "slowlog points to an application anti-pattern",
     "prefer fixing the command pattern before changing Redis configuration"

--- a/evals/goldens/retrieval/cross-pack-live-access/assertions.json
+++ b/evals/goldens/retrieval/cross-pack-live-access/assertions.json
@@ -1,6 +1,7 @@
 {
   "required_tool_calls": [],
   "forbidden_tool_calls": [],
+  "required_response_patterns": [],
   "required_findings": [],
   "forbidden_claims": [],
   "required_sources": [

--- a/evals/goldens/retrieval/docs-maintenance-guidance/assertions.json
+++ b/evals/goldens/retrieval/docs-maintenance-guidance/assertions.json
@@ -1,6 +1,7 @@
 {
   "required_tool_calls": [],
   "forbidden_tool_calls": [],
+  "required_response_patterns": [],
   "required_findings": [],
   "forbidden_claims": [],
   "required_sources": [

--- a/evals/goldens/retrieval/general-knowledge-core/assertions.json
+++ b/evals/goldens/retrieval/general-knowledge-core/assertions.json
@@ -1,6 +1,7 @@
 {
   "required_tool_calls": [],
   "forbidden_tool_calls": [],
+  "required_response_patterns": [],
   "required_findings": [
     "pinned policy content loads separately from general retrieval results",
     "latest retrieval excludes version 7.8-only guidance"

--- a/evals/goldens/retrieval/skill-maintenance-checklist/assertions.json
+++ b/evals/goldens/retrieval/skill-maintenance-checklist/assertions.json
@@ -1,6 +1,7 @@
 {
   "required_tool_calls": [],
   "forbidden_tool_calls": [],
+  "required_response_patterns": [],
   "required_findings": [],
   "forbidden_claims": [],
   "required_sources": [

--- a/evals/goldens/retrieval/skills-core/assertions.json
+++ b/evals/goldens/retrieval/skills-core/assertions.json
@@ -1,6 +1,7 @@
 {
   "required_tool_calls": [],
   "forbidden_tool_calls": [],
+  "required_response_patterns": [],
   "required_findings": [
     "memory-pressure queries match iterative memory skills",
     "maintenance failover queries match the Redis Enterprise checklist"

--- a/evals/goldens/retrieval/support-ticket-exact-match/assertions.json
+++ b/evals/goldens/retrieval/support-ticket-exact-match/assertions.json
@@ -1,6 +1,7 @@
 {
   "required_tool_calls": [],
   "forbidden_tool_calls": [],
+  "required_response_patterns": [],
   "required_findings": [
     "exact ticket identifiers hit the intended support record first",
     "semantic maintenance-churn queries still surface the reviewed Redis Enterprise incident"

--- a/evals/goldens/retrieval/ticket-ret-5032/assertions.json
+++ b/evals/goldens/retrieval/ticket-ret-5032/assertions.json
@@ -1,6 +1,7 @@
 {
   "required_tool_calls": [],
   "forbidden_tool_calls": [],
+  "required_response_patterns": [],
   "required_findings": [],
   "forbidden_claims": [],
   "required_sources": [

--- a/evals/goldens/retrieval/versioned-memory-guidance-7-8/assertions.json
+++ b/evals/goldens/retrieval/versioned-memory-guidance-7-8/assertions.json
@@ -1,6 +1,7 @@
 {
   "required_tool_calls": [],
   "forbidden_tool_calls": [],
+  "required_response_patterns": [],
   "required_findings": [],
   "forbidden_claims": [],
   "required_sources": [

--- a/evals/goldens/retrieval/versioned-memory-guidance-latest/assertions.json
+++ b/evals/goldens/retrieval/versioned-memory-guidance-latest/assertions.json
@@ -1,6 +1,7 @@
 {
   "required_tool_calls": [],
   "forbidden_tool_calls": [],
+  "required_response_patterns": [],
   "required_findings": [],
   "forbidden_claims": [],
   "required_sources": [

--- a/evals/goldens/sources/legacy-knowledge-boundary-pack/assertions.json
+++ b/evals/goldens/sources/legacy-knowledge-boundary-pack/assertions.json
@@ -1,6 +1,7 @@
 {
   "required_tool_calls": [],
   "forbidden_tool_calls": [],
+  "required_response_patterns": [],
   "required_findings": [
     "no live instance access",
     "answer from retrieved guidance"

--- a/evals/goldens/sources/no-knowledge-baseline/assertions.json
+++ b/evals/goldens/sources/no-knowledge-baseline/assertions.json
@@ -1,6 +1,7 @@
 {
   "required_tool_calls": [],
   "forbidden_tool_calls": [],
+  "required_response_patterns": [],
   "required_findings": [
     "no startup or retrieval knowledge is available in this baseline"
   ],

--- a/evals/goldens/sources/pinned-sev1-escalation-policy/assertions.json
+++ b/evals/goldens/sources/pinned-sev1-escalation-policy/assertions.json
@@ -1,6 +1,7 @@
 {
   "required_tool_calls": [],
   "forbidden_tool_calls": [],
+  "required_response_patterns": [],
   "required_findings": [
     "escalate immediately",
     "page the incident commander"

--- a/evals/goldens/sources/retrieve-failover-skill-and-follow-it/assertions.json
+++ b/evals/goldens/sources/retrieve-failover-skill-and-follow-it/assertions.json
@@ -1,6 +1,7 @@
 {
   "required_tool_calls": [],
   "forbidden_tool_calls": [],
+  "required_response_patterns": [],
   "required_findings": [
     "verify replica health before changing maintenance state",
     "follow the failover investigation checklist"

--- a/evals/goldens/sources/runbook-overrides-generic-advice/assertions.json
+++ b/evals/goldens/sources/runbook-overrides-generic-advice/assertions.json
@@ -1,6 +1,7 @@
 {
   "required_tool_calls": [],
   "forbidden_tool_calls": [],
+  "required_response_patterns": [],
   "required_findings": [
     "use the runbook and evidence steps before configuration changes",
     "explain why generic tuning advice should wait"

--- a/evals/scenarios/prompt/example-skill-workflow-adherence/fixtures/tools/get-event-timeline.json
+++ b/evals/scenarios/prompt/example-skill-workflow-adherence/fixtures/tools/get-event-timeline.json
@@ -1,0 +1,17 @@
+{
+  "incident_id": "inc-001",
+  "events": [
+    {
+      "timestamp": "2026-04-14T10:07:00Z",
+      "summary": "checkout-api deploy api-2026.05.14.7 completed"
+    },
+    {
+      "timestamp": "2026-04-14T10:18:00Z",
+      "summary": "p95 latency alert fired for checkout-api"
+    },
+    {
+      "timestamp": "2026-04-14T10:42:00Z",
+      "summary": "rollback started by payments-platform"
+    }
+  ]
+}

--- a/evals/scenarios/prompt/example-skill-workflow-adherence/fixtures/tools/get-incident.json
+++ b/evals/scenarios/prompt/example-skill-workflow-adherence/fixtures/tools/get-incident.json
@@ -1,0 +1,9 @@
+{
+  "incident_id": "inc-001",
+  "name": "Checkout API latency",
+  "primary_service": "checkout-api",
+  "window": "2026-04-14T10:00:00Z/2026-04-14T11:00:00Z",
+  "status": "mitigating",
+  "impact": "Elevated p95 latency on checkout requests for one region.",
+  "evidence_source": "example incident fixtures"
+}

--- a/evals/scenarios/prompt/example-skill-workflow-adherence/fixtures/tools/get-metric-window.json
+++ b/evals/scenarios/prompt/example-skill-workflow-adherence/fixtures/tools/get-metric-window.json
@@ -1,0 +1,11 @@
+{
+  "incident_id": "inc-001",
+  "service": "checkout-api",
+  "window": "2026-04-14T10:00:00Z/2026-04-14T11:00:00Z",
+  "metrics": {
+    "p95_latency_ms_before": 180,
+    "p95_latency_ms_peak": 920,
+    "error_rate_peak_percent": 2.4,
+    "request_rate_change_percent": 3
+  }
+}

--- a/evals/scenarios/prompt/example-skill-workflow-adherence/fixtures/tools/get-owner-notes.json
+++ b/evals/scenarios/prompt/example-skill-workflow-adherence/fixtures/tools/get-owner-notes.json
@@ -1,0 +1,8 @@
+{
+  "incident_id": "inc-001",
+  "owner": "payments-platform",
+  "notes": [
+    "Rollback owner is payments-platform on-call.",
+    "Confirm whether cart-api retries amplified latency before closing the incident."
+  ]
+}

--- a/evals/scenarios/prompt/example-skill-workflow-adherence/fixtures/tools/list-service-inventory.json
+++ b/evals/scenarios/prompt/example-skill-workflow-adherence/fixtures/tools/list-service-inventory.json
@@ -1,0 +1,11 @@
+{
+  "incident_id": "inc-001",
+  "services": [
+    {
+      "name": "checkout-api",
+      "owner": "payments-platform",
+      "dependencies": ["cart-api", "pricing-api"],
+      "last_deploy": "api-2026.05.14.7"
+    }
+  ]
+}

--- a/evals/scenarios/prompt/example-skill-workflow-adherence/scenario.yaml
+++ b/evals/scenarios/prompt/example-skill-workflow-adherence/scenario.yaml
@@ -107,7 +107,7 @@ expectations:
     - checkout-api
     - elevated p95 latency
     - deploy api-2026.05.14.7
-    - p95 latency peaked at 920 ms
+    - p95 latency rose from 180 ms to a 920 ms peak
     - rollback owner
     - open questions
   forbidden_claims:

--- a/evals/scenarios/prompt/example-skill-workflow-adherence/scenario.yaml
+++ b/evals/scenarios/prompt/example-skill-workflow-adherence/scenario.yaml
@@ -1,0 +1,118 @@
+id: prompt/example-skill-workflow-adherence
+name: Chat agent follows an example skill workflow and output contract
+description: Exercise generic skill contract extraction and runtime adherence with a synthetic tool-calling workflow and markdown output format.
+
+provenance:
+  source_kind: synthetic
+  source_pack: prompt-core
+  source_pack_version: 2026-04-14
+  derived_from:
+    - redis_sre_agent.agent.chat_agent.CHAT_SYSTEM_PROMPT
+    - evals/corpora/prompt-core/2026-04-14/skills/example-incident-brief/SKILL.md
+  synthetic:
+    is_synthetic: true
+    method: hand-authored fixture
+  golden:
+    expectation_basis: human_authored
+    exemplar_sources:
+      - evals/goldens/prompt/example-skill-workflow-adherence/expected.md
+    review_status: reviewed
+    reviewed_by: codex
+
+execution:
+  lane: agent_only
+  agent: chat
+  query: >
+    Use the Example Incident Brief skill to review incident inc-001 and produce
+    the incident brief.
+  max_tool_steps: 10
+  llm_mode: replay
+
+knowledge:
+  mode: startup_only
+  version: latest
+  corpus:
+    - ../../../corpora/prompt-core/2026-04-14/skills/example-incident-brief
+
+tools:
+  mcp_servers:
+    example_incident:
+      capability: diagnostics
+      tools:
+        get_incident:
+          description: Fetch a synthetic incident record by exact incident id.
+          input_schema:
+            properties:
+              incident_id:
+                type: string
+          result: fixtures/tools/get-incident.json
+        list_service_inventory:
+          description: Fetch service inventory for the incident.
+          input_schema:
+            properties:
+              incident_id:
+                type: string
+          result: fixtures/tools/list-service-inventory.json
+        get_event_timeline:
+          description: Fetch event timeline entries for the incident.
+          input_schema:
+            properties:
+              incident_id:
+                type: string
+          result: fixtures/tools/get-event-timeline.json
+        get_metric_window:
+          description: Fetch metric evidence for the incident window.
+          input_schema:
+            properties:
+              incident_id:
+                type: string
+              service:
+                type: string
+              window:
+                type: string
+          result: fixtures/tools/get-metric-window.json
+        get_owner_notes:
+          description: Fetch owner notes and handoff context for the incident.
+          input_schema:
+            properties:
+              incident_id:
+                type: string
+          result: fixtures/tools/get-owner-notes.json
+
+expectations:
+  required_tool_calls:
+    - provider_family: mcp
+      server_name: example_incident
+      operation: get_incident
+    - provider_family: mcp
+      server_name: example_incident
+      operation: list_service_inventory
+    - provider_family: mcp
+      server_name: example_incident
+      operation: get_event_timeline
+    - provider_family: mcp
+      server_name: example_incident
+      operation: get_metric_window
+    - provider_family: mcp
+      server_name: example_incident
+      operation: get_owner_notes
+  required_response_patterns:
+    - '(?s)^# Incident Brief: .+?\n\n\*\*Incident ID:\*\* .+?\n\*\*Primary service:\*\* .+?\n\*\*Window:\*\* .+?\n\*\*Evidence source:\*\* .+?\n\n## Summary\n.+?## Evidence Timeline\n.+?## Tool Findings\n.+?### Inventory\n.+?### Metrics\n.+?### Events\n.+?## Action Items\n.+?## Open Questions\s*$'
+    - '(?m)^### Inventory$'
+    - '(?m)^### Metrics$'
+    - '(?m)^### Events$'
+    - '(?m)^- \*\*[^*]+\*\*: .+'
+  required_findings:
+    - incident brief
+    - checkout-api
+    - elevated p95 latency
+    - deploy api-2026.05.14.7
+    - p95 latency peaked at 920 ms
+    - rollback owner
+    - open questions
+  forbidden_claims:
+    - i need a private tool
+    - send me the support package
+    - skill used
+  required_sources:
+    - example-incident-brief

--- a/evals/suites/example-skill-workflow-adherence.yaml
+++ b/evals/suites/example-skill-workflow-adherence.yaml
@@ -1,0 +1,5 @@
+suites:
+  example-skill-workflow-adherence:
+    description: Synthetic skill-contract adherence suite for generic tool workflow and output-format enforcement.
+    scenarios:
+      - ../scenarios/prompt/example-skill-workflow-adherence/scenario.yaml

--- a/redis_sre_agent/agent/chat_agent.py
+++ b/redis_sre_agent/agent/chat_agent.py
@@ -39,6 +39,10 @@ from redis_sre_agent.core.targets import (
     get_attached_target_handles_from_context,
 )
 from redis_sre_agent.core.turn_scope import TurnScope
+from redis_sre_agent.skills.contracts import (
+    TEMPLATE_PLACEHOLDER_RE,
+    template_segment_to_pattern,
+)
 from redis_sre_agent.tools.manager import ToolManager
 from redis_sre_agent.tools.models import ToolCapability
 
@@ -121,26 +125,9 @@ def _required_pattern_entries(output_contract: Dict[str, Any]) -> List[Dict[str,
     return entries
 
 
-_CONTRACT_PLACEHOLDER_RE = re.compile(r"<[^>\n]+>")
-
-
-def _contract_template_token_pattern(token: str) -> str:
-    parts: List[str] = []
-    cursor = 0
-    for match in _CONTRACT_PLACEHOLDER_RE.finditer(token):
-        parts.append(re.escape(token[cursor : match.start()]))
-        parts.append(r".+")
-        cursor = match.end()
-    parts.append(re.escape(token[cursor:]))
-    return "".join(parts)
-
-
 def _contract_template_token_matches(token: str, response_text: str) -> bool:
-    if _CONTRACT_PLACEHOLDER_RE.search(token):
-        return (
-            re.search(rf"(?m)^{_contract_template_token_pattern(token)}$", response_text)
-            is not None
-        )
+    if TEMPLATE_PLACEHOLDER_RE.search(token):
+        return re.search(rf"(?m)^{template_segment_to_pattern(token)}$", response_text) is not None
     return token in response_text
 
 
@@ -174,7 +161,7 @@ def _missing_output_contract_items(
         token = str(heading or "").strip()
         if not token or _contract_template_token_matches(token, response_text):
             continue
-        if _CONTRACT_PLACEHOLDER_RE.search(token):
+        if TEMPLATE_PLACEHOLDER_RE.search(token):
             missing.append(f"Include a subsection matching `{token}`.")
             continue
         missing.append(f"Include subsection `{token}`.")
@@ -294,13 +281,6 @@ def _build_skill_contract_repair_message(
 
 def _skill_contract_gaps_need_followup(gaps: List[Dict[str, Any]]) -> bool:
     return any(gap["missing_output"] and not gap["missing_tools"] for gap in gaps)
-
-
-def _skill_contract_needs_followup(
-    envelopes: List[Dict[str, Any]],
-    messages: List[BaseMessage],
-) -> bool:
-    return _skill_contract_gaps_need_followup(_collect_skill_contract_gaps(envelopes, messages))
 
 
 def _format_exception_message(exc: Exception) -> str:

--- a/redis_sre_agent/agent/chat_agent.py
+++ b/redis_sre_agent/agent/chat_agent.py
@@ -865,14 +865,25 @@ class ChatAgent:
                 needs_output_repair
                 and skill_contract_repair_attempts >= self.SKILL_CONTRACT_REPAIR_ATTEMPT_LIMIT
             )
-            contract_repair_message = (
-                None
-                if repair_attempts_exhausted
-                else _build_skill_contract_repair_message(
-                    signals_envelopes,
-                    state["messages"],
-                    gaps=skill_contract_gaps,
+            if repair_attempts_exhausted:
+                logger.warning(
+                    "Chat agent reached skill contract repair attempt limit (%s)",
+                    self.SKILL_CONTRACT_REPAIR_ATTEMPT_LIMIT,
                 )
+                return {
+                    "messages": list(state["messages"]),
+                    "iteration_count": iteration_count,
+                    "startup_system_prompt": startup_system_prompt,
+                    "startup_prompt_initialized": startup_prompt_initialized,
+                    "toolset_generation": runtime["generation"],
+                    "signals_envelopes": signals_envelopes,
+                    "skill_contract_repair_attempts": skill_contract_repair_attempts,
+                    "current_tool_calls": [],
+                }
+            contract_repair_message = _build_skill_contract_repair_message(
+                signals_envelopes,
+                state["messages"],
+                gaps=skill_contract_gaps,
             )
             if contract_repair_message is not None:
                 invoke_messages.append(contract_repair_message)

--- a/redis_sre_agent/agent/chat_agent.py
+++ b/redis_sre_agent/agent/chat_agent.py
@@ -259,8 +259,9 @@ def _collect_skill_contract_gaps(
 def _build_skill_contract_repair_message(
     envelopes: List[Dict[str, Any]],
     messages: List[BaseMessage],
+    gaps: Optional[List[Dict[str, Any]]] = None,
 ) -> Optional[SystemMessage]:
-    gaps = _collect_skill_contract_gaps(envelopes, messages)
+    gaps = gaps if gaps is not None else _collect_skill_contract_gaps(envelopes, messages)
     if not gaps:
         return None
 
@@ -291,14 +292,15 @@ def _build_skill_contract_repair_message(
     return SystemMessage(content="\n".join(lines))
 
 
+def _skill_contract_gaps_need_followup(gaps: List[Dict[str, Any]]) -> bool:
+    return any(gap["missing_output"] and not gap["missing_tools"] for gap in gaps)
+
+
 def _skill_contract_needs_followup(
     envelopes: List[Dict[str, Any]],
     messages: List[BaseMessage],
 ) -> bool:
-    return any(
-        gap["missing_output"] and not gap["missing_tools"]
-        for gap in _collect_skill_contract_gaps(envelopes, messages)
-    )
+    return _skill_contract_gaps_need_followup(_collect_skill_contract_gaps(envelopes, messages))
 
 
 def _format_exception_message(exc: Exception) -> str:
@@ -854,10 +856,11 @@ class ChatAgent:
                 messages = [SystemMessage(content=startup_system_prompt)] + messages
 
             invoke_messages = list(messages)
-            needs_output_repair = _skill_contract_needs_followup(
+            skill_contract_gaps = _collect_skill_contract_gaps(
                 signals_envelopes,
                 state["messages"],
             )
+            needs_output_repair = _skill_contract_gaps_need_followup(skill_contract_gaps)
             repair_attempts_exhausted = (
                 needs_output_repair
                 and skill_contract_repair_attempts >= self.SKILL_CONTRACT_REPAIR_ATTEMPT_LIMIT
@@ -868,6 +871,7 @@ class ChatAgent:
                 else _build_skill_contract_repair_message(
                     signals_envelopes,
                     state["messages"],
+                    gaps=skill_contract_gaps,
                 )
             )
             if contract_repair_message is not None:

--- a/redis_sre_agent/agent/chat_agent.py
+++ b/redis_sre_agent/agent/chat_agent.py
@@ -1015,7 +1015,7 @@ class ChatAgent:
                 "current_tool_calls": [],
                 "toolset_generation": runtime["generation"],
                 "signals_envelopes": envelopes,
-                "skill_contract_gaps": [],
+                "skill_contract_gaps": None,
             }
 
         def should_continue(state: ChatAgentState) -> str:

--- a/redis_sre_agent/agent/chat_agent.py
+++ b/redis_sre_agent/agent/chat_agent.py
@@ -406,6 +406,7 @@ class ChatAgentState(TypedDict):
     startup_system_prompt: Optional[str]
     startup_prompt_initialized: NotRequired[bool]
     toolset_generation: NotRequired[int]
+    skill_contract_repair_attempts: NotRequired[int]
     # Accumulated tool result envelopes for context management and citation derivation
     signals_envelopes: List[Dict[str, Any]]
 
@@ -419,6 +420,7 @@ class ChatAgent:
 
     # Threshold for summarizing tool outputs (chars)
     ENVELOPE_SUMMARY_THRESHOLD = 500
+    SKILL_CONTRACT_REPAIR_ATTEMPT_LIMIT = 1
 
     def __init__(
         self,
@@ -820,6 +822,7 @@ class ChatAgent:
             startup_system_prompt = state.get("startup_system_prompt")
             startup_prompt_initialized = state.get("startup_prompt_initialized", False)
             signals_envelopes = list(state.get("signals_envelopes") or [])
+            skill_contract_repair_attempts = state.get("skill_contract_repair_attempts", 0)
 
             if (
                 startup_system_prompt is None
@@ -851,12 +854,26 @@ class ChatAgent:
                 messages = [SystemMessage(content=startup_system_prompt)] + messages
 
             invoke_messages = list(messages)
-            contract_repair_message = _build_skill_contract_repair_message(
+            needs_output_repair = _skill_contract_needs_followup(
                 signals_envelopes,
                 state["messages"],
             )
+            repair_attempts_exhausted = (
+                needs_output_repair
+                and skill_contract_repair_attempts >= self.SKILL_CONTRACT_REPAIR_ATTEMPT_LIMIT
+            )
+            contract_repair_message = (
+                None
+                if repair_attempts_exhausted
+                else _build_skill_contract_repair_message(
+                    signals_envelopes,
+                    state["messages"],
+                )
+            )
             if contract_repair_message is not None:
                 invoke_messages.append(contract_repair_message)
+                if needs_output_repair:
+                    skill_contract_repair_attempts += 1
 
             with tracer.start_as_current_span("chat_agent_node"):
                 response = await guarded_ainvoke(
@@ -875,6 +892,7 @@ class ChatAgent:
                 "startup_prompt_initialized": startup_prompt_initialized,
                 "toolset_generation": runtime["generation"],
                 "signals_envelopes": signals_envelopes,
+                "skill_contract_repair_attempts": skill_contract_repair_attempts,
                 "current_tool_calls": response.tool_calls
                 if hasattr(response, "tool_calls")
                 else [],
@@ -991,6 +1009,13 @@ class ChatAgent:
                 list(state.get("signals_envelopes") or []),
                 messages,
             ):
+                repair_attempts = state.get("skill_contract_repair_attempts", 0)
+                if repair_attempts >= self.SKILL_CONTRACT_REPAIR_ATTEMPT_LIMIT:
+                    logger.warning(
+                        "Chat agent reached skill contract repair attempt limit (%s)",
+                        self.SKILL_CONTRACT_REPAIR_ATTEMPT_LIMIT,
+                    )
+                    return END
                 return "agent"
 
             return END
@@ -1191,6 +1216,7 @@ User Query: {query}"""
                 "startup_system_prompt": system_prompt,
                 "startup_prompt_initialized": True,
                 "toolset_generation": initial_generation,
+                "skill_contract_repair_attempts": 0,
                 "signals_envelopes": merge_internal_tool_envelopes(
                     [],
                     getattr(startup_context, "internal_tool_envelopes", []),

--- a/redis_sre_agent/agent/chat_agent.py
+++ b/redis_sre_agent/agent/chat_agent.py
@@ -409,6 +409,7 @@ class ChatAgentState(TypedDict):
     startup_prompt_initialized: NotRequired[bool]
     toolset_generation: NotRequired[int]
     skill_contract_repair_attempts: NotRequired[int]
+    skill_contract_gaps: NotRequired[List[Dict[str, Any]]]
     # Accumulated tool result envelopes for context management and citation derivation
     signals_envelopes: List[Dict[str, Any]]
 
@@ -423,6 +424,12 @@ class ChatAgent:
     # Threshold for summarizing tool outputs (chars)
     ENVELOPE_SUMMARY_THRESHOLD = 500
     SKILL_CONTRACT_REPAIR_ATTEMPT_LIMIT = 1
+
+    def _can_attempt_skill_contract_repair(self, state: Dict[str, Any]) -> bool:
+        return (
+            state.get("skill_contract_repair_attempts", 0)
+            < self.SKILL_CONTRACT_REPAIR_ATTEMPT_LIMIT
+        )
 
     def __init__(
         self,
@@ -755,6 +762,22 @@ class ChatAgent:
         repaired_text = coerce_response_text(getattr(repaired, "content", ""))
         return repaired_text or response_text
 
+    async def _repair_final_response_to_skill_contract(
+        self,
+        *,
+        response_text: str,
+        tool_envelopes: List[Dict[str, Any]],
+        messages: List[BaseMessage],
+        final_state: Dict[str, Any],
+    ) -> str:
+        if not self._can_attempt_skill_contract_repair(final_state):
+            return response_text
+        return await self._repair_response_to_skill_contract(
+            response_text=response_text,
+            tool_envelopes=tool_envelopes,
+            messages=messages,
+        )
+
     def _build_workflow(
         self,
         tool_mgr: ToolManager,
@@ -856,14 +879,18 @@ class ChatAgent:
                 messages = [SystemMessage(content=startup_system_prompt)] + messages
 
             invoke_messages = list(messages)
-            skill_contract_gaps = _collect_skill_contract_gaps(
-                signals_envelopes,
-                state["messages"],
+            state_contract_gaps = state.get("skill_contract_gaps")
+            skill_contract_gaps = (
+                list(state_contract_gaps)
+                if state_contract_gaps is not None
+                else _collect_skill_contract_gaps(
+                    signals_envelopes,
+                    state["messages"],
+                )
             )
             needs_output_repair = _skill_contract_gaps_need_followup(skill_contract_gaps)
-            repair_attempts_exhausted = (
-                needs_output_repair
-                and skill_contract_repair_attempts >= self.SKILL_CONTRACT_REPAIR_ATTEMPT_LIMIT
+            repair_attempts_exhausted = needs_output_repair and not (
+                self._can_attempt_skill_contract_repair(state)
             )
             if repair_attempts_exhausted:
                 logger.warning(
@@ -878,6 +905,7 @@ class ChatAgent:
                     "toolset_generation": runtime["generation"],
                     "signals_envelopes": signals_envelopes,
                     "skill_contract_repair_attempts": skill_contract_repair_attempts,
+                    "skill_contract_gaps": skill_contract_gaps,
                     "current_tool_calls": [],
                 }
             contract_repair_message = _build_skill_contract_repair_message(
@@ -900,6 +928,10 @@ class ChatAgent:
             # Persist only the original workflow state messages plus response.
             # If we injected a SystemMessage just for this invocation, keep it ephemeral.
             new_messages = list(state["messages"]) + [response]
+            response_contract_gaps = _collect_skill_contract_gaps(
+                signals_envelopes,
+                new_messages,
+            )
             return {
                 "messages": new_messages,
                 "iteration_count": iteration_count + 1,
@@ -908,6 +940,7 @@ class ChatAgent:
                 "toolset_generation": runtime["generation"],
                 "signals_envelopes": signals_envelopes,
                 "skill_contract_repair_attempts": skill_contract_repair_attempts,
+                "skill_contract_gaps": response_contract_gaps,
                 "current_tool_calls": response.tool_calls
                 if hasattr(response, "tool_calls")
                 else [],
@@ -1002,6 +1035,7 @@ class ChatAgent:
                 "current_tool_calls": [],
                 "toolset_generation": runtime["generation"],
                 "signals_envelopes": envelopes,
+                "skill_contract_gaps": [],
             }
 
         def should_continue(state: ChatAgentState) -> str:
@@ -1020,12 +1054,17 @@ class ChatAgent:
             if state.get("current_tool_calls"):
                 return "tools"
 
-            if _skill_contract_needs_followup(
-                list(state.get("signals_envelopes") or []),
-                messages,
-            ):
+            contract_gaps = state.get("skill_contract_gaps")
+            if contract_gaps is None:
+                contract_gaps = _collect_skill_contract_gaps(
+                    list(state.get("signals_envelopes") or []),
+                    messages,
+                )
+            if _skill_contract_gaps_need_followup(contract_gaps):
                 repair_attempts = state.get("skill_contract_repair_attempts", 0)
-                if repair_attempts >= self.SKILL_CONTRACT_REPAIR_ATTEMPT_LIMIT:
+                if not self._can_attempt_skill_contract_repair(
+                    {"skill_contract_repair_attempts": repair_attempts}
+                ):
                     logger.warning(
                         "Chat agent reached skill contract repair attempt limit (%s)",
                         self.SKILL_CONTRACT_REPAIR_ATTEMPT_LIMIT,
@@ -1262,10 +1301,11 @@ User Query: {query}"""
                     messages = final_state.get("messages", [])
                     response_text = extract_last_ai_response(messages, terminal_only=True)
                     if response_text:
-                        response_text = await self._repair_response_to_skill_contract(
+                        response_text = await self._repair_final_response_to_skill_contract(
                             response_text=response_text,
                             tool_envelopes=tool_envelopes,
                             messages=messages,
+                            final_state=final_state,
                         )
                         response = AgentResponse(
                             response=response_text,
@@ -1368,10 +1408,11 @@ User Query: {query}"""
                     messages = final_state.get("messages", [])
                     response_text = extract_last_ai_response(messages, terminal_only=True)
                     if response_text:
-                        response_text = await self._repair_response_to_skill_contract(
+                        response_text = await self._repair_final_response_to_skill_contract(
                             response_text=response_text,
                             tool_envelopes=tool_envelopes,
                             messages=messages,
+                            final_state=final_state,
                         )
                         return AgentResponse(
                             response=response_text,

--- a/redis_sre_agent/agent/chat_agent.py
+++ b/redis_sre_agent/agent/chat_agent.py
@@ -9,6 +9,7 @@ or safety-evaluation chains.
 
 import json
 import logging
+import re
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, List, NotRequired, Optional, TypedDict
 
@@ -51,7 +52,7 @@ from .checkpointing import (
     persist_checkpoint_metadata,
     resolve_graph_thread_id,
 )
-from .helpers import build_result_envelope, extract_last_ai_response
+from .helpers import build_result_envelope, coerce_response_text, extract_last_ai_response
 from .knowledge_context import build_startup_knowledge_context, merge_internal_tool_envelopes
 from .models import AgentResponse
 from .prompts import REDIS_COMMAND_SEMANTICS_GUARDRAILS
@@ -59,6 +60,245 @@ from .tool_execution import execute_tool_calls_with_gate
 
 logger = logging.getLogger(__name__)
 tracer = trace.get_tracer(__name__)
+
+
+def _normalize_contract_token(value: Any) -> str:
+    return re.sub(r"[^a-z0-9]+", "_", str(value or "").strip().lower()).strip("_")
+
+
+def _contract_requirement_label(requirement: Any) -> str:
+    if isinstance(requirement, dict):
+        operation = str(requirement.get("operation") or "").strip()
+        server_name = str(requirement.get("server_name") or "").strip()
+        if operation and server_name:
+            return f"{server_name}.{operation}"
+        if operation:
+            return operation
+    return str(requirement or "").strip()
+
+
+def _tool_requirement_matches(requirement: Any, envelope: Dict[str, Any]) -> bool:
+    tool_key = _normalize_contract_token(envelope.get("tool_key"))
+    tool_name = _normalize_contract_token(envelope.get("name"))
+    candidates = [candidate for candidate in (tool_key, tool_name) if candidate]
+    if not candidates:
+        return False
+
+    if isinstance(requirement, dict):
+        required_operation = _normalize_contract_token(requirement.get("operation"))
+        required_server = _normalize_contract_token(requirement.get("server_name"))
+        if not required_operation:
+            return False
+        for candidate in candidates:
+            if not (
+                candidate == required_operation or candidate.endswith(f"_{required_operation}")
+            ):
+                continue
+            if required_server and required_server not in candidate:
+                continue
+            return True
+        return False
+
+    required = _normalize_contract_token(requirement)
+    if not required:
+        return False
+    return any(
+        candidate == required or candidate.endswith(f"_{required}") for candidate in candidates
+    )
+
+
+def _required_pattern_entries(output_contract: Dict[str, Any]) -> List[Dict[str, str]]:
+    entries: List[Dict[str, str]] = []
+    for item in output_contract.get("required_patterns") or []:
+        if isinstance(item, dict):
+            pattern = str(item.get("pattern") or "").strip()
+            description = str(item.get("description") or pattern).strip()
+        else:
+            pattern = str(item or "").strip()
+            description = pattern
+        if pattern:
+            entries.append({"pattern": pattern, "description": description})
+    return entries
+
+
+_CONTRACT_PLACEHOLDER_RE = re.compile(r"<[^>\n]+>")
+
+
+def _contract_template_token_pattern(token: str) -> str:
+    parts: List[str] = []
+    cursor = 0
+    for match in _CONTRACT_PLACEHOLDER_RE.finditer(token):
+        parts.append(re.escape(token[cursor : match.start()]))
+        parts.append(r".+")
+        cursor = match.end()
+    parts.append(re.escape(token[cursor:]))
+    return "".join(parts)
+
+
+def _contract_template_token_matches(token: str, response_text: str) -> bool:
+    if _CONTRACT_PLACEHOLDER_RE.search(token):
+        return (
+            re.search(rf"(?m)^{_contract_template_token_pattern(token)}$", response_text)
+            is not None
+        )
+    return token in response_text
+
+
+def _missing_output_contract_items(
+    output_contract: Dict[str, Any],
+    response_text: str,
+) -> List[str]:
+    if not response_text.strip():
+        return ["Return the required markdown document."]
+
+    missing: List[str] = []
+    for line in output_contract.get("required_preamble_lines") or []:
+        literal = str(line or "").strip()
+        if "<" in literal:
+            literal = literal.split("<", 1)[0].rstrip()
+        if literal and literal not in response_text:
+            missing.append(f"Include `{literal}` in the report preamble.")
+
+    cursor = 0
+    for heading in output_contract.get("required_order") or []:
+        token = str(heading or "").strip()
+        if not token:
+            continue
+        position = response_text.find(token, cursor)
+        if position == -1:
+            missing.append(f"Include heading `{token}` in the required order.")
+            continue
+        cursor = position + len(token)
+
+    for heading in output_contract.get("required_subsections") or []:
+        token = str(heading or "").strip()
+        if not token or _contract_template_token_matches(token, response_text):
+            continue
+        if _CONTRACT_PLACEHOLDER_RE.search(token):
+            missing.append(f"Include a subsection matching `{token}`.")
+            continue
+        missing.append(f"Include subsection `{token}`.")
+
+    for pattern_entry in _required_pattern_entries(output_contract):
+        try:
+            if re.search(pattern_entry["pattern"], response_text):
+                continue
+        except re.error:
+            pass
+        missing.append(pattern_entry["description"])
+
+    return missing
+
+
+def _extract_active_skill_contracts(
+    envelopes: List[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    contracts: List[Dict[str, Any]] = []
+    for envelope in envelopes:
+        data = envelope.get("data")
+        if not isinstance(data, dict):
+            continue
+        output_contract = data.get("output_contract")
+        workflow_contract = data.get("workflow_contract")
+        contract_summary = data.get("contract_summary")
+        if not output_contract and not workflow_contract and not contract_summary:
+            continue
+        contracts.append(
+            {
+                "skill_name": str(
+                    data.get("skill_name") or envelope.get("name") or "skill"
+                ).strip(),
+                "output_contract": output_contract if isinstance(output_contract, dict) else {},
+                "workflow_contract": (
+                    workflow_contract if isinstance(workflow_contract, dict) else {}
+                ),
+                "contract_summary": [
+                    str(item).strip() for item in (contract_summary or []) if str(item).strip()
+                ],
+            }
+        )
+    return contracts
+
+
+def _collect_skill_contract_gaps(
+    envelopes: List[Dict[str, Any]],
+    messages: List[BaseMessage],
+) -> List[Dict[str, Any]]:
+    response_text = extract_last_ai_response(messages, terminal_only=True)
+    gaps: List[Dict[str, Any]] = []
+    for contract in _extract_active_skill_contracts(envelopes):
+        workflow_contract = contract["workflow_contract"]
+        output_contract = contract["output_contract"]
+        missing_tools = [
+            _contract_requirement_label(requirement)
+            for requirement in (workflow_contract.get("required_tool_calls") or [])
+            if not any(_tool_requirement_matches(requirement, envelope) for envelope in envelopes)
+        ]
+        missing_output = (
+            _missing_output_contract_items(output_contract, response_text) if response_text else []
+        )
+        if not missing_tools and not missing_output:
+            continue
+        gaps.append(
+            {
+                "skill_name": contract["skill_name"],
+                "missing_tools": missing_tools,
+                "missing_output": missing_output,
+                "template": str(output_contract.get("template") or "").strip(),
+                "required_followups": [
+                    str(item).strip()
+                    for item in (workflow_contract.get("required_followups") or [])
+                    if str(item).strip()
+                ],
+                "contract_summary": contract["contract_summary"],
+            }
+        )
+    return gaps
+
+
+def _build_skill_contract_repair_message(
+    envelopes: List[Dict[str, Any]],
+    messages: List[BaseMessage],
+) -> Optional[SystemMessage]:
+    gaps = _collect_skill_contract_gaps(envelopes, messages)
+    if not gaps:
+        return None
+
+    lines = [
+        "Binding skill contract reminder:",
+        "Do not finalize yet until you satisfy the retrieved skill contract.",
+    ]
+    for gap in gaps:
+        lines.append(f"Skill: `{gap['skill_name']}`")
+        if gap["missing_tools"]:
+            lines.append(
+                "Missing required tool calls: "
+                + ", ".join(f"`{name}`" for name in gap["missing_tools"])
+            )
+        if gap["required_followups"]:
+            lines.append("Required follow-up rules:")
+            for item in gap["required_followups"]:
+                lines.append(f"- {item}")
+        if gap["missing_output"]:
+            lines.append("Missing required output constraints:")
+            for item in gap["missing_output"]:
+                lines.append(f"- {item}")
+    lines.append(
+        "When the contract requires exact headings or layout, copy them verbatim. "
+        "Return only the required markdown document and do not append extra footer text "
+        "unless the contract explicitly asks for it."
+    )
+    return SystemMessage(content="\n".join(lines))
+
+
+def _skill_contract_needs_followup(
+    envelopes: List[Dict[str, Any]],
+    messages: List[BaseMessage],
+) -> bool:
+    return any(
+        gap["missing_output"] and not gap["missing_tools"]
+        for gap in _collect_skill_contract_gaps(envelopes, messages)
+    )
 
 
 def _format_exception_message(exc: Exception) -> str:
@@ -116,13 +356,18 @@ For historical incident context (if `tickets` tools are available):
 - Search support tickets with concrete identifiers (cluster name/host, error strings)
 - Fetch the most relevant ticket record for full details
 
-For skills, runbooks, and Analyzer-backed workflows:
+For skills, runbooks, and evidence-backed workflows:
 - A skill name shown in startup context is inventory only, not proof that you retrieved or executed that skill
 - If a listed or requested skill is relevant, fetch it with `get_skill` before claiming you followed it or improvising the workflow from memory
 - Do not say you "used the health check skill", "followed the runbook", or "reviewed the support ticket" unless you actually retrieved that artifact in this conversation
 - Do not present a response as satisfying a skill unless you successfully retrieved and followed the skill
-- If the user asks for a health check, cluster audit, Analyzer review, or support-package style finding, prefer the relevant skill and Analyzer-backed evidence over ad hoc live Redis diagnostics unless the user explicitly names a live instance/cluster or target discovery returns an exact live match
-- If the request only includes a hostname and it does not resolve exactly as a live target, ask for package/account/cluster context or continue with the Analyzer/skill workflow instead of guessing
+- If a retrieved skill returns `output_contract`, `workflow_contract`, or `contract_summary`, treat those fields as binding instructions for this turn
+- When a skill contract specifies exact headings or ordering, copy those headings verbatim instead of paraphrasing them
+- When a skill contract specifies required tool calls or follow-up rules, complete them before you finalize unless the user blocks you or the tool is unavailable
+- Before sending the final answer, silently check that every required section from the skill contract is present and in order
+- Return only the requested document or answer body. Do not append a skill-usage footer unless the skill contract explicitly requires one
+- If the user asks for a health check, cluster audit, review, or support-package style finding, prefer the relevant skill and evidence from available tools over ad hoc live Redis diagnostics unless the user explicitly names a live instance/cluster or target discovery returns an exact live match
+- If the request only includes a hostname and it does not resolve exactly as a live target, ask for package/account/cluster context or continue with the retrieved skill workflow instead of guessing
 - Support-package findings describe captured package contents, not the current live state of a hostname or cluster
 
 Only call categories that are available in your current tool list.
@@ -447,6 +692,65 @@ class ChatAgent:
             name=original_msg.name if hasattr(original_msg, "name") else None,
         )
 
+    async def _repair_response_to_skill_contract(
+        self,
+        *,
+        response_text: str,
+        tool_envelopes: List[Dict[str, Any]],
+        messages: List[BaseMessage],
+    ) -> str:
+        """Rewrite a final answer to satisfy binding skill output contracts.
+
+        This is a formatting-only repair pass. It must preserve the already-gathered
+        evidence and never introduce new tool calls or unsupported claims.
+        """
+        gaps = _collect_skill_contract_gaps(tool_envelopes, messages)
+        relevant_gaps = [gap for gap in gaps if gap["missing_output"] and not gap["missing_tools"]]
+        if not relevant_gaps:
+            return response_text
+
+        lines = [
+            "You are repairing an answer so it exactly satisfies a binding Agent Skills output contract.",
+            "Do not add new evidence, findings, or tool claims.",
+            "Preserve the facts, metrics, and recommendations already present in the source answer.",
+            "Return only the rewritten markdown document.",
+            "",
+            "Contracts to satisfy:",
+        ]
+        for gap in relevant_gaps:
+            lines.append(f"Skill: `{gap['skill_name']}`")
+            if gap["contract_summary"]:
+                lines.extend(f"- {item}" for item in gap["contract_summary"])
+            lines.append("Missing output requirements:")
+            lines.extend(f"- {item}" for item in gap["missing_output"])
+            if gap["template"]:
+                lines.append("Required markdown template:")
+                lines.append("```markdown")
+                lines.append(gap["template"])
+                lines.append("```")
+
+        repair_messages: List[BaseMessage] = [
+            SystemMessage(content="\n".join(lines)),
+            HumanMessage(
+                content=(
+                    "Rewrite the following answer to satisfy the contract exactly.\n\n"
+                    "Original answer:\n"
+                    f"{response_text}"
+                )
+            ),
+        ]
+        try:
+            repaired = await self.llm.ainvoke(repair_messages)
+        except Exception as exc:
+            logger.warning(
+                "Skill contract repair failed; returning original response: %s",
+                _format_exception_message(exc),
+                exc_info=True,
+            )
+            return response_text
+        repaired_text = coerce_response_text(getattr(repaired, "content", ""))
+        return repaired_text or response_text
+
     def _build_workflow(
         self,
         tool_mgr: ToolManager,
@@ -546,10 +850,18 @@ class ChatAgent:
                 startup_system_prompt = startup_system_prompt or CHAT_SYSTEM_PROMPT
                 messages = [SystemMessage(content=startup_system_prompt)] + messages
 
+            invoke_messages = list(messages)
+            contract_repair_message = _build_skill_contract_repair_message(
+                signals_envelopes,
+                state["messages"],
+            )
+            if contract_repair_message is not None:
+                invoke_messages.append(contract_repair_message)
+
             with tracer.start_as_current_span("chat_agent_node"):
                 response = await guarded_ainvoke(
                     runtime["llm_with_expand"],
-                    messages,
+                    invoke_messages,
                     request_kind="chat_agent.agent_node",
                 )
 
@@ -675,13 +987,23 @@ class ChatAgent:
             if state.get("current_tool_calls"):
                 return "tools"
 
+            if _skill_contract_needs_followup(
+                list(state.get("signals_envelopes") or []),
+                messages,
+            ):
+                return "agent"
+
             return END
 
         workflow = StateGraph(ChatAgentState)
         workflow.add_node("agent", agent_node)
         workflow.add_node("tools", tool_node)
         workflow.set_entry_point("agent")
-        workflow.add_conditional_edges("agent", should_continue, {"tools": "tools", END: END})
+        workflow.add_conditional_edges(
+            "agent",
+            should_continue,
+            {"tools": "tools", "agent": "agent", END: END},
+        )
         workflow.add_edge("tools", "agent")
 
         return workflow
@@ -899,6 +1221,11 @@ User Query: {query}"""
                     messages = final_state.get("messages", [])
                     response_text = extract_last_ai_response(messages, terminal_only=True)
                     if response_text:
+                        response_text = await self._repair_response_to_skill_contract(
+                            response_text=response_text,
+                            tool_envelopes=tool_envelopes,
+                            messages=messages,
+                        )
                         response = AgentResponse(
                             response=response_text,
                             tool_envelopes=tool_envelopes,
@@ -1000,6 +1327,11 @@ User Query: {query}"""
                     messages = final_state.get("messages", [])
                     response_text = extract_last_ai_response(messages, terminal_only=True)
                     if response_text:
+                        response_text = await self._repair_response_to_skill_contract(
+                            response_text=response_text,
+                            tool_envelopes=tool_envelopes,
+                            messages=messages,
+                        )
                         return AgentResponse(
                             response=response_text,
                             tool_envelopes=tool_envelopes,

--- a/redis_sre_agent/agent/knowledge_context.py
+++ b/redis_sre_agent/agent/knowledge_context.py
@@ -54,9 +54,16 @@ def _skills_toc_lines(
     skills: List[Dict[str, Any]],
     *,
     total_skills: Optional[int] = None,
+    displayed_limit: Optional[int] = None,
 ) -> List[str]:
     """Render the ADR skills table of contents lines."""
     if not skills:
+        return []
+
+    displayed_skills = skills
+    if displayed_limit is not None:
+        displayed_skills = skills[: max(displayed_limit, 0)]
+    if not displayed_skills:
         return []
 
     lines = [
@@ -66,18 +73,25 @@ def _skills_toc_lines(
         "- If a listed skill matches the request, retrieve it with `get_skill` before claiming that you used, followed, or executed it.",
         "- If you use any retrieved skills during your turn, add a note to your answer saying which skill(s) you used.",
     ]
-    if total_skills is not None and total_skills > len(skills):
-        remaining = total_skills - len(skills)
-        shown = len(skills)
+    effective_total_skills = total_skills
+    if effective_total_skills is None and len(skills) > len(displayed_skills):
+        effective_total_skills = len(skills)
+    if effective_total_skills is not None and effective_total_skills > len(displayed_skills):
+        shown = len(displayed_skills)
+        remaining = effective_total_skills - shown
         lines.append(
             "- This startup inventory is truncated: "
             f"{shown} skill{'s' if shown != 1 else ''} shown, {remaining} more available in the backend. "
             "If you need a related skill that is not listed here, search for related skills before concluding there is no relevant match."
         )
-    for skill in skills:
-        name = str(skill.get("name", "")).strip() or str(skill.get("title", "")).strip()
+    for skill in displayed_skills:
+        title = str(skill.get("title", "")).strip() or str(skill.get("name", "")).strip()
+        lookup_name = str(skill.get("name", "")).strip()
         summary = str(skill.get("summary", "")).strip() or str(skill.get("description", "")).strip()
-        lines.append(f"- {name}: {summary}")
+        if lookup_name and title and lookup_name != title:
+            lines.append(f"- {title} (`{lookup_name}`): {summary}")
+        else:
+            lines.append(f"- {title or lookup_name}: {summary}")
     return lines
 
 
@@ -226,12 +240,13 @@ def _build_internal_startup_skills_envelope(
 
     results: List[Dict[str, Any]] = []
     for skill in skills:
-        title = str(skill.get("name", "")).strip() or str(skill.get("title", "")).strip()
+        title = str(skill.get("title", "")).strip() or str(skill.get("name", "")).strip()
+        lookup_name = str(skill.get("name", "")).strip()
         document_hash = str(skill.get("document_hash", "")).strip()
         results.append(
             {
-                "id": document_hash or title,
-                "title": title or document_hash or "Skill",
+                "id": document_hash or lookup_name or title,
+                "title": title or lookup_name or document_hash or "Skill",
                 "source": str(skill.get("source", "")).strip(),
                 "document_hash": document_hash,
                 "doc_type": "skill",
@@ -354,6 +369,7 @@ async def build_startup_knowledge_context(
     skills_lines = _skills_toc_lines(
         skill_rows,
         total_skills=normalized_total_skills,
+        displayed_limit=effective_skills_limit,
     )
     if skills_lines:
         sections.append("\n".join(skills_lines))

--- a/redis_sre_agent/agent/prompts.py
+++ b/redis_sre_agent/agent/prompts.py
@@ -59,6 +59,10 @@ When skills or runbooks are relevant:
 - If a listed or requested skill matches the task, retrieve it with `get_skill` before claiming that you followed it
 - Do not say you used a health-check skill, runbook, or ticket unless you actually retrieved it in this conversation
 - Do not present a response as satisfying a skill unless you successfully retrieved and followed the skill
+- If a retrieved skill returns `output_contract`, `workflow_contract`, or `contract_summary`, treat those fields as binding instructions for this turn
+- When a skill contract specifies exact headings or ordering, copy those headings verbatim instead of paraphrasing them
+- When a skill contract specifies required tool calls or follow-up rules, complete them before you finalize unless the user blocks you or the tool is unavailable
+- Before sending the final answer, silently check that every required section from the skill contract is present and in order
 
 Only call categories that are available in your current tool list.
 

--- a/redis_sre_agent/cli/skills.py
+++ b/redis_sre_agent/cli/skills.py
@@ -25,16 +25,30 @@ def skills():
 
 @skills.command("list")
 @click.option("--query", "-q", type=str, default=None, help="Optional search query")
+@click.option(
+    "--search-type",
+    type=click.Choice(["semantic", "keyword", "hybrid"], case_sensitive=False),
+    default=None,
+    help="Optional search type. Defaults to semantic when --query is set.",
+)
 @click.option("--limit", "-l", default=20, show_default=True, help="Number of skills to return")
 @click.option("--offset", "-o", default=0, show_default=True, help="Offset for pagination")
 @click.option("--version", "-v", default="latest", show_default=True, help="Version filter")
 @click.option("--json", "as_json", is_flag=True, help="Output JSON")
-def skills_list(query: str | None, limit: int, offset: int, version: str, as_json: bool):
+def skills_list(
+    query: str | None,
+    search_type: str | None,
+    limit: int,
+    offset: int,
+    version: str,
+    as_json: bool,
+):
     """List skills from the active skill backend."""
 
     async def _run():
         result = await skills_check_helper(
             query=query,
+            search_type=search_type,
             limit=limit,
             offset=offset,
             version=version,

--- a/redis_sre_agent/core/config.py
+++ b/redis_sre_agent/core/config.py
@@ -644,7 +644,7 @@ class Settings(BaseSettings):
         description="Character budget for explicit skill resource retrieval responses.",
     )
     startup_skills_toc_limit: int = Field(
-        default=50,
+        default=25,
         description="Maximum number of skills to inject into the startup prompt TOC.",
     )
 

--- a/redis_sre_agent/core/knowledge_helpers.py
+++ b/redis_sre_agent/core/knowledge_helpers.py
@@ -665,6 +665,7 @@ async def skills_check_helper(
     limit: int = 20,
     offset: int = 0,
     version: Optional[str] = "latest",
+    search_type: Optional[str] = None,
     distance_threshold: Optional[float] = 0.8,
     config: Optional[Settings] = None,
 ) -> Dict[str, Any]:
@@ -678,6 +679,7 @@ async def skills_check_helper(
         limit=limit,
         offset=offset,
         version=version,
+        search_type=search_type,
         distance_threshold=distance_threshold,
     )
     if override_result is not None:
@@ -686,8 +688,9 @@ async def skills_check_helper(
     limit = _coerce_positive_int(limit, default=20)
     offset = _coerce_non_negative_int(offset, default=0)
     logger.info(
-        "Listing skills (query=%s, version=%s, offset=%s, limit=%s)",
+        "Listing skills (query=%s, search_type=%s, version=%s, offset=%s, limit=%s)",
         bool(query),
+        search_type,
         version,
         offset,
         limit,
@@ -698,6 +701,7 @@ async def skills_check_helper(
         limit=limit,
         offset=offset,
         version=version,
+        search_type=search_type,
         distance_threshold=distance_threshold,
     )
 

--- a/redis_sre_agent/core/runtime_overrides.py
+++ b/redis_sre_agent/core/runtime_overrides.py
@@ -37,6 +37,7 @@ class EvalKnowledgeBackend(Protocol):
         limit: int = 20,
         offset: int = 0,
         version: Optional[str] = "latest",
+        search_type: Optional[str] = None,
         distance_threshold: Optional[float] = 0.8,
     ) -> dict[str, Any]: ...
 

--- a/redis_sre_agent/evaluation/assertions.py
+++ b/redis_sre_agent/evaluation/assertions.py
@@ -136,6 +136,27 @@ def _infer_trace_logical_identity(
                 )
             )
 
+    for server_name, server_config in scenario.tools.mcp_servers.items():
+        provider_prefix = f"mcp_{_normalize_text(server_name).replace(' ', '_')}_"
+        if not normalized_name.startswith(provider_prefix):
+            continue
+        for operation in server_config.tools:
+            normalized_operation = _normalize_text(operation).replace(" ", "_")
+            if not normalized_name.endswith(f"_{normalized_operation}"):
+                continue
+            candidate_operations.append(
+                (
+                    len(normalized_operation),
+                    LogicalToolIdentity.model_validate(
+                        {
+                            "provider_family": "mcp",
+                            "server_name": server_name,
+                            "operation": normalized_operation,
+                        }
+                    ),
+                )
+            )
+
     if not candidate_operations:
         return None
     return max(candidate_operations, key=lambda item: item[0])[1]
@@ -234,6 +255,13 @@ def _contains_phrase(text: str, phrase: str) -> bool:
             continue
         return True
     return False
+
+
+def _matches_response_pattern(text: str, pattern: str) -> bool:
+    try:
+        return re.search(pattern, text, flags=re.MULTILINE | re.DOTALL) is not None
+    except re.error:
+        return False
 
 
 def _pass(message: str, *, expected: Any = None, actual: Any = None) -> EvalAssertionResult:
@@ -378,6 +406,25 @@ def score_structured_assertions(
                 )
             )
 
+    required_response_patterns: list[EvalAssertionResult] = []
+    for expected in scenario.expectations.required_response_patterns:
+        if _matches_response_pattern(final_answer, expected):
+            required_response_patterns.append(
+                _pass(
+                    "Observed required response pattern in final answer",
+                    expected=expected,
+                    actual=final_answer,
+                )
+            )
+        else:
+            required_response_patterns.append(
+                _fail(
+                    "Missing required response pattern in final answer",
+                    expected=expected,
+                    actual=final_answer,
+                )
+            )
+
     forbidden_claims: list[EvalAssertionResult] = []
     for expected in scenario.expectations.forbidden_claims:
         if _contains_phrase(answer, expected):
@@ -436,6 +483,7 @@ def score_structured_assertions(
         required_tool_calls=required_tool_calls,
         forbidden_tool_calls=forbidden_tool_calls,
         required_sources=required_sources,
+        required_response_patterns=required_response_patterns,
         forbidden_claims=forbidden_claims,
         required_findings=required_findings,
         expected_routing_decision=expected_routing_decision,
@@ -452,6 +500,7 @@ def flatten_structured_assertions(
         "required_tool_call": results.required_tool_calls,
         "forbidden_tool_call": results.forbidden_tool_calls,
         "required_source": results.required_sources,
+        "required_response_pattern": results.required_response_patterns,
         "forbidden_claim": results.forbidden_claims,
         "required_finding": results.required_findings,
     }

--- a/redis_sre_agent/evaluation/assertions.py
+++ b/redis_sre_agent/evaluation/assertions.py
@@ -58,6 +58,10 @@ def _normalize_text(value: Any) -> str:
     return " ".join(str(value or "").strip().lower().split())
 
 
+def _normalize_tool_name_token(value: Any) -> str:
+    return _normalize_text(value).replace("-", "_").replace(" ", "_")
+
+
 def _normalize_routing_decision(value: Any) -> str:
     normalized = _normalize_text(value)
     return _ROUTING_ALIASES.get(normalized, normalized)
@@ -95,7 +99,7 @@ def _infer_trace_logical_identity(
     scenario: EvalScenario,
     concrete_name: str,
 ) -> LogicalToolIdentity | None:
-    normalized_name = _normalize_text(concrete_name).replace(" ", "_")
+    normalized_name = _normalize_tool_name_token(concrete_name)
     if not normalized_name:
         return None
     if normalized_name == "knowledge.pinned_context":
@@ -106,7 +110,7 @@ def _infer_trace_logical_identity(
 
     candidate_operations: list[tuple[int, LogicalToolIdentity]] = []
     for provider_family, operation_map in scenario.tools.providers.items():
-        raw_provider = _normalize_text(provider_family).replace(" ", "_")
+        raw_provider = _normalize_tool_name_token(provider_family)
         canonical_provider = normalize_provider_family(raw_provider)
         provider_prefixes = {
             f"{provider_prefix}_"
@@ -115,7 +119,7 @@ def _infer_trace_logical_identity(
         if not any(normalized_name.startswith(prefix) for prefix in provider_prefixes):
             continue
         for operation in operation_map:
-            normalized_operation = _normalize_text(operation).replace(" ", "_")
+            normalized_operation = _normalize_tool_name_token(operation)
             if not normalized_name.endswith(f"_{normalized_operation}"):
                 continue
             payload: dict[str, Any] = {
@@ -137,11 +141,12 @@ def _infer_trace_logical_identity(
             )
 
     for server_name, server_config in scenario.tools.mcp_servers.items():
-        provider_prefix = f"mcp_{_normalize_text(server_name).replace(' ', '_')}_"
+        normalized_server_name = _normalize_tool_name_token(server_name)
+        provider_prefix = f"mcp_{normalized_server_name}_"
         if not normalized_name.startswith(provider_prefix):
             continue
         for operation in server_config.tools:
-            normalized_operation = _normalize_text(operation).replace(" ", "_")
+            normalized_operation = _normalize_tool_name_token(operation)
             if not normalized_name.endswith(f"_{normalized_operation}"):
                 continue
             candidate_operations.append(

--- a/redis_sre_agent/evaluation/assertions.py
+++ b/redis_sre_agent/evaluation/assertions.py
@@ -259,7 +259,7 @@ def _contains_phrase(text: str, phrase: str) -> bool:
 
 def _matches_response_pattern(text: str, pattern: str) -> bool:
     try:
-        return re.search(pattern, text, flags=re.MULTILINE | re.DOTALL) is not None
+        return re.search(pattern, text) is not None
     except re.error:
         return False
 

--- a/redis_sre_agent/evaluation/assertions.py
+++ b/redis_sre_agent/evaluation/assertions.py
@@ -19,6 +19,7 @@ from redis_sre_agent.evaluation.tool_identity import (
     LogicalToolIdentity,
     concrete_provider_family_prefixes,
     normalize_provider_family,
+    normalize_tool_name_token,
 )
 
 _TOKEN_RE = re.compile(r"[a-z0-9]+(?:[-'][a-z0-9]+)*")
@@ -58,10 +59,6 @@ def _normalize_text(value: Any) -> str:
     return " ".join(str(value or "").strip().lower().split())
 
 
-def _normalize_tool_name_token(value: Any) -> str:
-    return _normalize_text(value).replace("-", "_").replace(" ", "_")
-
-
 def _normalize_routing_decision(value: Any) -> str:
     normalized = _normalize_text(value)
     return _ROUTING_ALIASES.get(normalized, normalized)
@@ -99,7 +96,7 @@ def _infer_trace_logical_identity(
     scenario: EvalScenario,
     concrete_name: str,
 ) -> LogicalToolIdentity | None:
-    normalized_name = _normalize_tool_name_token(concrete_name)
+    normalized_name = normalize_tool_name_token(concrete_name)
     if not normalized_name:
         return None
     if normalized_name == "knowledge.pinned_context":
@@ -110,7 +107,7 @@ def _infer_trace_logical_identity(
 
     candidate_operations: list[tuple[int, LogicalToolIdentity]] = []
     for provider_family, operation_map in scenario.tools.providers.items():
-        raw_provider = _normalize_tool_name_token(provider_family)
+        raw_provider = normalize_tool_name_token(provider_family)
         canonical_provider = normalize_provider_family(raw_provider)
         provider_prefixes = {
             f"{provider_prefix}_"
@@ -119,7 +116,7 @@ def _infer_trace_logical_identity(
         if not any(normalized_name.startswith(prefix) for prefix in provider_prefixes):
             continue
         for operation in operation_map:
-            normalized_operation = _normalize_tool_name_token(operation)
+            normalized_operation = normalize_tool_name_token(operation)
             if not normalized_name.endswith(f"_{normalized_operation}"):
                 continue
             payload: dict[str, Any] = {
@@ -141,12 +138,12 @@ def _infer_trace_logical_identity(
             )
 
     for server_name, server_config in scenario.tools.mcp_servers.items():
-        normalized_server_name = _normalize_tool_name_token(server_name)
+        normalized_server_name = normalize_tool_name_token(server_name)
         provider_prefix = f"mcp_{normalized_server_name}_"
         if not normalized_name.startswith(provider_prefix):
             continue
         for operation in server_config.tools:
-            normalized_operation = _normalize_tool_name_token(operation)
+            normalized_operation = normalize_tool_name_token(operation)
             if not normalized_name.endswith(f"_{normalized_operation}"):
                 continue
             candidate_operations.append(

--- a/redis_sre_agent/evaluation/knowledge_backend.py
+++ b/redis_sre_agent/evaluation/knowledge_backend.py
@@ -14,6 +14,15 @@ import yaml
 
 from redis_sre_agent.evaluation.injection import EvalKnowledgeBackend
 from redis_sre_agent.evaluation.scenarios import EvalScenario
+from redis_sre_agent.skills.backend import (
+    normalize_skill_search_type,
+    unsupported_skill_search_type_result,
+)
+from redis_sre_agent.skills.contracts import (
+    build_contract_summary,
+    extract_output_contract,
+    extract_workflow_contract,
+)
 from redis_sre_agent.skills.discovery import find_skill_package_root, load_skill_package
 
 _FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---\s*\n?(.*)$", re.DOTALL)
@@ -565,11 +574,25 @@ class FixtureKnowledgeBackend(EvalKnowledgeBackend):
         limit: int = 20,
         offset: int = 0,
         version: Optional[str] = "latest",
+        search_type: Optional[str] = None,
         distance_threshold: Optional[float] = 0.8,
         **_: Any,
     ) -> dict[str, Any]:
         effective_limit = _coerce_positive_int(limit, default=20)
         effective_offset = _coerce_non_negative_int(offset, default=0)
+        normalized_search_type = normalize_skill_search_type(query, search_type)
+        supported_search_types = ("semantic", "keyword")
+
+        if normalized_search_type == "hybrid":
+            return unsupported_skill_search_type_result(
+                query=query,
+                search_type=normalized_search_type,
+                version=version,
+                offset=effective_offset,
+                limit=effective_limit,
+                backend_kind="redis",
+                supported_search_types=supported_search_types,
+            )
 
         def _representative_rank(
             document: FixtureKnowledgeDocument,
@@ -611,6 +634,7 @@ class FixtureKnowledgeBackend(EvalKnowledgeBackend):
             "version": version,
             "offset": effective_offset,
             "limit": effective_limit,
+            "search_type": normalized_search_type,
             "results_count": len(paged_documents),
             "total_fetched": len(ordered_documents),
             "skills": [
@@ -638,6 +662,7 @@ class FixtureKnowledgeBackend(EvalKnowledgeBackend):
                 for document in paged_documents
             ],
             "distance_threshold": distance_threshold,
+            "supported_search_types": list(supported_search_types),
             "timestamp": datetime.now(timezone.utc).isoformat(),
         }
 
@@ -669,6 +694,12 @@ class FixtureKnowledgeBackend(EvalKnowledgeBackend):
                     "skill_name": entrypoint.name,
                     "full_content": entrypoint.content,
                 }
+            ui_metadata = dict(entrypoint.ui_metadata or {})
+            output_contract = extract_output_contract(
+                ui_metadata,
+                skill_content=entrypoint.content,
+            )
+            workflow_contract = extract_workflow_contract(ui_metadata)
             return {
                 "skill_name": entrypoint.name,
                 "backend_kind": "redis",
@@ -693,7 +724,10 @@ class FixtureKnowledgeBackend(EvalKnowledgeBackend):
                     if document.resource_kind == "script"
                 ],
                 "assets": list((entrypoint.skill_manifest or {}).get("assets", [])),
-                "ui_metadata": dict(entrypoint.ui_metadata or {}),
+                "ui_metadata": ui_metadata,
+                "output_contract": output_contract,
+                "workflow_contract": workflow_contract,
+                "contract_summary": build_contract_summary(output_contract, workflow_contract),
             }
         available_skills = await self.skills_check(query=skill_name, limit=50, version=version)
         return {
@@ -1039,6 +1073,7 @@ def _load_fixture_skill_package_documents(
         str(package.metadata.get("version") or default_version or "latest").strip() or "latest"
     )
     priority = str(package.metadata.get("priority") or "normal").strip().lower() or "normal"
+    package_document_hash = str(package.metadata.get("document_hash") or "").strip()
     manifest = {
         "assets": [
             {"path": resource.path, "title": resource.title, "description": resource.description}
@@ -1061,9 +1096,18 @@ def _load_fixture_skill_package_documents(
         resource_hash = hashlib.sha1(
             f"{package.name}:{resource.path}:{resource.content}".encode("utf-8")
         ).hexdigest()[:16]
+        document_hash = (
+            package_document_hash
+            if package_document_hash and resource.kind.value == "entrypoint"
+            else (
+                f"{package_document_hash}:{resource.path}"
+                if package_document_hash
+                else f"{package.name}:{resource_hash}"
+            )
+        )
         documents.append(
             FixtureKnowledgeDocument(
-                document_hash=f"{package.name}:{resource_hash}",
+                document_hash=document_hash,
                 title=package.display_title
                 if resource.kind.value == "entrypoint"
                 else (resource.title or f"{package.display_title}: {resource.path}"),

--- a/redis_sre_agent/evaluation/live_suite/__init__.py
+++ b/redis_sre_agent/evaluation/live_suite/__init__.py
@@ -347,7 +347,7 @@ def _infer_live_trace_logical_identity(
             "operation": "pinned_context",
         }
 
-    candidate_operations: list[tuple[int, str, str]] = []
+    candidate_operations: list[tuple[int, str, str, str | None]] = []
     for provider_family, operation_map in scenario.tools.providers.items():
         raw_provider = str(provider_family or "").strip().lower().replace("-", "_")
         normalized_provider = normalize_provider_family(raw_provider)
@@ -361,13 +361,28 @@ def _infer_live_trace_logical_identity(
             normalized_operation = str(operation or "").strip().lower().replace("-", "_")
             if normalized_name.endswith(f"_{normalized_operation}"):
                 candidate_operations.append(
-                    (len(normalized_operation), normalized_provider, normalized_operation)
+                    (len(normalized_operation), normalized_provider, normalized_operation, None)
+                )
+
+    for server_name, server_config in scenario.tools.mcp_servers.items():
+        normalized_server = str(server_name or "").strip().lower().replace("-", "_")
+        if not normalized_server:
+            continue
+        if not normalized_name.startswith(f"mcp_{normalized_server}_"):
+            continue
+        for operation in server_config.tools:
+            normalized_operation = str(operation or "").strip().lower().replace("-", "_")
+            if normalized_name.endswith(f"_{normalized_operation}"):
+                candidate_operations.append(
+                    (len(normalized_operation), "mcp", normalized_operation, normalized_server)
                 )
 
     if not candidate_operations:
         return None
 
-    _length, provider_family, operation = max(candidate_operations, key=lambda item: item[0])
+    _length, provider_family, operation, server_name = max(
+        candidate_operations, key=lambda item: item[0]
+    )
     target_handle = (
         scenario.scope.bound_targets[0] if len(scenario.scope.bound_targets) == 1 else None
     )
@@ -375,7 +390,9 @@ def _infer_live_trace_logical_identity(
         "provider_family": provider_family,
         "operation": operation,
     }
-    if target_handle and provider_family not in {
+    if server_name is not None:
+        logical_identity["server_name"] = server_name
+    elif target_handle and provider_family not in {
         "knowledge",
         "mcp",
         "target_discovery",
@@ -446,14 +463,13 @@ def _mechanical_assertion_scenario(scenario: EvalScenario) -> EvalScenario:
     """Drop free-form text assertions for live suites.
 
     Live-model evals should use hard assertions only for mechanical outputs
-    such as tool calls and routing. Text quality, semantic correctness, and
-    retrieval/source selection belong in the judge path because they depend on
-    live-model wording and query formulation.
+    such as tool calls, retrieved sources, and routing. Text quality,
+    semantic correctness, and narrative wording belong in the judge path
+    because they depend on live-model phrasing and query formulation.
     """
 
     expectations = scenario.expectations.model_copy(
         update={
-            "required_sources": [],
             "required_findings": [],
             "forbidden_claims": [],
         }

--- a/redis_sre_agent/evaluation/live_suite/__init__.py
+++ b/redis_sre_agent/evaluation/live_suite/__init__.py
@@ -38,6 +38,7 @@ from redis_sre_agent.evaluation.scenarios import EvalScenario, ExecutionLane, LL
 from redis_sre_agent.evaluation.tool_identity import (
     concrete_provider_family_prefixes,
     normalize_provider_family,
+    normalize_tool_name_token,
 )
 from redis_sre_agent.evaluation.tool_runtime import FixtureBehaviorState, build_fixture_tool_runtime
 
@@ -334,15 +335,11 @@ def normalize_agent_response_payload(
     )
 
 
-def _normalize_tool_name_token(value: Any) -> str:
-    return str(value or "").strip().lower().replace("-", "_").replace(" ", "_")
-
-
 def _infer_live_trace_logical_identity(
     scenario: EvalScenario,
     concrete_name: str,
 ) -> dict[str, Any] | None:
-    normalized_name = _normalize_tool_name_token(concrete_name)
+    normalized_name = normalize_tool_name_token(concrete_name)
     if not normalized_name:
         return None
     if normalized_name == "knowledge.pinned_context":
@@ -353,7 +350,7 @@ def _infer_live_trace_logical_identity(
 
     candidate_operations: list[tuple[int, str, str, str | None]] = []
     for provider_family, operation_map in scenario.tools.providers.items():
-        raw_provider = _normalize_tool_name_token(provider_family)
+        raw_provider = normalize_tool_name_token(provider_family)
         normalized_provider = normalize_provider_family(raw_provider)
         provider_prefixes = {
             f"{provider_prefix}_"
@@ -362,7 +359,7 @@ def _infer_live_trace_logical_identity(
         if not any(normalized_name.startswith(prefix) for prefix in provider_prefixes):
             continue
         for operation in operation_map:
-            normalized_operation = _normalize_tool_name_token(operation)
+            normalized_operation = normalize_tool_name_token(operation)
             if normalized_name.endswith(f"_{normalized_operation}"):
                 candidate_operations.append(
                     (len(normalized_operation), normalized_provider, normalized_operation, None)
@@ -370,13 +367,13 @@ def _infer_live_trace_logical_identity(
 
     for server_name, server_config in scenario.tools.mcp_servers.items():
         raw_server_name = str(server_name or "").strip()
-        normalized_server = _normalize_tool_name_token(raw_server_name)
+        normalized_server = normalize_tool_name_token(raw_server_name)
         if not normalized_server:
             continue
         if not normalized_name.startswith(f"mcp_{normalized_server}_"):
             continue
         for operation in server_config.tools:
-            normalized_operation = _normalize_tool_name_token(operation)
+            normalized_operation = normalize_tool_name_token(operation)
             if normalized_name.endswith(f"_{normalized_operation}"):
                 candidate_operations.append(
                     (len(normalized_operation), "mcp", normalized_operation, raw_server_name)

--- a/redis_sre_agent/evaluation/live_suite/__init__.py
+++ b/redis_sre_agent/evaluation/live_suite/__init__.py
@@ -334,11 +334,15 @@ def normalize_agent_response_payload(
     )
 
 
+def _normalize_tool_name_token(value: Any) -> str:
+    return str(value or "").strip().lower().replace("-", "_").replace(" ", "_")
+
+
 def _infer_live_trace_logical_identity(
     scenario: EvalScenario,
     concrete_name: str,
 ) -> dict[str, Any] | None:
-    normalized_name = str(concrete_name or "").strip().lower().replace("-", "_")
+    normalized_name = _normalize_tool_name_token(concrete_name)
     if not normalized_name:
         return None
     if normalized_name == "knowledge.pinned_context":
@@ -349,7 +353,7 @@ def _infer_live_trace_logical_identity(
 
     candidate_operations: list[tuple[int, str, str, str | None]] = []
     for provider_family, operation_map in scenario.tools.providers.items():
-        raw_provider = str(provider_family or "").strip().lower().replace("-", "_")
+        raw_provider = _normalize_tool_name_token(provider_family)
         normalized_provider = normalize_provider_family(raw_provider)
         provider_prefixes = {
             f"{provider_prefix}_"
@@ -358,23 +362,24 @@ def _infer_live_trace_logical_identity(
         if not any(normalized_name.startswith(prefix) for prefix in provider_prefixes):
             continue
         for operation in operation_map:
-            normalized_operation = str(operation or "").strip().lower().replace("-", "_")
+            normalized_operation = _normalize_tool_name_token(operation)
             if normalized_name.endswith(f"_{normalized_operation}"):
                 candidate_operations.append(
                     (len(normalized_operation), normalized_provider, normalized_operation, None)
                 )
 
     for server_name, server_config in scenario.tools.mcp_servers.items():
-        normalized_server = str(server_name or "").strip().lower().replace("-", "_")
+        raw_server_name = str(server_name or "").strip()
+        normalized_server = _normalize_tool_name_token(raw_server_name)
         if not normalized_server:
             continue
         if not normalized_name.startswith(f"mcp_{normalized_server}_"):
             continue
         for operation in server_config.tools:
-            normalized_operation = str(operation or "").strip().lower().replace("-", "_")
+            normalized_operation = _normalize_tool_name_token(operation)
             if normalized_name.endswith(f"_{normalized_operation}"):
                 candidate_operations.append(
-                    (len(normalized_operation), "mcp", normalized_operation, normalized_server)
+                    (len(normalized_operation), "mcp", normalized_operation, raw_server_name)
                 )
 
     if not candidate_operations:

--- a/redis_sre_agent/evaluation/report_schema.py
+++ b/redis_sre_agent/evaluation/report_schema.py
@@ -137,6 +137,7 @@ class StructuredAssertionResults(BaseModel):
     required_tool_calls: list[EvalAssertionResult] = Field(default_factory=list)
     forbidden_tool_calls: list[EvalAssertionResult] = Field(default_factory=list)
     required_sources: list[EvalAssertionResult] = Field(default_factory=list)
+    required_response_patterns: list[EvalAssertionResult] = Field(default_factory=list)
     forbidden_claims: list[EvalAssertionResult] = Field(default_factory=list)
     required_findings: list[EvalAssertionResult] = Field(default_factory=list)
     expected_routing_decision: EvalAssertionResult | None = None
@@ -148,6 +149,7 @@ class StructuredAssertionResults(BaseModel):
             *self.required_tool_calls,
             *self.forbidden_tool_calls,
             *self.required_sources,
+            *self.required_response_patterns,
             *self.forbidden_claims,
             *self.required_findings,
         ]
@@ -382,6 +384,7 @@ class EvalReportBundle(BaseModel):
             len(self.structured_assertion_results.required_tool_calls)
             + len(self.structured_assertion_results.forbidden_tool_calls)
             + len(self.structured_assertion_results.required_sources)
+            + len(self.structured_assertion_results.required_response_patterns)
             + len(self.structured_assertion_results.forbidden_claims)
             + len(self.structured_assertion_results.required_findings)
             + (1 if self.structured_assertion_results.expected_routing_decision is not None else 0)

--- a/redis_sre_agent/evaluation/scenarios.py
+++ b/redis_sre_agent/evaluation/scenarios.py
@@ -338,6 +338,7 @@ class EvalExpectations(BaseModel):
 
     required_tool_calls: list[EvalLogicalToolRef] = Field(default_factory=list)
     forbidden_tool_calls: list[EvalLogicalToolRef] = Field(default_factory=list)
+    required_response_patterns: list[str] = Field(default_factory=list)
     required_findings: list[str] = Field(default_factory=list)
     forbidden_claims: list[str] = Field(default_factory=list)
     required_sources: list[str] = Field(default_factory=list)

--- a/redis_sre_agent/evaluation/tool_identity.py
+++ b/redis_sre_agent/evaluation/tool_identity.py
@@ -33,6 +33,11 @@ def _normalize_optional_token(value: Any) -> str | None:
     return normalized or None
 
 
+def normalize_tool_name_token(value: Any) -> str:
+    normalized = " ".join(str(value or "").strip().lower().split())
+    return normalized.replace("-", "_").replace(" ", "_")
+
+
 def normalize_provider_family(provider_family: str) -> str:
     """Return the canonical scenario-facing provider family."""
     normalized = _normalize_token(provider_family)

--- a/redis_sre_agent/mcp_server/server.py
+++ b/redis_sre_agent/mcp_server/server.py
@@ -1269,6 +1269,7 @@ async def redis_sre_get_related_knowledge_fragments(
 @mcp.tool()
 async def redis_sre_list_skills(
     query: Optional[str] = None,
+    search_type: Optional[str] = None,
     limit: int = 20,
     offset: int = 0,
     version: Optional[str] = "latest",
@@ -1276,7 +1277,8 @@ async def redis_sre_list_skills(
     """List skills from the active skill backend.
 
     Args:
-        query: Optional search query for relevance-ranked matching.
+        query: Optional search query for skill lookup.
+        search_type: Optional search type. Defaults to semantic when query is present.
         limit: Maximum number of skills to return.
         offset: Number of skills to skip for pagination.
         version: Optional version filter. Defaults to "latest".
@@ -1287,8 +1289,9 @@ async def redis_sre_list_skills(
     from redis_sre_agent.core.knowledge_helpers import skills_check_helper
 
     logger.info(
-        "MCP list_skills: query=%s limit=%s offset=%s version=%s",
+        "MCP list_skills: query=%s search_type=%s limit=%s offset=%s version=%s",
         bool(query),
+        search_type,
         limit,
         offset,
         version,
@@ -1297,6 +1300,7 @@ async def redis_sre_list_skills(
     try:
         return await skills_check_helper(
             query=query,
+            search_type=search_type,
             limit=limit,
             offset=offset,
             version=version,
@@ -1308,6 +1312,7 @@ async def redis_sre_list_skills(
             "skills": [],
             "total": 0,
             "query": query,
+            "search_type": search_type,
             "limit": limit,
             "offset": offset,
             "version": version,

--- a/redis_sre_agent/skills/afs_workspace_backend.py
+++ b/redis_sre_agent/skills/afs_workspace_backend.py
@@ -13,6 +13,16 @@ from urllib.error import HTTPError, URLError
 from urllib.parse import urlencode
 from urllib.request import Request, urlopen
 
+from redis_sre_agent.skills.backend import (
+    normalize_skill_search_type,
+    unsupported_skill_search_type_result,
+)
+from redis_sre_agent.skills.contracts import (
+    build_contract_summary,
+    extract_output_contract,
+    extract_workflow_contract,
+)
+
 try:
     import httpx
 except ModuleNotFoundError:  # pragma: no cover - runtime image fallback
@@ -46,6 +56,7 @@ _GATEWAY_QUERY_STOPWORDS = {
     "you",
 }
 _SEMANTIC_SKILL_FETCH_LIMIT = 500
+_AFS_SUPPORTED_SEARCH_TYPES: tuple[str, ...] = ("semantic", "keyword")
 
 
 def _first_non_empty(
@@ -216,18 +227,25 @@ class AFSWorkspaceSkillBackend:
         limit: int,
         offset: int,
         version: str | None,
+        search_type: str | None = None,
         distance_threshold: float | None = 0.8,
     ) -> dict[str, Any]:
         del distance_threshold
+        normalized_search_type = normalize_skill_search_type(query, search_type)
         if self._use_gateway():
             return await self._list_skills_via_gateway(
                 query=query,
                 limit=limit,
                 offset=offset,
                 version=version,
+                search_type=normalized_search_type,
             )
         return await self._list_skills_via_api(
-            query=query, limit=limit, offset=offset, version=version
+            query=query,
+            limit=limit,
+            offset=offset,
+            version=version,
+            search_type=normalized_search_type,
         )
 
     async def get_skill(self, *, skill_name: str, version: str | None) -> dict[str, Any]:
@@ -261,13 +279,27 @@ class AFSWorkspaceSkillBackend:
         limit: int,
         offset: int,
         version: str | None,
+        search_type: str | None,
     ) -> dict[str, Any]:
         if query:
+            if search_type == "hybrid":
+                return unsupported_skill_search_type_result(
+                    query=query,
+                    search_type=search_type,
+                    version=version,
+                    offset=offset,
+                    limit=limit,
+                    backend_kind="afs_workspace",
+                    supported_search_types=_AFS_SUPPORTED_SEARCH_TYPES,
+                )
             raw_skills = await self._fetch_api_skill_catalog(
                 version=version,
                 minimum_count=max(limit + offset, 1),
             )
-            ranked_skills = await self._semantic_rank_skills(raw_skills, query=query)
+            if search_type == "keyword":
+                ranked_skills = self._filter_skills_keyword(raw_skills, query=query)
+            else:
+                ranked_skills = await self._semantic_rank_skills(raw_skills, query=query)
             paged_skills = ranked_skills[offset : offset + limit]
             normalized_skills = [
                 self._normalize_skill_summary(skill, matched_path=None)
@@ -279,9 +311,12 @@ class AFSWorkspaceSkillBackend:
                 "version": version,
                 "offset": offset,
                 "limit": limit,
+                "search_type": search_type,
                 "results_count": len(normalized_skills),
                 "total_fetched": len(ranked_skills),
                 "skills": normalized_skills,
+                "backend_kind": "afs_workspace",
+                "supported_search_types": list(_AFS_SUPPORTED_SEARCH_TYPES),
             }
 
         payload = await self._request_json(
@@ -307,9 +342,12 @@ class AFSWorkspaceSkillBackend:
             "version": version,
             "offset": offset,
             "limit": limit,
+            "search_type": search_type,
             "results_count": len(normalized_skills),
             "total_fetched": int(data.get("total", len(normalized_skills))),
             "skills": normalized_skills,
+            "backend_kind": "afs_workspace",
+            "supported_search_types": list(_AFS_SUPPORTED_SEARCH_TYPES),
         }
 
     async def _list_skills_via_gateway(
@@ -319,10 +357,24 @@ class AFSWorkspaceSkillBackend:
         limit: int,
         offset: int,
         version: str | None,
+        search_type: str | None,
     ) -> dict[str, Any]:
         raw_skills = await self._gateway_catalog_entries(version=version)
         if query:
-            raw_skills = await self._semantic_rank_skills(raw_skills, query=query)
+            if search_type == "hybrid":
+                return unsupported_skill_search_type_result(
+                    query=query,
+                    search_type=search_type,
+                    version=version,
+                    offset=offset,
+                    limit=limit,
+                    backend_kind="afs_workspace",
+                    supported_search_types=_AFS_SUPPORTED_SEARCH_TYPES,
+                )
+            if search_type == "keyword":
+                raw_skills = self._filter_skills_keyword(raw_skills, query=query)
+            else:
+                raw_skills = await self._semantic_rank_skills(raw_skills, query=query)
         paged = raw_skills[offset : offset + limit]
         normalized_skills = [
             self._normalize_skill_summary(skill, matched_path=None) for skill in paged
@@ -332,9 +384,12 @@ class AFSWorkspaceSkillBackend:
             "version": version,
             "offset": offset,
             "limit": limit,
+            "search_type": search_type,
             "results_count": len(normalized_skills),
             "total_fetched": len(raw_skills),
             "skills": normalized_skills,
+            "backend_kind": "afs_workspace",
+            "supported_search_types": list(_AFS_SUPPORTED_SEARCH_TYPES),
         }
 
     async def _fetch_api_skill_catalog(
@@ -387,7 +442,7 @@ class AFSWorkspaceSkillBackend:
         if not query_text:
             return list(skills)
 
-        fallback_matches = self._filter_gateway_skills(skills, query=query)
+        fallback_matches = self._filter_skills_keyword(skills, query=query)
         if not skills:
             return []
 
@@ -422,7 +477,7 @@ class AFSWorkspaceSkillBackend:
         ranked = [item[3] for item in scored]
         return ranked or fallback_matches or list(skills)
 
-    def _filter_gateway_skills(
+    def _filter_skills_keyword(
         self,
         skills: list[Mapping[str, Any]],
         *,
@@ -721,6 +776,17 @@ class AFSWorkspaceSkillBackend:
                 scripts.append(normalized)
             elif normalized["kind"] == "asset":
                 assets.append(normalized)
+        ui_metadata = skill.get("uiMetadata")
+        if not isinstance(ui_metadata, Mapping):
+            ui_metadata = skill.get("ui_metadata")
+        if not isinstance(ui_metadata, Mapping):
+            ui_metadata = {}
+        ui_metadata = dict(ui_metadata)
+        output_contract = extract_output_contract(
+            ui_metadata,
+            skill_content=entrypoint_content,
+        )
+        workflow_contract = extract_workflow_contract(ui_metadata)
         return {
             "skill_name": str(skill.get("skillSlug", default_skill_name)).strip()
             or default_skill_name,
@@ -729,11 +795,16 @@ class AFSWorkspaceSkillBackend:
             "summary": str(skill.get("description", "")).strip(),
             "version": str(skill.get("version", default_version or "v1")).strip() or "v1",
             "content": entrypoint_content,
+            "full_content": entrypoint_content,
             "protocol": "agent_skills_v1",
             "backend_kind": "afs_workspace",
             "references": references,
             "scripts": scripts,
             "assets": assets,
+            "ui_metadata": ui_metadata,
+            "output_contract": output_contract,
+            "workflow_contract": workflow_contract,
+            "contract_summary": build_contract_summary(output_contract, workflow_contract),
         }
 
     @staticmethod

--- a/redis_sre_agent/skills/backend.py
+++ b/redis_sre_agent/skills/backend.py
@@ -6,9 +6,61 @@ import importlib
 import json
 import threading
 from dataclasses import dataclass
-from typing import Any, Protocol
+from typing import Any, Literal, Protocol, cast
 
 from redis_sre_agent.core.config import Settings, settings
+
+from .contracts import build_contract_summary, extract_output_contract, extract_workflow_contract
+
+SkillSearchType = Literal["semantic", "keyword", "hybrid"]
+SUPPORTED_SKILL_SEARCH_TYPES: tuple[SkillSearchType, ...] = ("semantic", "keyword", "hybrid")
+
+
+def normalize_skill_search_type(
+    query: str | None,
+    search_type: str | None,
+    *,
+    default_when_queried: SkillSearchType = "semantic",
+) -> SkillSearchType | None:
+    """Normalize search_type for queried skill lookups."""
+    if not str(query or "").strip():
+        return None
+
+    normalized = str(search_type or default_when_queried).strip().lower() or default_when_queried
+    if normalized not in SUPPORTED_SKILL_SEARCH_TYPES:
+        supported = ", ".join(SUPPORTED_SKILL_SEARCH_TYPES)
+        raise ValueError(
+            f"Unsupported skill search_type '{normalized}'. Expected one of: {supported}"
+        )
+    return cast(SkillSearchType, normalized)
+
+
+def unsupported_skill_search_type_result(
+    *,
+    query: str | None,
+    search_type: str | None,
+    version: str | None,
+    offset: int,
+    limit: int,
+    backend_kind: str,
+    supported_search_types: tuple[str, ...],
+) -> dict[str, Any]:
+    """Return a structured unsupported-search response."""
+    requested = str(search_type or "").strip().lower() or None
+    return {
+        "query": query,
+        "search_type": requested,
+        "version": version,
+        "offset": offset,
+        "limit": limit,
+        "results_count": 0,
+        "total_fetched": 0,
+        "skills": [],
+        "backend_kind": backend_kind,
+        "error": "unsupported_search_type",
+        "requested_search_type": requested,
+        "supported_search_types": list(supported_search_types),
+    }
 
 
 class SkillBackend(Protocol):
@@ -21,6 +73,7 @@ class SkillBackend(Protocol):
         limit: int,
         offset: int,
         version: str | None,
+        search_type: str | None = None,
         distance_threshold: float | None = 0.8,
     ) -> dict[str, Any]: ...
 
@@ -60,11 +113,13 @@ class RedisSkillBackend:
         limit: int,
         offset: int,
         version: str | None,
+        search_type: str | None = None,
         distance_threshold: float | None = 0.8,
     ) -> dict[str, Any]:
         from redis_sre_agent.core import knowledge_helpers as helpers
 
         index = await helpers.get_skills_index(config=self.settings)
+        normalized_search_type = normalize_skill_search_type(query, search_type)
 
         fetch_limit = min(max(limit + offset, 1) * 8, 1000)
         return_fields = [
@@ -104,7 +159,7 @@ class RedisSkillBackend:
             "meta_pinned",
         ]
 
-        if query:
+        if normalized_search_type == "semantic":
             vectorizer = helpers.get_vectorizer(config=self.settings)
             vectors = await vectorizer.aembed_many([query])
             query_vector = vectors[0] if vectors else []
@@ -124,6 +179,40 @@ class RedisSkillBackend:
                     num_results=fetch_limit,
                 )
             candidates = await index.query(query_obj)
+        elif normalized_search_type == "keyword":
+            candidates = await index.query(
+                helpers._RawTextQuery(
+                    query or "",
+                    return_fields=return_fields,
+                    num_results=fetch_limit,
+                )
+            )
+        elif normalized_search_type == "hybrid":
+            vectorizer = helpers.get_vectorizer(config=self.settings)
+            vectors = await vectorizer.aembed_many([query or ""])
+            query_vector = vectors[0] if vectors else []
+            try:
+                candidates = await index.query(
+                    helpers.HybridQuery(
+                        vector=query_vector,
+                        vector_field_name="vector",
+                        text_field_name="content",
+                        text=query or "",
+                        num_results=fetch_limit,
+                        return_fields=return_fields,
+                    )
+                )
+            except Exception as exc:
+                if not helpers._is_hybrid_query_unsupported_error(exc):
+                    raise
+                candidates = await helpers._run_hybrid_rrf_fallback(
+                    index=index,
+                    query=query or "",
+                    query_vector=query_vector,
+                    query_filter=None,
+                    return_fields=return_fields,
+                    num_results=fetch_limit,
+                )
         else:
             candidates = await index.query(
                 helpers.FilterQuery(
@@ -172,7 +261,7 @@ class RedisSkillBackend:
             if existing is None:
                 by_skill[skill_key] = doc
                 continue
-            if query:
+            if normalized_search_type is not None:
                 if (_score(doc), str(doc.get("resource_path") or "")) < (
                     _score(existing),
                     str(existing.get("resource_path") or ""),
@@ -191,7 +280,7 @@ class RedisSkillBackend:
                         str(d.get("resource_path") or "").lower(),
                     )
                 )
-                if query
+                if normalized_search_type is not None
                 else (lambda d: (_skill_key(d).lower(), str(d.get("resource_path") or "").lower()))
             ),
         )
@@ -233,12 +322,14 @@ class RedisSkillBackend:
 
         return {
             "query": query,
+            "search_type": normalized_search_type,
             "version": version,
             "offset": offset,
             "limit": limit,
             "results_count": len(skills),
             "total_fetched": len(ordered_docs),
             "skills": skills,
+            "supported_search_types": list(SUPPORTED_SKILL_SEARCH_TYPES),
             "timestamp": datetime.now(timezone.utc).isoformat(),
         }
 
@@ -294,6 +385,12 @@ class RedisSkillBackend:
                 "skill_name": str(entrypoint.get("skill_name") or normalized_name),
                 "full_content": str(entrypoint.get("content") or "").strip(),
             }
+        ui_metadata = self._extract_ui_metadata(entrypoint.get("metadata", {}))
+        output_contract = extract_output_contract(
+            ui_metadata,
+            skill_content=str(entrypoint.get("content") or ""),
+        )
+        workflow_contract = extract_workflow_contract(ui_metadata)
         return {
             "skill_name": str(entrypoint.get("skill_name") or normalized_name),
             "backend_kind": "redis",
@@ -325,7 +422,10 @@ class RedisSkillBackend:
                 for resource in resources
                 if resource["resource_kind"] == "asset"
             ],
-            "ui_metadata": self._extract_ui_metadata(entrypoint.get("metadata", {})),
+            "ui_metadata": ui_metadata,
+            "output_contract": output_contract,
+            "workflow_contract": workflow_contract,
+            "contract_summary": build_contract_summary(output_contract, workflow_contract),
         }
 
     async def get_skill_resource(

--- a/redis_sre_agent/skills/contracts.py
+++ b/redis_sre_agent/skills/contracts.py
@@ -1,0 +1,378 @@
+"""Helpers for normalizing agent-specific skill contracts."""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Mapping
+
+_OUTPUT_STRUCTURE_BLOCK_RE = re.compile(
+    r"(?ims)^##\s+Output structure\b.*?```(?:markdown|md)?\n(.*?)```"
+)
+_PLACEHOLDER_RE = re.compile(r"<[^>]+>")
+
+
+def _merge_unique_strings(*values: Any) -> list[str]:
+    merged: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        for item in _normalize_string_list(value):
+            if item in seen:
+                continue
+            seen.add(item)
+            merged.append(item)
+    return merged
+
+
+def _merge_pattern_entries(*values: Any) -> list[dict[str, str] | str]:
+    merged: list[dict[str, str] | str] = []
+    seen: set[tuple[str, str]] = set()
+    for value in values:
+        for item in _normalize_pattern_entries(value):
+            if isinstance(item, Mapping):
+                normalized = (
+                    str(item.get("pattern") or "").strip(),
+                    str(item.get("description") or "").strip(),
+                )
+                if not normalized[0] or normalized in seen:
+                    continue
+                seen.add(normalized)
+                merged.append(
+                    {"pattern": normalized[0], "description": normalized[1] or normalized[0]}
+                )
+                continue
+            normalized = str(item or "").strip()
+            if not normalized:
+                continue
+            key = (normalized, normalized)
+            if key in seen:
+                continue
+            seen.add(key)
+            merged.append(normalized)
+    return merged
+
+
+def _infer_output_contract_from_skill_content(content: str) -> dict[str, Any]:
+    text = str(content or "").strip()
+    if not text:
+        return {}
+
+    match = _OUTPUT_STRUCTURE_BLOCK_RE.search(text)
+    if match is None:
+        return {}
+
+    template = match.group(1).strip("\n")
+    template_lines = [line.rstrip() for line in template.splitlines()]
+    non_empty_lines = [line for line in template_lines if line.strip()]
+    if not non_empty_lines:
+        return {}
+
+    preamble: list[str] = []
+    preamble_segment_lines: list[str] = []
+    for line in template_lines:
+        stripped = line.strip()
+        if stripped.startswith("## "):
+            break
+        preamble_segment_lines.append(line)
+        if stripped:
+            preamble.append(stripped)
+
+    required_order = [line.strip() for line in template_lines if line.strip().startswith("## ")]
+    required_subsections = [
+        line.strip() for line in template_lines if line.strip().startswith("### ")
+    ]
+
+    required_patterns: list[dict[str, str]] = []
+    preamble_segment = "\n".join(preamble_segment_lines).rstrip()
+    if preamble_segment:
+        metadata_labels = [
+            _line_prefix_before_placeholder(line) for line in preamble if line.startswith("**")
+        ]
+        metadata_labels = [label for label in metadata_labels if label]
+        preamble_description = (
+            f"Put `{preamble[0]}` on its own line, add a blank line, then place "
+            + ", ".join(f"`{label}`" for label in metadata_labels)
+            + " on separate lines."
+            if preamble and metadata_labels
+            else "Follow the title-and-metadata preamble layout from the skill template."
+        )
+        required_patterns.append(
+            {
+                "pattern": rf"(?s)^{_template_segment_to_pattern(preamble_segment)}",
+                "description": preamble_description,
+            }
+        )
+    for line in _template_lines_with_placeholders(template_lines):
+        required_patterns.append(
+            {
+                "pattern": rf"(?m)^{_template_segment_to_pattern(line.strip())}$",
+                "description": f"Include a line matching `{line.strip()}`.",
+            }
+        )
+    if required_order:
+        last_heading = re.escape(required_order[-1])
+        required_patterns.append(
+            {
+                "pattern": rf"(?s){last_heading}(?:(?!\n##\s).)*\s*$",
+                "description": (
+                    f"End the document in the required `{required_order[-1]}` section "
+                    "without adding another `##` section."
+                ),
+            }
+        )
+
+    instructions = [
+        "Return one markdown document only.",
+        "Do not rename required headings.",
+        "Use the required headings verbatim and in order.",
+        "Include all required sections even when brief.",
+    ]
+    validation_checklist = [
+        "Confirm the final answer follows the markdown template from the skill's Output structure section.",
+    ]
+    if required_order:
+        validation_checklist.append(
+            f"Confirm the document ends after `{required_order[-1]}` with no footer."
+        )
+
+    return {
+        "mode": "markdown",
+        "required_preamble_lines": preamble,
+        "required_order": required_order,
+        "required_subsections": required_subsections,
+        "required_patterns": required_patterns,
+        "instructions": instructions,
+        "validation_checklist": validation_checklist,
+        "must_include_even_if_empty": True,
+        "template": template,
+    }
+
+
+def _template_segment_to_pattern(segment: str) -> str:
+    pattern_parts: list[str] = []
+    cursor = 0
+    for match in _PLACEHOLDER_RE.finditer(segment):
+        pattern_parts.append(re.escape(segment[cursor : match.start()]))
+        pattern_parts.append(r".+?")
+        cursor = match.end()
+    pattern_parts.append(re.escape(segment[cursor:]))
+    return "".join(pattern_parts)
+
+
+def _template_lines_with_placeholders(lines: list[str]) -> list[str]:
+    placeholder_lines: list[str] = []
+    seen: set[str] = set()
+    for line in lines:
+        stripped = line.strip()
+        if not stripped or not _PLACEHOLDER_RE.search(stripped):
+            continue
+        if stripped.startswith("#"):
+            continue
+        if stripped in seen:
+            continue
+        seen.add(stripped)
+        placeholder_lines.append(line)
+    return placeholder_lines
+
+
+def _line_prefix_before_placeholder(line: str) -> str:
+    match = _PLACEHOLDER_RE.search(line)
+    if match is None:
+        return line.strip()
+    return line[: match.start()].rstrip()
+
+
+def _normalize_string_list(value: Any) -> list[str]:
+    if isinstance(value, list):
+        return [str(item).strip() for item in value if str(item).strip()]
+    normalized = str(value or "").strip()
+    return [normalized] if normalized else []
+
+
+def _normalize_pattern_entries(value: Any) -> list[dict[str, str] | str]:
+    if not isinstance(value, list):
+        normalized = str(value or "").strip()
+        return [normalized] if normalized else []
+
+    entries: list[dict[str, str] | str] = []
+    for item in value:
+        if isinstance(item, Mapping):
+            pattern = str(item.get("pattern") or "").strip()
+            if not pattern:
+                continue
+            description = str(item.get("description") or pattern).strip()
+            entries.append({"pattern": pattern, "description": description})
+            continue
+        normalized = str(item or "").strip()
+        if normalized:
+            entries.append(normalized)
+    return entries
+
+
+def extract_output_contract(
+    ui_metadata: Mapping[str, Any] | None,
+    *,
+    skill_content: str = "",
+) -> dict[str, Any]:
+    """Return a normalized output contract from agent-specific metadata."""
+
+    raw: Mapping[str, Any] = {}
+    if isinstance(ui_metadata, Mapping):
+        candidate = ui_metadata.get("output_contract")
+        if isinstance(candidate, Mapping):
+            raw = candidate
+
+    inferred = _infer_output_contract_from_skill_content(skill_content)
+    contract: dict[str, Any] = {}
+    mode = str(raw.get("mode") or raw.get("output_mode") or inferred.get("mode") or "").strip()
+    if mode:
+        contract["mode"] = mode
+    instructions = _merge_unique_strings(inferred.get("instructions"), raw.get("instructions"))
+    if instructions:
+        contract["instructions"] = instructions
+    validation_checklist = _merge_unique_strings(
+        inferred.get("validation_checklist"),
+        raw.get("validation_checklist"),
+    )
+    if validation_checklist:
+        contract["validation_checklist"] = validation_checklist
+    required_sections = _merge_unique_strings(
+        inferred.get("required_sections"),
+        raw.get("required_sections"),
+    )
+    if required_sections:
+        contract["required_sections"] = required_sections
+    required_subsections = _merge_unique_strings(
+        inferred.get("required_subsections"),
+        raw.get("required_subsections"),
+    )
+    if required_subsections:
+        contract["required_subsections"] = required_subsections
+    required_order = _merge_unique_strings(
+        inferred.get("required_order"),
+        raw.get("required_order"),
+    )
+    if required_order:
+        contract["required_order"] = required_order
+    required_preamble_lines = _merge_unique_strings(
+        inferred.get("required_preamble_lines"),
+        raw.get("required_preamble_lines"),
+    )
+    if required_preamble_lines:
+        contract["required_preamble_lines"] = required_preamble_lines
+    required_patterns = _merge_pattern_entries(
+        inferred.get("required_patterns"),
+        raw.get("required_patterns"),
+    )
+    if required_patterns:
+        contract["required_patterns"] = required_patterns
+    validation_patterns = _merge_unique_strings(
+        inferred.get("validation_patterns"),
+        raw.get("validation_patterns"),
+    )
+    if validation_patterns:
+        contract["validation_patterns"] = validation_patterns
+    template = str(
+        raw.get("template") or raw.get("markdown_template") or inferred.get("template") or ""
+    ).strip()
+    if template:
+        contract["template"] = template
+    if raw.get("must_include_even_if_empty") is not None:
+        contract["must_include_even_if_empty"] = bool(raw.get("must_include_even_if_empty"))
+    elif inferred.get("must_include_even_if_empty") is not None:
+        contract["must_include_even_if_empty"] = bool(inferred.get("must_include_even_if_empty"))
+    return contract
+
+
+def extract_workflow_contract(ui_metadata: Mapping[str, Any] | None) -> dict[str, Any]:
+    """Return a normalized workflow contract from agent-specific metadata."""
+
+    if not isinstance(ui_metadata, Mapping):
+        return {}
+    raw = ui_metadata.get("workflow_contract")
+    if not isinstance(raw, Mapping):
+        return {}
+
+    contract: dict[str, Any] = {}
+    required_tool_calls = _normalize_string_list(raw.get("required_tool_calls"))
+    if required_tool_calls:
+        contract["required_tool_calls"] = required_tool_calls
+    required_followups = _normalize_string_list(raw.get("required_followups"))
+    if required_followups:
+        contract["required_followups"] = required_followups
+    progress_checklist = _normalize_string_list(raw.get("progress_checklist"))
+    if progress_checklist:
+        contract["progress_checklist"] = progress_checklist
+    completion_rules = _normalize_string_list(raw.get("completion_rules"))
+    if completion_rules:
+        contract["completion_rules"] = completion_rules
+    return contract
+
+
+def build_contract_summary(
+    output_contract: Mapping[str, Any] | None,
+    workflow_contract: Mapping[str, Any] | None,
+) -> list[str]:
+    """Build compact human-readable guidance from normalized contracts."""
+
+    summary: list[str] = []
+
+    if isinstance(output_contract, Mapping) and output_contract:
+        summary.append(
+            "This skill defines a binding output contract. Follow it exactly when producing the final answer."
+        )
+        mode = str(output_contract.get("mode") or "").strip()
+        if mode:
+            summary.append(f"Output mode: {mode}.")
+        required_order = _normalize_string_list(output_contract.get("required_order"))
+        required_sections = _normalize_string_list(output_contract.get("required_sections"))
+        section_order = required_order or required_sections
+        if section_order:
+            summary.append(
+                "Use these exact section headings in order: " + ", ".join(section_order) + "."
+            )
+        required_subsections = _normalize_string_list(output_contract.get("required_subsections"))
+        if required_subsections:
+            summary.append(
+                "Include these exact subsection headings when relevant: "
+                + ", ".join(required_subsections)
+                + "."
+            )
+        required_preamble_lines = _normalize_string_list(
+            output_contract.get("required_preamble_lines")
+        )
+        if required_preamble_lines:
+            summary.append("Required opening lines: " + " | ".join(required_preamble_lines) + ".")
+        instructions = _normalize_string_list(output_contract.get("instructions"))
+        for instruction in instructions[:5]:
+            summary.append(f"Output rule: {instruction}")
+        validation_checklist = _normalize_string_list(output_contract.get("validation_checklist"))
+        for item in validation_checklist[:5]:
+            summary.append(f"Validation checklist: {item}")
+        required_patterns = _normalize_pattern_entries(output_contract.get("required_patterns"))
+        for entry in required_patterns[:5]:
+            if isinstance(entry, dict):
+                summary.append(f"Output pattern: {entry['description']}")
+            else:
+                summary.append(f"Output pattern: {entry}")
+        if output_contract.get("must_include_even_if_empty"):
+            summary.append("Do not omit required sections even when they are brief or empty.")
+
+    if isinstance(workflow_contract, Mapping) and workflow_contract:
+        required_tool_calls = _normalize_string_list(workflow_contract.get("required_tool_calls"))
+        if required_tool_calls:
+            summary.append(
+                "Before finalizing, make these required tool calls unless impossible: "
+                + ", ".join(required_tool_calls)
+                + "."
+            )
+        required_followups = _normalize_string_list(workflow_contract.get("required_followups"))
+        for followup in required_followups[:5]:
+            summary.append(f"Workflow rule: {followup}")
+        progress_checklist = _normalize_string_list(workflow_contract.get("progress_checklist"))
+        for item in progress_checklist[:6]:
+            summary.append(f"Workflow checklist: {item}")
+        completion_rules = _normalize_string_list(workflow_contract.get("completion_rules"))
+        for rule in completion_rules[:5]:
+            summary.append(f"Completion rule: {rule}")
+
+    return summary

--- a/redis_sre_agent/skills/contracts.py
+++ b/redis_sre_agent/skills/contracts.py
@@ -8,7 +8,7 @@ from typing import Any, Mapping
 _OUTPUT_STRUCTURE_BLOCK_RE = re.compile(
     r"(?ims)^##\s+Output structure\b.*?```(?:markdown|md)?\n(.*?)```"
 )
-_PLACEHOLDER_RE = re.compile(r"<[^>]+>")
+TEMPLATE_PLACEHOLDER_RE = re.compile(r"<[^>\n]+>")
 
 
 def _merge_unique_strings(*values: Any) -> list[str]:
@@ -97,14 +97,14 @@ def _infer_output_contract_from_skill_content(content: str) -> dict[str, Any]:
         )
         required_patterns.append(
             {
-                "pattern": rf"(?s)^{_template_segment_to_pattern(preamble_segment)}",
+                "pattern": rf"(?s)^{template_segment_to_pattern(preamble_segment)}",
                 "description": preamble_description,
             }
         )
     for line in _template_lines_with_placeholders(template_lines):
         required_patterns.append(
             {
-                "pattern": rf"(?m)^{_template_segment_to_pattern(line.strip())}$",
+                "pattern": rf"(?m)^{template_segment_to_pattern(line.strip())}$",
                 "description": f"Include a line matching `{line.strip()}`.",
             }
         )
@@ -147,10 +147,10 @@ def _infer_output_contract_from_skill_content(content: str) -> dict[str, Any]:
     }
 
 
-def _template_segment_to_pattern(segment: str) -> str:
+def template_segment_to_pattern(segment: str) -> str:
     pattern_parts: list[str] = []
     cursor = 0
-    for match in _PLACEHOLDER_RE.finditer(segment):
+    for match in TEMPLATE_PLACEHOLDER_RE.finditer(segment):
         pattern_parts.append(re.escape(segment[cursor : match.start()]))
         pattern_parts.append(r".+?")
         cursor = match.end()
@@ -163,7 +163,7 @@ def _template_lines_with_placeholders(lines: list[str]) -> list[str]:
     seen: set[str] = set()
     for line in lines:
         stripped = line.strip()
-        if not stripped or not _PLACEHOLDER_RE.search(stripped):
+        if not stripped or not TEMPLATE_PLACEHOLDER_RE.search(stripped):
             continue
         if stripped.startswith("#"):
             continue
@@ -175,7 +175,7 @@ def _template_lines_with_placeholders(lines: list[str]) -> list[str]:
 
 
 def _line_prefix_before_placeholder(line: str) -> str:
-    match = _PLACEHOLDER_RE.search(line)
+    match = TEMPLATE_PLACEHOLDER_RE.search(line)
     if match is None:
         return line.strip()
     return line[: match.start()].rstrip()

--- a/redis_sre_agent/skills/discovery.py
+++ b/redis_sre_agent/skills/discovery.py
@@ -121,7 +121,13 @@ def find_skill_package_root(path: Path, *, boundary: Path | None = None) -> Path
             resolved_boundary if resolved_boundary.is_dir() else resolved_boundary.parent
         )
 
-    for candidate in (resolved_path.parent, *resolved_path.parents):
+    candidate_roots = (
+        (resolved_path, *resolved_path.parents)
+        if resolved_path.is_dir()
+        else (resolved_path.parent, *resolved_path.parents)
+    )
+
+    for candidate in candidate_roots:
         if boundary_path is not None:
             try:
                 candidate.relative_to(boundary_path)
@@ -304,7 +310,9 @@ def skill_package_to_documents(
 
     source_root = source_root.resolve()
     root_label = str(source_root_label or source_root.name or "skills").strip().strip("/")
-    package_hash = _package_hash(package)
+    package_hash = str(package.metadata.get("document_hash") or "").strip() or _package_hash(
+        package
+    )
     manifest_json = json.dumps(_skill_package_manifest(package), sort_keys=True)
     documents: list[ScrapedDocument] = []
 

--- a/redis_sre_agent/skills/scaffold.py
+++ b/redis_sre_agent/skills/scaffold.py
@@ -124,6 +124,16 @@ def scaffold_skill_package_from_markdown(
             {
                 "display_name": title or name,
                 "preferred_entrypoint": "SKILL.md",
+                "output_contract": {
+                    "mode": "markdown",
+                    "instructions": [
+                        "Add exact output-shape rules here when the response format is mandatory."
+                    ],
+                },
+                "workflow_contract": {
+                    "required_tool_calls": [],
+                    "required_followups": [],
+                },
             },
             sort_keys=False,
         ),

--- a/redis_sre_agent/tools/knowledge/knowledge_base.py
+++ b/redis_sre_agent/tools/knowledge/knowledge_base.py
@@ -260,7 +260,10 @@ class KnowledgeBaseToolProvider(ToolProvider):
                 name=self._make_tool_name("get_skill"),
                 description=(
                     "Retrieve the complete content of a skill by skill name. "
-                    "Use the name returned by skills_check."
+                    "Use the name returned by skills_check. "
+                    "Agent Skills packages may also return provider-specific contract fields such as "
+                    "`output_contract`, `workflow_contract`, and `contract_summary`; when present, "
+                    "treat them as binding instructions for the final answer and required follow-up work."
                 ),
                 capability=ToolCapability.KNOWLEDGE,
                 parameters={
@@ -517,13 +520,15 @@ class KnowledgeBaseToolProvider(ToolProvider):
         limit: int = 20,
         offset: int = 0,
         version: Optional[str] = "latest",
+        search_type: Optional[str] = None,
     ) -> Dict[str, Any]:
         """List available skills from the knowledge base."""
         limit = _coerce_positive_int(limit, default=20)
         offset = _coerce_non_negative_int(offset, default=0)
         logger.info(
-            "Checking skills (query=%s, limit=%s, offset=%s, version=%s)",
+            "Checking skills (query=%s, search_type=%s, limit=%s, offset=%s, version=%s)",
             bool(query),
+            search_type,
             limit,
             offset,
             version,
@@ -532,6 +537,7 @@ class KnowledgeBaseToolProvider(ToolProvider):
             "tool.knowledge.skills_check",
             attributes={
                 "query.len": len(query or ""),
+                "search_type": search_type or "",
                 "limit": int(limit),
                 "offset": int(offset),
                 "version": version or "all",
@@ -542,6 +548,7 @@ class KnowledgeBaseToolProvider(ToolProvider):
                 limit=limit,
                 offset=offset,
                 version=version,
+                search_type=search_type,
             )
 
     async def get_skill(self, skill_name: str) -> Dict[str, Any]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -108,13 +108,15 @@ def pytest_collection_modifyitems(config, items):
         ) and not config.getoption("--run-api-tests"):
             item.add_marker(skip_api)
 
-        # Require --run-api-tests for integration tests and attach redis container fixture
-        if "integration" in item.keywords:
+        # Require --run-api-tests for external-service tests and attach the
+        # testcontainer settings fixture so global Redis helpers use the same
+        # isolated Redis as dependency-injected tests.
+        if "integration" in item.keywords or "docket_integration" in item.keywords:
             if not config.getoption("--run-api-tests"):
                 item.add_marker(skip_integration)
                 continue
-            # Add redis_container as a fixture dependency only when running integration
-            item.fixturenames.append("redis_container")
+            if "use_redis_testcontainer" not in item.fixturenames:
+                item.fixturenames.append("use_redis_testcontainer")
 
 
 # Test environment variables - only set if not already present
@@ -123,7 +125,8 @@ test_env = {
     "DEBUG": "true",
 }
 
-# REDIS_URL is not defaulted here; tests rely on Testcontainers-provided Redis via the use_redis_testcontainer autouse fixture
+# REDIS_URL is not defaulted here; integration tests route global Redis settings
+# to the Testcontainers-provided Redis via the use_redis_testcontainer fixture.
 
 # Only set test API key if no real key is present
 if not os.environ.get("OPENAI_API_KEY") or os.environ.get("OPENAI_API_KEY") == "":
@@ -359,6 +362,7 @@ def redis_container(worker_id):
 
     from pydantic import SecretStr
 
+    import redis_sre_agent.core.config as config_module
     from redis_sre_agent.core.config import Settings
     from redis_sre_agent.core.redis import create_indices
 
@@ -397,6 +401,8 @@ def redis_container(worker_id):
             redis_url=SecretStr(url),
             # Other settings are inherited from environment/defaults
         )
+        old_settings_redis_url = config_module.settings.redis_url
+        config_module.settings.redis_url = SecretStr(url)
 
         # Create indices using dependency injection (no module reload needed!)
         asyncio.run(create_indices(config=test_settings))
@@ -414,9 +420,9 @@ def redis_container(worker_id):
 
                     storage = ArtifactStorage(str(artifacts_path))
                     pipeline = IngestionPipeline(storage)
-                    # Note: IngestionPipeline doesn't yet support config injection.
-                    # For now, we skip ingestion in tests or it uses global settings.
-                    # TODO: Add config parameter to IngestionPipeline for full DI support.
+                    # IngestionPipeline still reads the process-global settings.
+                    # Route that global to the same testcontainer Redis instead
+                    # of relying on REDIS_URL or local development Redis.
                     asyncio.run(pipeline.ingest_batch(latest_batch))
                     print(f"✅ Ingested knowledge base batch: {latest_batch}")
                 except Exception as e:
@@ -427,6 +433,9 @@ def redis_container(worker_id):
         yield RedisContainerInfo(compose=compose, url=url, settings=test_settings)
 
     finally:
+        if "old_settings_redis_url" in locals():
+            config_module.settings.redis_url = old_settings_redis_url
+
         # Restore compose env vars
         for key, old_value in old_compose_env.items():
             if old_value is None:
@@ -451,6 +460,23 @@ def test_settings(redis_container):
             status = await initialize_redis(config=test_settings)
     """
     return redis_container.settings
+
+
+@pytest.fixture
+def use_redis_testcontainer(redis_container, monkeypatch):
+    """Route global Redis settings to the integration-test Redis container.
+
+    Production code should prefer explicit config injection, but several CLI
+    and worker entrypoints intentionally read the process-global settings
+    object. This fixture keeps those paths on the same testcontainer Redis
+    without setting REDIS_URL.
+    """
+    from pydantic import SecretStr
+
+    import redis_sre_agent.core.config as config_module
+
+    monkeypatch.setattr(config_module.settings, "redis_url", SecretStr(redis_container.url))
+    return redis_container
 
 
 @pytest.fixture(scope="session")

--- a/tests/integration/test_cli_purge_commands.py
+++ b/tests/integration/test_cli_purge_commands.py
@@ -7,7 +7,6 @@ from datetime import datetime, timedelta, timezone
 
 import pytest
 from click.testing import CliRunner
-from pydantic import SecretStr
 
 from redis_sre_agent.cli.main import main as cli_main
 
@@ -46,192 +45,170 @@ async def _set_task_status_and_time(
 
 
 def test_thread_purge_deletes_old_threads_and_tasks(redis_url):
-    import redis_sre_agent.core.config as config_module
+    runner = CliRunner()
 
-    original_settings = config_module.settings
-    try:
-        config_module.settings.redis_url = SecretStr(redis_url)
+    async def _setup():
+        from redis.asyncio import Redis as AsyncRedis
 
-        runner = CliRunner()
+        from redis_sre_agent.core.tasks import TaskManager, TaskStatus
+        from redis_sre_agent.core.threads import ThreadManager
 
-        async def _setup():
-            from redis.asyncio import Redis as AsyncRedis
+        client = AsyncRedis.from_url(redis_url, decode_responses=False)
+        try:
+            await client.flushdb()
 
-            from redis_sre_agent.core.tasks import TaskManager, TaskStatus
-            from redis_sre_agent.core.threads import ThreadManager
+            tm = ThreadManager(redis_client=client)
+            task_mgr = TaskManager(redis_client=client)
 
-            client = AsyncRedis.from_url(redis_url, decode_responses=False)
-            try:
-                await client.flushdb()
+            # Create two threads
+            t_old = await tm.create_thread(user_id="u1", session_id="s1")
+            t_new = await tm.create_thread(user_id="u1", session_id="s1")
 
-                tm = ThreadManager(redis_client=client)
-                task_mgr = TaskManager(redis_client=client)
+            # Create tasks under the old thread
+            task_old_1 = await task_mgr.create_task(thread_id=t_old, user_id="u1", subject="old1")
+            task_old_2 = await task_mgr.create_task(thread_id=t_old, user_id="u1", subject="old2")
+            await task_mgr.update_task_status(task_old_1, TaskStatus.DONE)
+            await task_mgr.update_task_status(task_old_2, TaskStatus.DONE)
 
-                # Create two threads
-                t_old = await tm.create_thread(user_id="u1", session_id="s1")
-                t_new = await tm.create_thread(user_id="u1", session_id="s1")
+            now = datetime.now(timezone.utc)
+            # Make t_old very old, t_new recent
+            await _set_thread_created_at(tm, client, t_old, now - timedelta(days=30))
+            await _set_thread_created_at(tm, client, t_new, now - timedelta(hours=1))
 
-                # Create tasks under the old thread
-                task_old_1 = await task_mgr.create_task(
-                    thread_id=t_old, user_id="u1", subject="old1"
-                )
-                task_old_2 = await task_mgr.create_task(
-                    thread_id=t_old, user_id="u1", subject="old2"
-                )
-                await task_mgr.update_task_status(task_old_1, TaskStatus.DONE)
-                await task_mgr.update_task_status(task_old_2, TaskStatus.DONE)
+            # Also make tasks for t_old appear old in the index
+            await _set_task_status_and_time(
+                task_mgr, client, task_old_1, "done", now - timedelta(days=30)
+            )
+            await _set_task_status_and_time(
+                task_mgr, client, task_old_2, "done", now - timedelta(days=29)
+            )
 
-                now = datetime.now(timezone.utc)
-                # Make t_old very old, t_new recent
-                await _set_thread_created_at(tm, client, t_old, now - timedelta(days=30))
-                await _set_thread_created_at(tm, client, t_new, now - timedelta(hours=1))
+            return t_old, t_new, task_old_1, task_old_2
+        finally:
+            await client.aclose()
 
-                # Also make tasks for t_old appear old in the index
-                await _set_task_status_and_time(
-                    task_mgr, client, task_old_1, "done", now - timedelta(days=30)
-                )
-                await _set_task_status_and_time(
-                    task_mgr, client, task_old_2, "done", now - timedelta(days=29)
-                )
+    t_old, t_new, task_old_1, task_old_2 = asyncio.run(_setup())
 
-                return t_old, t_new, task_old_1, task_old_2
-            finally:
-                await client.aclose()
+    # Dry-run first
+    res_preview = runner.invoke(cli_main, ["thread", "purge", "--older-than", "7d", "--dry-run"])
+    assert res_preview.exit_code == 0, res_preview.output
+    assert t_old in res_preview.output
+    assert t_new not in res_preview.output
 
-        t_old, t_new, task_old_1, task_old_2 = asyncio.run(_setup())
+    # Purge for real (includes tasks by default)
+    res = runner.invoke(cli_main, ["thread", "purge", "--older-than", "7d", "-y"])
+    assert res.exit_code == 0, res.output
+    assert "Threads deleted:" in res.output
 
-        # Dry-run first
-        res_preview = runner.invoke(
-            cli_main, ["thread", "purge", "--older-than", "7d", "--dry-run"]
-        )
-        assert res_preview.exit_code == 0, res_preview.output
-        assert t_old in res_preview.output
-        assert t_new not in res_preview.output
+    # Validate: old thread and its tasks removed; new thread remains
+    async def _validate():
+        from redis.asyncio import Redis as AsyncRedis
 
-        # Purge for real (includes tasks by default)
-        res = runner.invoke(cli_main, ["thread", "purge", "--older-than", "7d", "-y"])
-        assert res.exit_code == 0, res.output
-        assert "Threads deleted:" in res.output
+        from redis_sre_agent.core.keys import RedisKeys
+        from redis_sre_agent.core.redis import SRE_TASKS_INDEX, SRE_THREADS_INDEX
 
-        # Validate: old thread and its tasks removed; new thread remains
-        async def _validate():
-            from redis.asyncio import Redis as AsyncRedis
+        client = AsyncRedis.from_url(redis_url, decode_responses=False)
+        try:
+            # Old thread keys gone
+            assert not (await client.exists(RedisKeys.thread_metadata(t_old)))
+            assert not (await client.exists(RedisKeys.thread_context(t_old)))
+            assert not (await client.exists(f"{SRE_THREADS_INDEX}:{t_old}"))
+            # Old tasks gone (KV + FT)
+            for tid in (task_old_1, task_old_2):
+                assert not (await client.exists(RedisKeys.task_status(tid)))
+                assert not (await client.exists(RedisKeys.task_metadata(tid)))
+                assert not (await client.exists(f"{SRE_TASKS_INDEX}:{tid}"))
+            # New thread still present
+            assert await client.exists(RedisKeys.thread_metadata(t_new))
+            assert await client.exists(f"{SRE_THREADS_INDEX}:{t_new}")
+        finally:
+            await client.aclose()
 
-            from redis_sre_agent.core.keys import RedisKeys
-            from redis_sre_agent.core.redis import SRE_TASKS_INDEX, SRE_THREADS_INDEX
-
-            client = AsyncRedis.from_url(redis_url, decode_responses=False)
-            try:
-                # Old thread keys gone
-                assert not (await client.exists(RedisKeys.thread_metadata(t_old)))
-                assert not (await client.exists(RedisKeys.thread_context(t_old)))
-                assert not (await client.exists(f"{SRE_THREADS_INDEX}:{t_old}"))
-                # Old tasks gone (KV + FT)
-                for tid in (task_old_1, task_old_2):
-                    assert not (await client.exists(RedisKeys.task_status(tid)))
-                    assert not (await client.exists(RedisKeys.task_metadata(tid)))
-                    assert not (await client.exists(f"{SRE_TASKS_INDEX}:{tid}"))
-                # New thread still present
-                assert await client.exists(RedisKeys.thread_metadata(t_new))
-                assert await client.exists(f"{SRE_THREADS_INDEX}:{t_new}")
-            finally:
-                await client.aclose()
-
-        asyncio.run(_validate())
-    finally:
-        config_module.settings = original_settings
+    asyncio.run(_validate())
 
 
 def test_task_purge_by_status_and_age(redis_url):
-    import redis_sre_agent.core.config as config_module
+    runner = CliRunner()
 
-    original_settings = config_module.settings
-    try:
-        config_module.settings.redis_url = SecretStr(redis_url)
+    async def _setup():
+        from redis.asyncio import Redis as AsyncRedis
 
-        runner = CliRunner()
+        from redis_sre_agent.core.tasks import TaskManager, TaskStatus
+        from redis_sre_agent.core.threads import ThreadManager
 
-        async def _setup():
-            from redis.asyncio import Redis as AsyncRedis
+        client = AsyncRedis.from_url(redis_url, decode_responses=False)
+        try:
+            await client.flushdb()
 
-            from redis_sre_agent.core.tasks import TaskManager, TaskStatus
-            from redis_sre_agent.core.threads import ThreadManager
+            tm = ThreadManager(redis_client=client)
+            task_mgr = TaskManager(redis_client=client)
 
-            client = AsyncRedis.from_url(redis_url, decode_responses=False)
-            try:
-                await client.flushdb()
+            thread_id = await tm.create_thread(user_id="u1", session_id="s1")
+            t_done_old = await task_mgr.create_task(
+                thread_id=thread_id, user_id="u1", subject="done-old"
+            )
+            t_done_new = await task_mgr.create_task(
+                thread_id=thread_id, user_id="u1", subject="done-new"
+            )
+            t_queued_old = await task_mgr.create_task(
+                thread_id=thread_id, user_id="u1", subject="queued-old"
+            )
 
-                tm = ThreadManager(redis_client=client)
-                task_mgr = TaskManager(redis_client=client)
+            await task_mgr.update_task_status(t_done_old, TaskStatus.DONE)
+            await task_mgr.update_task_status(t_done_new, TaskStatus.DONE)
+            # Leave t_queued_old in queued
 
-                thread_id = await tm.create_thread(user_id="u1", session_id="s1")
-                t_done_old = await task_mgr.create_task(
-                    thread_id=thread_id, user_id="u1", subject="done-old"
-                )
-                t_done_new = await task_mgr.create_task(
-                    thread_id=thread_id, user_id="u1", subject="done-new"
-                )
-                t_queued_old = await task_mgr.create_task(
-                    thread_id=thread_id, user_id="u1", subject="queued-old"
-                )
+            now = datetime.now(timezone.utc)
+            await _set_task_status_and_time(
+                task_mgr, client, t_done_old, "done", now - timedelta(days=10)
+            )
+            await _set_task_status_and_time(
+                task_mgr, client, t_done_new, "done", now - timedelta(hours=1)
+            )
+            await _set_task_status_and_time(
+                task_mgr, client, t_queued_old, "queued", now - timedelta(days=10)
+            )
 
-                await task_mgr.update_task_status(t_done_old, TaskStatus.DONE)
-                await task_mgr.update_task_status(t_done_new, TaskStatus.DONE)
-                # Leave t_queued_old in queued
+            return thread_id, t_done_old, t_done_new, t_queued_old
+        finally:
+            await client.aclose()
 
-                now = datetime.now(timezone.utc)
-                await _set_task_status_and_time(
-                    task_mgr, client, t_done_old, "done", now - timedelta(days=10)
-                )
-                await _set_task_status_and_time(
-                    task_mgr, client, t_done_new, "done", now - timedelta(hours=1)
-                )
-                await _set_task_status_and_time(
-                    task_mgr, client, t_queued_old, "queued", now - timedelta(days=10)
-                )
+    thread_id, t_done_old, t_done_new, t_queued_old = asyncio.run(_setup())
 
-                return thread_id, t_done_old, t_done_new, t_queued_old
-            finally:
-                await client.aclose()
+    # Dry-run first: expect to see only the old done task
+    res_preview = runner.invoke(
+        cli_main,
+        ["task", "purge", "--status", "done", "--older-than", "7d", "--dry-run"],
+    )
+    assert res_preview.exit_code == 0, res_preview.output
+    assert t_done_old in res_preview.output
+    assert t_done_new not in res_preview.output
+    assert t_queued_old not in res_preview.output
 
-        thread_id, t_done_old, t_done_new, t_queued_old = asyncio.run(_setup())
+    # Purge for real
+    res = runner.invoke(
+        cli_main,
+        ["task", "purge", "--status", "done", "--older-than", "7d", "-y"],
+    )
+    assert res.exit_code == 0, res.output
 
-        # Dry-run first: expect to see only the old done task
-        res_preview = runner.invoke(
-            cli_main,
-            ["task", "purge", "--status", "done", "--older-than", "7d", "--dry-run"],
-        )
-        assert res_preview.exit_code == 0, res_preview.output
-        assert t_done_old in res_preview.output
-        assert t_done_new not in res_preview.output
-        assert t_queued_old not in res_preview.output
+    # Validate: old done task removed; others remain
+    async def _validate():
+        from redis.asyncio import Redis as AsyncRedis
 
-        # Purge for real
-        res = runner.invoke(
-            cli_main,
-            ["task", "purge", "--status", "done", "--older-than", "7d", "-y"],
-        )
-        assert res.exit_code == 0, res.output
+        from redis_sre_agent.core.keys import RedisKeys
+        from redis_sre_agent.core.redis import SRE_TASKS_INDEX
 
-        # Validate: old done task removed; others remain
-        async def _validate():
-            from redis.asyncio import Redis as AsyncRedis
+        client = AsyncRedis.from_url(redis_url, decode_responses=False)
+        try:
+            # Old done task gone
+            assert not (await client.exists(RedisKeys.task_status(t_done_old)))
+            assert not (await client.exists(f"{SRE_TASKS_INDEX}:{t_done_old}"))
+            # New done task remains
+            assert await client.exists(RedisKeys.task_status(t_done_new))
+            # Queued old task remains (we filtered by status=done)
+            assert await client.exists(RedisKeys.task_status(t_queued_old))
+        finally:
+            await client.aclose()
 
-            from redis_sre_agent.core.keys import RedisKeys
-            from redis_sre_agent.core.redis import SRE_TASKS_INDEX
-
-            client = AsyncRedis.from_url(redis_url, decode_responses=False)
-            try:
-                # Old done task gone
-                assert not (await client.exists(RedisKeys.task_status(t_done_old)))
-                assert not (await client.exists(f"{SRE_TASKS_INDEX}:{t_done_old}"))
-                # New done task remains
-                assert await client.exists(RedisKeys.task_status(t_done_new))
-                # Queued old task remains (we filtered by status=done)
-                assert await client.exists(RedisKeys.task_status(t_queued_old))
-            finally:
-                await client.aclose()
-
-        asyncio.run(_validate())
-    finally:
-        config_module.settings = original_settings
+    asyncio.run(_validate())

--- a/tests/integration/test_cli_task_list_display.py
+++ b/tests/integration/test_cli_task_list_display.py
@@ -3,7 +3,6 @@ import json
 
 import pytest
 from click.testing import CliRunner
-from pydantic import SecretStr
 
 from redis_sre_agent.cli.main import main as cli_main
 
@@ -16,132 +15,119 @@ def test_task_list_shows_task_id_and_local_time_and_done_status(redis_url):
 
     Uses a real Redis (docker-compose integration fixture) and no mocks.
     """
-    # Patch settings so CLI uses the integration Redis
-    import redis_sre_agent.core.config as config_module
+    runner = CliRunner()
 
-    original_settings = config_module.settings
-    try:
-        # Clone settings with updated redis_url (minimally mutate the existing instance)
-        config_module.settings.redis_url = SecretStr(redis_url)
+    async def _setup():
+        from redis.asyncio import Redis as AsyncRedis
 
-        runner = CliRunner()
+        from redis_sre_agent.core.tasks import TaskManager, TaskStatus
+        from redis_sre_agent.core.threads import ThreadManager
 
-        async def _setup():
-            from redis.asyncio import Redis as AsyncRedis
+        # Create a clean client to the same Redis the CLI will hit
+        client = AsyncRedis.from_url(redis_url, decode_responses=False)
+        try:
+            await client.flushdb()
 
-            from redis_sre_agent.core.tasks import TaskManager
-            from redis_sre_agent.core.threads import TaskStatus, ThreadManager
+            tm = ThreadManager(redis_client=client)
+            thread_id = await tm.create_thread(user_id="test-user", session_id="s")
 
-            # Create a clean client to the same Redis the CLI will hit
-            client = AsyncRedis.from_url(redis_url, decode_responses=False)
-            try:
-                await client.flushdb()
+            task_mgr = TaskManager(redis_client=client)
+            task_id = await task_mgr.create_task(
+                thread_id=thread_id, user_id="test-user", subject="Test task"
+            )
 
-                tm = ThreadManager(redis_client=client)
-                thread_id = await tm.create_thread(user_id="test-user", session_id="s")
+            # Mark task done and set a simple result
+            await task_mgr.set_task_result(task_id, {"ok": True})
+            await task_mgr.update_task_status(task_id, TaskStatus.DONE)
 
-                task_mgr = TaskManager(redis_client=client)
-                task_id = await task_mgr.create_task(
-                    thread_id=thread_id, user_id="test-user", subject="Test task"
-                )
+            # Small wait to allow RediSearch to index initial doc (queued). The CLI refreshes status from KV.
+            await asyncio.sleep(0.05)
 
-                # Mark task done and set a simple result
-                await task_mgr.set_task_result(task_id, {"ok": True})
-                await task_mgr.update_task_status(task_id, TaskStatus.DONE)
+            return thread_id, task_id
+        finally:
+            await client.aclose()
 
-                # Small wait to allow RediSearch to index initial doc (queued). The CLI refreshes status from KV.
-                await asyncio.sleep(0.05)
+    thread_id, task_id = asyncio.run(_setup())
 
-                return thread_id, task_id
-            finally:
-                await client.aclose()
+    # Invoke CLI and include DONE tasks. Set a wide terminal to avoid Rich truncation.
+    env = {"COLUMNS": "220"}
+    result = runner.invoke(
+        cli_main,
+        ["task", "list", "--all", "--limit", "10", "--tz", "UTC"],
+        env=env,
+    )
+    assert result.exit_code == 0, result.output
+    out = result.output
 
-        thread_id, task_id = asyncio.run(_setup())
+    # Headers
+    assert "Tasks" in out
+    assert "Task ID" in out
 
-        # Invoke CLI and include DONE tasks. Set a wide terminal to avoid Rich truncation.
-        env = {"COLUMNS": "220"}
-        result = runner.invoke(
-            cli_main,
-            ["task", "list", "--all", "--limit", "10", "--tz", "UTC"],
-            env=env,
-        )
-        assert result.exit_code == 0, result.output
-        out = result.output
+    # Should show our task id (or at least its prefix) and status done
+    assert (task_id in out) or (task_id[:12] in out)
+    assert "done" in out
+    # Should show a timezone label (UTC was requested)
+    assert "UTC" in out
 
-        # Headers
-        assert "Tasks" in out
-        assert "Task ID" in out
-
-        # Should show our task id (or at least its prefix) and status done
-        assert (task_id in out) or (task_id[:12] in out)
-        assert "done" in out
-        # Should show a timezone label (UTC was requested)
-        assert "UTC" in out
-
-        # Sanity: thread id also present (may be truncated; check prefix)
-        assert (thread_id in out) or (thread_id[:12] in out)
-    finally:
-        config_module.settings = original_settings
+    # Sanity: thread id also present (may be truncated; check prefix)
+    assert (thread_id in out) or (thread_id[:12] in out)
 
 
 def test_thread_sources_lists_recorded_fragments(redis_url):
     """Record a knowledge_sources update and verify CLI returns it (JSON mode)."""
-    import redis_sre_agent.core.config as config_module
+    runner = CliRunner()
 
-    original_settings = config_module.settings
-    try:
-        config_module.settings.redis_url = SecretStr(redis_url)
+    async def _setup_and_emit():
+        from redis.asyncio import Redis as AsyncRedis
 
-        runner = CliRunner()
+        from redis_sre_agent.core.tasks import TaskManager
+        from redis_sre_agent.core.threads import ThreadManager
 
-        async def _setup_and_emit():
-            from redis.asyncio import Redis as AsyncRedis
+        client = AsyncRedis.from_url(redis_url, decode_responses=False)
+        try:
+            await client.flushdb()
 
-            from redis_sre_agent.core.threads import ThreadManager
+            tm = ThreadManager(redis_client=client)
+            thread_id = await tm.create_thread(user_id="u", session_id="s")
+            task_mgr = TaskManager(redis_client=client)
+            task_id = await task_mgr.create_task(
+                thread_id=thread_id, user_id="u", subject="source lookup"
+            )
+            # Emit a knowledge_sources update for the task attached to this thread.
+            await task_mgr.add_task_update(
+                task_id,
+                "Found fragments",
+                "knowledge_sources",
+                {
+                    "task_id": "task-xyz",
+                    "fragments": [
+                        {
+                            "id": "frag-1",
+                            "document_hash": "doc-abc",
+                            "chunk_index": 0,
+                            "title": "Example title",
+                            "source": "https://example.com/doc",
+                        }
+                    ],
+                },
+            )
+            return thread_id
+        finally:
+            await client.aclose()
 
-            client = AsyncRedis.from_url(redis_url, decode_responses=False)
-            try:
-                await client.flushdb()
+    thread_id = asyncio.run(_setup_and_emit())
 
-                tm = ThreadManager(redis_client=client)
-                thread_id = await tm.create_thread(user_id="u", session_id="s")
-                # Emit a knowledge_sources update
-                await tm.add_thread_update(
-                    thread_id,
-                    "Found fragments",
-                    "knowledge_sources",
-                    {
-                        "task_id": "task-xyz",
-                        "fragments": [
-                            {
-                                "id": "frag-1",
-                                "document_hash": "doc-abc",
-                                "chunk_index": 0,
-                                "title": "Example title",
-                                "source": "https://example.com/doc",
-                            }
-                        ],
-                    },
-                )
-                return thread_id
-            finally:
-                await client.aclose()
-
-        thread_id = asyncio.run(_setup_and_emit())
-
-        # Invoke CLI in JSON mode for stable assertions
-        result = runner.invoke(cli_main, ["thread", "sources", thread_id, "--json"])
-        assert result.exit_code == 0, result.output
-        payload = json.loads(result.output)
-        assert payload["thread_id"] == thread_id
-        frags = payload.get("fragments") or []
-        assert len(frags) == 1
-        frag = frags[0]
-        assert frag["id"] == "frag-1"
-        assert frag["document_hash"] == "doc-abc"
-        assert frag["chunk_index"] == 0
-        assert frag["title"] == "Example title"
-        assert frag["source"].startswith("http")
-        assert payload.get("task_id") is None  # Filter is optional, not set
-    finally:
-        config_module.settings = original_settings
+    # Invoke CLI in JSON mode for stable assertions
+    result = runner.invoke(cli_main, ["thread", "sources", thread_id, "--json"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["thread_id"] == thread_id
+    frags = payload.get("fragments") or []
+    assert len(frags) == 1
+    frag = frags[0]
+    assert frag["id"] == "frag-1"
+    assert frag["document_hash"] == "doc-abc"
+    assert frag["chunk_index"] == 0
+    assert frag["title"] == "Example title"
+    assert frag["source"].startswith("http")
+    assert payload.get("task_id") is None  # Filter is optional, not set

--- a/tests/integration/test_docket_sre_integration.py
+++ b/tests/integration/test_docket_sre_integration.py
@@ -1,7 +1,8 @@
 """Docket integration tests for SRE tasks with real Redis."""
 
 import asyncio
-from unittest.mock import patch
+from array import array
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
@@ -89,10 +90,11 @@ class TestDocketSREIntegration:
         await create_indices(config=test_settings)
 
         # Mock vectorizer to avoid OpenAI calls in Docket integration tests
-        with patch("redis_sre_agent.core.tasks.get_vectorizer") as mock_vectorizer:
-            mock_vectorizer_instance = mock_vectorizer.return_value
-            mock_vectorizer_instance.embed_many.return_value = [[0.1] * 1536]
-
+        vectorizer = Mock()
+        vectorizer.aembed = AsyncMock(return_value=array("f", [0.1] * 1536).tobytes())
+        with patch(
+            "redis_sre_agent.core.knowledge_helpers.get_vectorizer", return_value=vectorizer
+        ):
             # Execute the task
             result = await ingest_sre_document(
                 title="Docket Integration Test Document",
@@ -117,21 +119,24 @@ class TestDocketSREIntegration:
         await create_indices(config=test_settings)
 
         # Mock vectorizer for consistent testing
-        with patch("redis_sre_agent.core.tasks.get_vectorizer") as mock_vectorizer:
-            mock_vectorizer_instance = mock_vectorizer.return_value
-            mock_vectorizer_instance.embed_many.return_value = [[0.2] * 1536]
-
+        vectorizer = Mock()
+        vectorizer.aembed_many = AsyncMock(return_value=[[0.2] * 1536])
+        with patch(
+            "redis_sre_agent.core.knowledge_helpers.get_vectorizer", return_value=vectorizer
+        ):
             # Mock search results
-            with patch("redis_sre_agent.core.tasks.get_knowledge_index") as mock_index:
+            with patch("redis_sre_agent.core.knowledge_helpers.get_knowledge_index") as mock_index:
                 mock_index_instance = mock_index.return_value
-                mock_index_instance.query.return_value = [
-                    {
-                        "title": "Mock SRE Document",
-                        "content": "Mock content for testing search functionality",
-                        "source": "mock_runbook.md",
-                        "score": 0.85,
-                    }
-                ]
+                mock_index_instance.query = AsyncMock(
+                    return_value=[
+                        {
+                            "title": "Mock SRE Document",
+                            "content": "Mock content for testing search functionality",
+                            "source": "mock_runbook.md",
+                            "score": 0.85,
+                        }
+                    ]
+                )
 
                 # Execute the task
                 result = await search_knowledge_base(
@@ -158,33 +163,28 @@ class TestDocketSREIntegration:
         """Test concurrent execution of multiple SRE tasks."""
         await create_indices(config=test_settings)
 
-        # Mock vectorizer for predictable results
-        with patch("redis_sre_agent.core.tasks.get_vectorizer") as mock_vectorizer:
-            mock_vectorizer_instance = mock_vectorizer.return_value
-            mock_vectorizer_instance.embed_many.return_value = [[0.3] * 1536]
+        # Execute multiple tasks concurrently
+        tasks = [
+            check_service_health("redis_cluster", ["redis:6379"], 30),
+            check_service_health("web_servers", ["web1:80", "web2:80"], 30),
+        ]
 
-            # Execute multiple tasks concurrently
-            tasks = [
-                check_service_health("redis_cluster", ["redis:6379"], 30),
-                check_service_health("web_servers", ["web1:80", "web2:80"], 30),
-            ]
+        # Run concurrently
+        results = await asyncio.gather(*tasks)
 
-            # Run concurrently
-            results = await asyncio.gather(*tasks)
+        # Validate all tasks completed
+        assert len(results) == 2
 
-            # Validate all tasks completed
-            assert len(results) == 2
+        # Validate each result has expected structure
+        for result in results:
+            assert "task_id" in result
+            assert "timestamp" in result
+            assert "overall_status" in result
+            assert "health_checks" in result
 
-            # Validate each result has expected structure
-            for result in results:
-                assert "task_id" in result
-                assert "timestamp" in result
-                assert "overall_status" in result
-                assert "health_checks" in result
-
-            # Verify all task IDs are unique
-            task_ids = [result["task_id"] for result in results]
-            assert len(set(task_ids)) == 2  # All unique
+        # Verify all task IDs are unique
+        task_ids = [result["task_id"] for result in results]
+        assert len(set(task_ids)) == 2  # All unique
 
     @pytest.mark.asyncio
     async def test_task_retry_behavior(self, test_settings):
@@ -218,19 +218,20 @@ class TestDocketSREIntegration:
 class TestDocketWorkerIntegration:
     """Test Docket worker integration with SRE tasks."""
 
-    @pytest.mark.asyncio
-    async def test_worker_startup_with_real_redis(self, redis_url):
+    def test_worker_startup_with_real_redis(self, redis_url):
         """Test that worker can start up with real Redis."""
         from click.testing import CliRunner
 
-        from redis_sre_agent.cli.main import worker as worker_cmd
+        from redis_sre_agent.cli.worker import worker as worker_cmd
 
         # Mock Worker.run to avoid infinite loop
-        with patch("redis_sre_agent.cli.main.Worker.run") as mock_worker_run:
+        with patch(
+            "redis_sre_agent.cli.worker.Worker.run", new_callable=AsyncMock
+        ) as mock_worker_run:
             mock_worker_run.return_value = None
 
-            # Invoke CLI with redis_url env var
-            result = CliRunner(env={"REDIS_URL": redis_url}).invoke(worker_cmd)
+            # Invoke CLI with global settings already routed to the testcontainer.
+            result = CliRunner().invoke(worker_cmd, ["start", "--concurrency", "2"])
             assert result.exit_code == 0
 
             # Verify Worker.run was called with correct parameters
@@ -240,15 +241,12 @@ class TestDocketWorkerIntegration:
             assert call_kwargs["docket_name"] == "sre_docket"
             assert call_kwargs["url"] == redis_url
             assert call_kwargs["concurrency"] == 2
-            assert call_kwargs["tasks"] == ["redis_sre_agent.core.tasks:SRE_TASK_COLLECTION"]
+            assert call_kwargs["tasks"] == ["redis_sre_agent.core.docket_tasks:SRE_TASK_COLLECTION"]
 
     @pytest.mark.asyncio
     async def test_task_collection_registration(self, test_settings):
         """Test that SRE task collection is properly registered."""
         from redis_sre_agent.core.docket_tasks import SRE_TASK_COLLECTION
-
-        # Verify task collection has expected tasks
-        assert len(SRE_TASK_COLLECTION) == 4
 
         task_names = [task.__name__ for task in SRE_TASK_COLLECTION]
         expected_tasks = [
@@ -257,6 +255,8 @@ class TestDocketWorkerIntegration:
             "scheduler_task",
         ]
 
+        # Verify task collection includes the core task wrappers.
+        assert len(SRE_TASK_COLLECTION) >= len(expected_tasks)
         for expected_task in expected_tasks:
             assert expected_task in task_names
 
@@ -279,8 +279,10 @@ class TestDocketErrorHandling:
 
         invalid_settings = Settings(redis_url=SecretStr("redis://invalid-host:6379/0"))
 
-        # Task system test should fail gracefully with injected invalid config
-        system_ok = await test_task_system(config=invalid_settings)
+        # Task system test should fail gracefully when Docket cannot connect.
+        with patch("redis_sre_agent.core.docket_tasks.Docket") as mock_docket:
+            mock_docket.return_value.__aenter__.side_effect = OSError("connection failed")
+            system_ok = await test_task_system(config=invalid_settings)
         assert system_ok is False
 
     @pytest.mark.asyncio

--- a/tests/integration/test_instance_tool_routing.py
+++ b/tests/integration/test_instance_tool_routing.py
@@ -12,21 +12,23 @@ from redis_sre_agent.core.instances import (
     get_instances,
     save_instances,
 )
-from redis_sre_agent.core.redis import get_redis_client
 from redis_sre_agent.core.threads import ThreadManager
 
 
 @pytest.fixture
-async def thread_manager():
+async def thread_manager(async_redis_client):
     """Get the ThreadManager bound to the test Redis."""
-    manager = ThreadManager(redis_client=get_redis_client())
+    manager = ThreadManager(redis_client=async_redis_client)
     yield manager
 
 
 @pytest.mark.integration
 @pytest.mark.asyncio
-async def test_tools_connect_to_correct_instance(thread_manager):
+async def test_tools_connect_to_correct_instance(thread_manager, async_redis_client):
     """Test that diagnostic tools connect to the specified instance, not default Redis."""
+    from redis_sre_agent.core.tasks import TaskManager
+
+    task_manager = TaskManager(redis_client=async_redis_client)
 
     # 1. Register a Redis Enterprise instance (simulating user's production instance)
     test_instance = RedisInstance(
@@ -63,6 +65,7 @@ async def test_tools_connect_to_correct_instance(thread_manager):
 
     print(f"✅ Created thread: {thread_id}")
     print(f"   Instance context: {test_instance.id}")
+    task_id = await task_manager.create_task(thread_id=thread_id, user_id="test-user")
 
     # 3. Ask about the instance's health (this should trigger diagnostics)
     query = f"Check the health of Redis instance {test_instance.name}"
@@ -78,26 +81,29 @@ async def test_tools_connect_to_correct_instance(thread_manager):
         await process_agent_turn(
             thread_id=thread_id,
             message=query,
+            task_id=task_id,
         )
     except Exception as e:
         print(f"\n⚠️  Agent execution failed (expected): {e}")
 
     # 5. Verify the thread state and check what happened
     thread_state = await thread_manager.get_thread(thread_id)
+    task_state = await task_manager.get_task_state(task_id)
+    task_updates = task_state.updates if task_state else []
 
     print("\n📊 Thread state:")
     print(f"   Context keys: {list(thread_state.context.keys())}")
-    print(f"   Updates: {len(thread_state.updates)}")
-    print(f"   Result: {thread_state.result}")
+    print(f"   Updates: {len(task_updates)}")
+    print(f"   Result: {task_state.result if task_state else None}")
 
     # Print ALL updates to see what happened
     print("\n📝 All updates:")
-    for i, update in enumerate(thread_state.updates):
+    for i, update in enumerate(task_updates):
         print(f"   {i + 1}. [{update.update_type}] {update.message[:150]}")
 
     # Check the updates for evidence of which Redis URL was used
     redis_urls_mentioned = []
-    for update in thread_state.updates:
+    for update in task_updates:
         if "redis://" in update.message:
             print(f"   Update with Redis URL: {update.message[:100]}")
             # Extract Redis URLs from the message
@@ -108,15 +114,17 @@ async def test_tools_connect_to_correct_instance(thread_manager):
 
     # Also check the final result
     result_str = ""
-    if thread_state.result:
+    if task_state and task_state.result:
         print("\n📄 Final result:")
-        result_str = str(thread_state.result)
+        result_str = str(task_state.result)
         print(f"   {result_str[:500]}")
         if "redis://" in result_str:
             import re
 
             urls = re.findall(r"redis://[^\s]+", result_str)
             redis_urls_mentioned.extend(urls)
+    elif task_state and task_state.error_message:
+        result_str = task_state.error_message
 
     print("\n🔍 Redis URLs mentioned in updates:")
     for url in set(redis_urls_mentioned):

--- a/tests/integration/test_llm_judge_evaluation.py
+++ b/tests/integration/test_llm_judge_evaluation.py
@@ -25,10 +25,10 @@ logger = logging.getLogger(__name__)
 openai.api_key = settings.openai_api_key
 
 
-def check_redis_search_available() -> bool:
+def check_redis_search_available(redis_url: str) -> bool:
     """Check if Redis with search capabilities is available (Redis 8+ or Redis Stack)."""
     try:
-        r = redis.Redis.from_url(settings.redis_url)
+        r = redis.Redis.from_url(redis_url)
 
         # Test if FT.SEARCH command is available by checking command info
         try:
@@ -49,10 +49,10 @@ def check_redis_search_available() -> bool:
         return False
 
 
-def check_knowledge_index_exists() -> bool:
+def check_knowledge_index_exists(redis_url: str) -> bool:
     """Check if the sre_knowledge index exists and is populated."""
     try:
-        r = redis.Redis.from_url(settings.redis_url)
+        r = redis.Redis.from_url(redis_url)
         # Try to get index info
         try:
             info = r.execute_command("FT.INFO", "sre_knowledge")
@@ -68,12 +68,6 @@ def check_knowledge_index_exists() -> bool:
             return False
     except Exception:
         return False
-
-
-redis_search_available = check_redis_search_available()
-redis_search_required = pytest.mark.skipif(
-    not redis_search_available, reason="Redis 8+ or Redis Stack with search module required"
-)
 
 
 JUDGE_SYSTEM_PROMPT = """You are an expert Redis Site Reliability Engineer with 10+ years of production experience managing Redis at scale. You will evaluate search results from a Redis SRE knowledge base.
@@ -572,8 +566,7 @@ async def run_comprehensive_llm_judge_evaluation():
 @pytest.mark.asyncio
 @pytest.mark.integration
 @pytest.mark.slow
-@redis_search_required
-async def test_llm_judge_evaluation():
+async def test_llm_judge_evaluation(redis_url):
     """Test comprehensive LLM judge evaluation of Redis SRE search quality.
 
     This test requires:
@@ -583,8 +576,11 @@ async def test_llm_judge_evaluation():
     The test will be skipped if either requirement is not met.
     """
 
+    if not check_redis_search_available(redis_url):
+        pytest.skip("Redis 8+ with search support required")
+
     # Skip if knowledge base is not populated
-    if not check_knowledge_index_exists():
+    if not check_knowledge_index_exists(redis_url):
         pytest.skip(
             "Knowledge base not populated - run 'poetry run redis-sre-agent pipeline run-all' first"
         )
@@ -626,8 +622,7 @@ async def test_llm_judge_evaluation():
 @pytest.mark.asyncio
 @pytest.mark.integration
 @pytest.mark.slow
-@redis_search_required
-async def test_single_scenario_evaluation():
+async def test_single_scenario_evaluation(redis_url):
     """Test evaluation of a single scenario for faster feedback.
 
     This test requires:
@@ -638,8 +633,11 @@ async def test_single_scenario_evaluation():
     """
     # Skip if OpenAI API key is not available
 
+    if not check_redis_search_available(redis_url):
+        pytest.skip("Redis 8+ with search support required")
+
     # Skip if knowledge base is not populated
-    if not check_knowledge_index_exists():
+    if not check_knowledge_index_exists(redis_url):
         pytest.skip(
             "Knowledge base not populated - run 'poetry run redis-sre-agent pipeline run-all' first"
         )

--- a/tests/integration/test_multi_turn_agent_evaluation.py
+++ b/tests/integration/test_multi_turn_agent_evaluation.py
@@ -578,7 +578,7 @@ async def run_multi_turn_evaluation() -> List[Dict[str, Any]]:
 @pytest.mark.asyncio
 @pytest.mark.integration
 @pytest.mark.slow
-async def test_multi_turn_agent_evaluation():
+async def test_multi_turn_agent_evaluation(test_settings):
     """Test comprehensive multi-turn agent evaluation."""
 
     # Check if knowledge base is available
@@ -587,7 +587,7 @@ async def test_multi_turn_agent_evaluation():
     from redis_sre_agent.core.redis import get_redis_client
 
     try:
-        redis_client = await get_redis_client()
+        redis_client = await get_redis_client(config=test_settings)
         index = AsyncSearchIndex.from_dict(
             {
                 "index": {"name": "sre_knowledge", "prefix": "doc"},

--- a/tests/unit/agent/test_agent.py
+++ b/tests/unit/agent/test_agent.py
@@ -62,6 +62,16 @@ def mock_sre_tasks():
                     yield mocks
 
 
+@pytest.fixture(autouse=True)
+def mock_configured_instances():
+    """Keep agent unit tests isolated from locally configured Redis instances."""
+    with patch(
+        "redis_sre_agent.agent.langgraph_agent.get_instances",
+        AsyncMock(return_value=[]),
+    ):
+        yield
+
+
 class TestSRELangGraphAgent:
     """Test cases for SRE LangGraph Agent."""
 

--- a/tests/unit/agent/test_chat_agent.py
+++ b/tests/unit/agent/test_chat_agent.py
@@ -2872,3 +2872,4 @@ class TestChatAgentStartupContext:
             {"id": "call-1", "name": "demo", "args": {}, "type": "tool_call"}
         ]
         assert tool_state["toolset_generation"] == 1
+        assert tool_state["skill_contract_gaps"] is None

--- a/tests/unit/agent/test_chat_agent.py
+++ b/tests/unit/agent/test_chat_agent.py
@@ -684,6 +684,69 @@ class TestSkillContractRuntimeRepair:
             for message in second_invoke_messages
         )
 
+    @pytest.mark.asyncio
+    @patch("redis_sre_agent.agent.helpers.build_adapters_for_tooldefs", new_callable=AsyncMock)
+    @patch("redis_sre_agent.agent.chat_agent.create_llm")
+    @patch("redis_sre_agent.agent.chat_agent.create_mini_llm")
+    async def test_workflow_skips_llm_when_skill_contract_repair_limit_is_exhausted(
+        self,
+        mock_create_mini_llm,
+        mock_create_llm,
+        mock_build_adapters,
+    ):
+        mock_llm = MagicMock()
+        mock_llm.bind_tools.return_value = mock_llm
+        mock_llm.ainvoke = AsyncMock(return_value=AIMessage(content="unused"))
+        mock_create_llm.return_value = mock_llm
+        mock_create_mini_llm.return_value = mock_llm
+        mock_build_adapters.return_value = []
+
+        agent = ChatAgent()
+        mock_tool_mgr = MagicMock()
+        mock_tool_mgr.get_tools_for_llm.return_value = []
+        mock_tool_mgr.get_toolset_generation.return_value = 1
+        workflow = agent._build_workflow(tool_mgr=mock_tool_mgr, emitter=None)
+        compiled = workflow.compile()
+
+        previous_response = "## Summary\nStill missing required ending."
+        state = {
+            "messages": [
+                HumanMessage(content="Review incident"),
+                AIMessage(content=previous_response),
+            ],
+            "session_id": "test-session",
+            "user_id": "test-user",
+            "current_tool_calls": [],
+            "iteration_count": 1,
+            "max_iterations": 10,
+            "startup_system_prompt": "CTX",
+            "startup_prompt_initialized": True,
+            "skill_contract_repair_attempts": agent.SKILL_CONTRACT_REPAIR_ATTEMPT_LIMIT,
+            "signals_envelopes": [
+                {
+                    "tool_key": "knowledge_123abc_get_skill",
+                    "name": "get_skill",
+                    "data": {
+                        "skill_name": "example-incident-brief",
+                        "output_contract": {
+                            "required_patterns": [
+                                {
+                                    "pattern": r"(?s)## Open Questions\s*$",
+                                    "description": "End with the Open Questions section.",
+                                }
+                            ]
+                        },
+                    },
+                }
+            ],
+        }
+
+        final_state = await compiled.ainvoke(state)
+
+        mock_llm.ainvoke.assert_not_awaited()
+        assert final_state["messages"] == state["messages"]
+        assert final_state["iteration_count"] == 1
+
     def test_system_prompt_warns_about_managed_redis(self):
         """Test that the system prompt has Redis Enterprise/Cloud notes."""
         assert "Enterprise" in CHAT_SYSTEM_PROMPT or "Cloud" in CHAT_SYSTEM_PROMPT

--- a/tests/unit/agent/test_chat_agent.py
+++ b/tests/unit/agent/test_chat_agent.py
@@ -607,6 +607,7 @@ class TestSkillContractRuntimeRepair:
         mock_create_mini_llm,
         mock_create_llm,
         mock_build_adapters,
+        monkeypatch,
     ):
         mock_llm = MagicMock()
         mock_llm.bind_tools.return_value = mock_llm
@@ -626,6 +627,15 @@ class TestSkillContractRuntimeRepair:
         mock_tool_mgr.get_toolset_generation.return_value = 1
         workflow = agent._build_workflow(tool_mgr=mock_tool_mgr, emitter=None)
         compiled = workflow.compile()
+
+        collect_calls = {"count": 0}
+        real_collect = chat_agent_module._collect_skill_contract_gaps
+
+        def collect_spy(envelopes, messages):
+            collect_calls["count"] += 1
+            return real_collect(envelopes, messages)
+
+        monkeypatch.setattr(chat_agent_module, "_collect_skill_contract_gaps", collect_spy)
 
         state = {
             "messages": [HumanMessage(content="Review incident")],
@@ -666,6 +676,7 @@ class TestSkillContractRuntimeRepair:
         assert mock_llm.ainvoke.await_count == 2
         assert final_state["iteration_count"] == 2
         assert final_state["skill_contract_repair_attempts"] == 1
+        assert collect_calls["count"] == 4
         second_invoke_messages = mock_llm.ainvoke.await_args_list[1].args[0]
         assert any(
             isinstance(message, SystemMessage)

--- a/tests/unit/agent/test_chat_agent.py
+++ b/tests/unit/agent/test_chat_agent.py
@@ -599,6 +599,38 @@ class TestSkillContractRuntimeRepair:
         assert "Skill contract repair failed; returning original response" in caplog.text
 
     @pytest.mark.asyncio
+    async def test_final_skill_contract_repair_respects_exhausted_attempt_budget(self):
+        agent = ChatAgent.__new__(ChatAgent)
+        agent._repair_response_to_skill_contract = AsyncMock(return_value="repaired")
+
+        repaired = await agent._repair_final_response_to_skill_contract(
+            response_text="original",
+            tool_envelopes=[],
+            messages=[],
+            final_state={
+                "skill_contract_repair_attempts": agent.SKILL_CONTRACT_REPAIR_ATTEMPT_LIMIT
+            },
+        )
+
+        assert repaired == "original"
+        agent._repair_response_to_skill_contract.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_final_skill_contract_repair_runs_when_attempt_budget_remains(self):
+        agent = ChatAgent.__new__(ChatAgent)
+        agent._repair_response_to_skill_contract = AsyncMock(return_value="repaired")
+
+        repaired = await agent._repair_final_response_to_skill_contract(
+            response_text="original",
+            tool_envelopes=[],
+            messages=[],
+            final_state={"skill_contract_repair_attempts": 0},
+        )
+
+        assert repaired == "repaired"
+        agent._repair_response_to_skill_contract.assert_awaited_once()
+
+    @pytest.mark.asyncio
     @patch("redis_sre_agent.agent.helpers.build_adapters_for_tooldefs", new_callable=AsyncMock)
     @patch("redis_sre_agent.agent.chat_agent.create_llm")
     @patch("redis_sre_agent.agent.chat_agent.create_mini_llm")
@@ -676,7 +708,7 @@ class TestSkillContractRuntimeRepair:
         assert mock_llm.ainvoke.await_count == 2
         assert final_state["iteration_count"] == 2
         assert final_state["skill_contract_repair_attempts"] == 1
-        assert collect_calls["count"] == 4
+        assert collect_calls["count"] == 3
         second_invoke_messages = mock_llm.ainvoke.await_args_list[1].args[0]
         assert any(
             isinstance(message, SystemMessage)

--- a/tests/unit/agent/test_chat_agent.py
+++ b/tests/unit/agent/test_chat_agent.py
@@ -1,5 +1,6 @@
 """Unit tests for the lightweight Chat Agent."""
 
+import logging
 from contextlib import asynccontextmanager
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -7,6 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, ToolMessage
 
+from redis_sre_agent.agent import chat_agent as chat_agent_module
 from redis_sre_agent.agent.chat_agent import (
     CHAT_SYSTEM_PROMPT,
     ChatAgent,
@@ -257,7 +259,344 @@ class TestChatAgentSystemPrompt:
         assert "get_skill" in CHAT_SYSTEM_PROMPT
         assert "exact live match" in prompt_lower
         assert "hostname or hostname fragment" in prompt_lower
-        assert "analyzer-backed evidence" in prompt_lower
+        assert "evidence from available tools" in prompt_lower
+
+
+class TestSkillContractRuntimeRepair:
+    """Test generic runtime enforcement for retrieved skill contracts."""
+
+    def test_skill_contract_gap_detection_reports_missing_tools_and_output(self):
+        envelopes = [
+            {
+                "tool_key": "knowledge_123abc_get_skill",
+                "name": "get_skill",
+                "data": {
+                    "skill_name": "example-incident-brief",
+                    "output_contract": {
+                        "required_order": [
+                            "## Summary",
+                            "## Evidence Timeline",
+                            "## Tool Findings",
+                            "## Open Questions",
+                        ],
+                        "required_patterns": [
+                            {
+                                "pattern": r"(?m)^### Metrics$",
+                                "description": "Include the Metrics subsection.",
+                            }
+                        ],
+                    },
+                    "workflow_contract": {
+                        "required_tool_calls": [
+                            "get_incident",
+                            "get_metric_window",
+                        ],
+                        "required_followups": [
+                            "Always fetch metric evidence before finalizing the brief."
+                        ],
+                    },
+                },
+            },
+            {
+                "tool_key": "mcp_example_incident_123abc_list_related_signals",
+                "name": "list_related_signals",
+                "data": {"status": "success"},
+            },
+        ]
+        messages = [
+            HumanMessage(content="Review incident inc-001"),
+            AIMessage(
+                content=(
+                    "# Incident Brief: Checkout API latency\n\n"
+                    "**Incident ID:** inc-001\n"
+                    "**Primary service:** checkout-api\n\n"
+                    "## Summary\nsummary\n"
+                    "## Evidence Timeline\ntimeline\n"
+                    "## Tool Findings\nno metrics subsection yet\n"
+                    "## Open Questions\nnone"
+                )
+            ),
+        ]
+
+        gaps = chat_agent_module._collect_skill_contract_gaps(envelopes, messages)
+
+        assert len(gaps) == 1
+        assert gaps[0]["missing_tools"] == [
+            "get_incident",
+            "get_metric_window",
+        ]
+        assert "Include the Metrics subsection." in gaps[0]["missing_output"]
+        assert gaps[0]["required_followups"] == [
+            "Always fetch metric evidence before finalizing the brief."
+        ]
+
+    def test_tool_requirement_matches_normalized_operation_and_server(self):
+        envelope = {
+            "tool_key": "mcp_example_incident_123abc_get_incident",
+            "name": "get_incident",
+        }
+
+        assert chat_agent_module._tool_requirement_matches("get_incident", envelope)
+        assert chat_agent_module._tool_requirement_matches(
+            {"operation": "get_incident", "server_name": "example_incident"}, envelope
+        )
+
+    def test_missing_output_contract_items_treats_invalid_regex_as_missing(self):
+        missing = chat_agent_module._missing_output_contract_items(
+            {
+                "required_patterns": [
+                    {
+                        "pattern": "[",
+                        "description": "Include the required malformed-pattern section.",
+                    }
+                ]
+            },
+            "## Summary\nok",
+        )
+
+        assert missing == ["Include the required malformed-pattern section."]
+
+    def test_missing_output_contract_items_matches_placeholder_subsections(self):
+        output_contract = {
+            "required_subsections": ["### <signal name>"],
+        }
+
+        assert (
+            chat_agent_module._missing_output_contract_items(
+                output_contract,
+                "## Tool Findings\n\n### Metrics\nHealthy.",
+            )
+            == []
+        )
+
+        assert chat_agent_module._missing_output_contract_items(
+            output_contract,
+            "## Tool Findings\n\nNo signal subsections.",
+        ) == ["Include a subsection matching `### <signal name>`."]
+
+    def test_build_skill_contract_repair_message_mentions_missing_requirements(self):
+        envelopes = [
+            {
+                "tool_key": "knowledge_123abc_get_skill",
+                "name": "get_skill",
+                "data": {
+                    "skill_name": "example-incident-brief",
+                    "output_contract": {
+                        "required_order": ["## Summary", "## Open Questions"],
+                        "required_patterns": [
+                            {
+                                "pattern": r"(?s)## Open Questions\s*$",
+                                "description": "End the document after the `## Open Questions` section without adding a footer.",
+                            }
+                        ],
+                    },
+                    "workflow_contract": {
+                        "required_tool_calls": ["get_metric_window"],
+                        "required_followups": [
+                            "Always fetch metric evidence before finalizing the brief."
+                        ],
+                    },
+                },
+            }
+        ]
+        messages = [
+            HumanMessage(content="Review incident"),
+            AIMessage(
+                content="## Summary\nBrief summary\n\n## Open Questions\nNone\n\nSkill used: example-incident-brief"
+            ),
+        ]
+
+        repair = chat_agent_module._build_skill_contract_repair_message(envelopes, messages)
+
+        assert repair is not None
+        content = str(repair.content)
+        assert "Do not finalize yet" in content
+        assert "`get_metric_window`" in content
+        assert "Always fetch metric evidence before finalizing the brief." in content
+        assert (
+            "End the document after the `## Open Questions` section without adding a footer."
+            in content
+        )
+
+    def test_skill_contract_needs_followup_when_output_constraints_are_missing(self):
+        envelopes = [
+            {
+                "tool_key": "knowledge_123abc_get_skill",
+                "name": "get_skill",
+                "data": {
+                    "skill_name": "example-incident-brief",
+                    "output_contract": {
+                        "required_patterns": [
+                            {
+                                "pattern": r"(?s)## Open Questions\s*$",
+                                "description": "End the document after the `## Open Questions` section without adding a footer.",
+                            }
+                        ]
+                    },
+                    "workflow_contract": {
+                        "required_tool_calls": ["get_incident"],
+                    },
+                },
+            },
+            {
+                "tool_key": "mcp_example_incident_123abc_get_incident",
+                "name": "get_incident",
+                "data": {"status": "success"},
+            },
+        ]
+        messages = [
+            HumanMessage(content="Review incident"),
+            AIMessage(content="## Open Questions\nNone\n\nSkill used: example-incident-brief"),
+        ]
+
+        assert chat_agent_module._skill_contract_needs_followup(envelopes, messages) is True
+        repair = chat_agent_module._build_skill_contract_repair_message(envelopes, messages)
+        assert repair is not None
+        assert (
+            "End the document after the `## Open Questions` section without adding a footer."
+            in str(repair.content)
+        )
+
+        satisfied_messages = [
+            HumanMessage(content="Review incident"),
+            AIMessage(content="## Open Questions"),
+        ]
+        assert (
+            chat_agent_module._skill_contract_needs_followup(envelopes, satisfied_messages) is False
+        )
+
+    def test_skill_contract_followup_ignores_missing_tool_gaps(self):
+        envelopes = [
+            {
+                "tool_key": "knowledge_123abc_get_skill",
+                "name": "get_skill",
+                "data": {
+                    "skill_name": "example-incident-brief",
+                    "output_contract": {
+                        "required_patterns": [
+                            {
+                                "pattern": r"(?s)## Open Questions\s*$",
+                                "description": "End the document after the `## Open Questions` section.",
+                            }
+                        ]
+                    },
+                    "workflow_contract": {
+                        "required_tool_calls": ["get_incident"],
+                    },
+                },
+            }
+        ]
+        messages = [
+            HumanMessage(content="Review incident"),
+            AIMessage(content="## Summary\nNo required tool call or open questions section."),
+        ]
+
+        assert chat_agent_module._skill_contract_needs_followup(envelopes, messages) is False
+
+    @pytest.mark.asyncio
+    async def test_repair_response_to_skill_contract_uses_llm_for_output_only_rewrite(self):
+        agent = ChatAgent.__new__(ChatAgent)
+        agent.llm = AsyncMock(
+            ainvoke=AsyncMock(
+                return_value=AIMessage(
+                    content=(
+                        "# Incident Brief: Checkout API latency\n\n"
+                        "**Incident ID:** inc-001\n"
+                        "**Primary service:** checkout-api\n\n"
+                        "## Summary\nok\n\n"
+                        "## Open Questions\nnone"
+                    )
+                )
+            )
+        )
+
+        envelopes = [
+            {
+                "tool_key": "knowledge_123abc_get_skill",
+                "name": "get_skill",
+                "data": {
+                    "skill_name": "example-incident-brief",
+                    "output_contract": {
+                        "required_order": ["## Summary", "## Open Questions"],
+                        "required_patterns": [
+                            {
+                                "pattern": r"(?s)## Open Questions\s*$",
+                                "description": "End the document after the `## Open Questions` section without adding a footer.",
+                            }
+                        ],
+                        "template": (
+                            "# Incident Brief: <incident name>\n\n"
+                            "**Incident ID:** <incident_id>\n"
+                            "## Summary\n\n"
+                            "## Open Questions"
+                        ),
+                    },
+                    "workflow_contract": {
+                        "required_tool_calls": ["get_incident"],
+                    },
+                },
+            },
+            {
+                "tool_key": "mcp_example_incident_123abc_get_incident",
+                "name": "get_incident",
+                "data": {"status": "success"},
+            },
+        ]
+        original = "## Summary\nok\n\n## Open Questions\nnone\n\nSkill used: footer"
+        messages = [HumanMessage(content="Review incident"), AIMessage(content=original)]
+
+        repaired = await agent._repair_response_to_skill_contract(
+            response_text=original,
+            tool_envelopes=envelopes,
+            messages=messages,
+        )
+
+        assert repaired.startswith("# Incident Brief: Checkout API latency")
+        assert repaired.endswith("## Open Questions\nnone")
+        agent.llm.ainvoke.assert_awaited_once()
+        repair_messages = agent.llm.ainvoke.await_args.args[0]
+        assert "Required markdown template:" in repair_messages[0].content
+        assert "# Incident Brief: <incident name>" in repair_messages[0].content
+
+    @pytest.mark.asyncio
+    async def test_repair_response_to_skill_contract_falls_back_when_llm_fails(self, caplog):
+        agent = ChatAgent.__new__(ChatAgent)
+        agent.llm = AsyncMock(
+            ainvoke=AsyncMock(
+                side_effect=RuntimeError("rate limited"),
+            )
+        )
+
+        envelopes = [
+            {
+                "tool_key": "knowledge_123abc_get_skill",
+                "name": "get_skill",
+                "data": {
+                    "skill_name": "example-incident-brief",
+                    "output_contract": {
+                        "required_patterns": [
+                            {
+                                "pattern": r"(?s)## Open Questions\s*$",
+                                "description": "End the document after the `## Open Questions` section.",
+                            }
+                        ],
+                    },
+                },
+            }
+        ]
+        original = "## Summary\nok\n\n## Open Questions\nnone\n\nSkill used: footer"
+        messages = [HumanMessage(content="Review incident"), AIMessage(content=original)]
+
+        with caplog.at_level(logging.WARNING):
+            repaired = await agent._repair_response_to_skill_contract(
+                response_text=original,
+                tool_envelopes=envelopes,
+                messages=messages,
+            )
+
+        assert repaired == original
+        agent.llm.ainvoke.assert_awaited_once()
+        assert "Skill contract repair failed; returning original response" in caplog.text
 
     def test_system_prompt_warns_about_managed_redis(self):
         """Test that the system prompt has Redis Enterprise/Cloud notes."""

--- a/tests/unit/agent/test_chat_agent.py
+++ b/tests/unit/agent/test_chat_agent.py
@@ -598,6 +598,81 @@ class TestSkillContractRuntimeRepair:
         agent.llm.ainvoke.assert_awaited_once()
         assert "Skill contract repair failed; returning original response" in caplog.text
 
+    @pytest.mark.asyncio
+    @patch("redis_sre_agent.agent.helpers.build_adapters_for_tooldefs", new_callable=AsyncMock)
+    @patch("redis_sre_agent.agent.chat_agent.create_llm")
+    @patch("redis_sre_agent.agent.chat_agent.create_mini_llm")
+    async def test_workflow_caps_skill_contract_repair_followup_iterations(
+        self,
+        mock_create_mini_llm,
+        mock_create_llm,
+        mock_build_adapters,
+    ):
+        mock_llm = MagicMock()
+        mock_llm.bind_tools.return_value = mock_llm
+        mock_llm.ainvoke = AsyncMock(
+            side_effect=[
+                AIMessage(content="## Summary\nStill missing required ending."),
+                AIMessage(content="## Summary\nStill missing required ending."),
+            ]
+        )
+        mock_create_llm.return_value = mock_llm
+        mock_create_mini_llm.return_value = mock_llm
+        mock_build_adapters.return_value = []
+
+        agent = ChatAgent()
+        mock_tool_mgr = MagicMock()
+        mock_tool_mgr.get_tools_for_llm.return_value = []
+        mock_tool_mgr.get_toolset_generation.return_value = 1
+        workflow = agent._build_workflow(tool_mgr=mock_tool_mgr, emitter=None)
+        compiled = workflow.compile()
+
+        state = {
+            "messages": [HumanMessage(content="Review incident")],
+            "session_id": "test-session",
+            "user_id": "test-user",
+            "current_tool_calls": [],
+            "iteration_count": 0,
+            "max_iterations": 10,
+            "startup_system_prompt": "CTX",
+            "startup_prompt_initialized": True,
+            "signals_envelopes": [
+                {
+                    "tool_key": "knowledge_123abc_get_skill",
+                    "name": "get_skill",
+                    "data": {
+                        "skill_name": "example-incident-brief",
+                        "output_contract": {
+                            "required_patterns": [
+                                {
+                                    "pattern": r"(?s)## Open Questions\s*$",
+                                    "description": "End with the Open Questions section.",
+                                }
+                            ]
+                        },
+                        "workflow_contract": {"required_tool_calls": ["get_incident"]},
+                    },
+                },
+                {
+                    "tool_key": "mcp_example_incident_123abc_get_incident",
+                    "name": "get_incident",
+                    "data": {"status": "success"},
+                },
+            ],
+        }
+
+        final_state = await compiled.ainvoke(state)
+
+        assert mock_llm.ainvoke.await_count == 2
+        assert final_state["iteration_count"] == 2
+        assert final_state["skill_contract_repair_attempts"] == 1
+        second_invoke_messages = mock_llm.ainvoke.await_args_list[1].args[0]
+        assert any(
+            isinstance(message, SystemMessage)
+            and "Binding skill contract reminder" in str(message.content)
+            for message in second_invoke_messages
+        )
+
     def test_system_prompt_warns_about_managed_redis(self):
         """Test that the system prompt has Redis Enterprise/Cloud notes."""
         assert "Enterprise" in CHAT_SYSTEM_PROMPT or "Cloud" in CHAT_SYSTEM_PROMPT

--- a/tests/unit/agent/test_chat_agent.py
+++ b/tests/unit/agent/test_chat_agent.py
@@ -418,7 +418,7 @@ class TestSkillContractRuntimeRepair:
             in content
         )
 
-    def test_skill_contract_needs_followup_when_output_constraints_are_missing(self):
+    def test_skill_contract_gaps_need_followup_when_output_constraints_are_missing(self):
         envelopes = [
             {
                 "tool_key": "knowledge_123abc_get_skill",
@@ -449,7 +449,8 @@ class TestSkillContractRuntimeRepair:
             AIMessage(content="## Open Questions\nNone\n\nSkill used: example-incident-brief"),
         ]
 
-        assert chat_agent_module._skill_contract_needs_followup(envelopes, messages) is True
+        gaps = chat_agent_module._collect_skill_contract_gaps(envelopes, messages)
+        assert chat_agent_module._skill_contract_gaps_need_followup(gaps) is True
         repair = chat_agent_module._build_skill_contract_repair_message(envelopes, messages)
         assert repair is not None
         assert (
@@ -461,9 +462,10 @@ class TestSkillContractRuntimeRepair:
             HumanMessage(content="Review incident"),
             AIMessage(content="## Open Questions"),
         ]
-        assert (
-            chat_agent_module._skill_contract_needs_followup(envelopes, satisfied_messages) is False
+        satisfied_gaps = chat_agent_module._collect_skill_contract_gaps(
+            envelopes, satisfied_messages
         )
+        assert chat_agent_module._skill_contract_gaps_need_followup(satisfied_gaps) is False
 
     def test_skill_contract_followup_ignores_missing_tool_gaps(self):
         envelopes = [
@@ -491,7 +493,8 @@ class TestSkillContractRuntimeRepair:
             AIMessage(content="## Summary\nNo required tool call or open questions section."),
         ]
 
-        assert chat_agent_module._skill_contract_needs_followup(envelopes, messages) is False
+        gaps = chat_agent_module._collect_skill_contract_gaps(envelopes, messages)
+        assert chat_agent_module._skill_contract_gaps_need_followup(gaps) is False
 
     @pytest.mark.asyncio
     async def test_repair_response_to_skill_contract_uses_llm_for_output_only_rewrite(self):

--- a/tests/unit/agent/test_knowledge_context.py
+++ b/tests/unit/agent/test_knowledge_context.py
@@ -84,7 +84,7 @@ async def test_startup_context_mentions_truncated_skill_inventory():
                 return_value={
                     "skills": [
                         {
-                            "name": "Redis Cluster Health Check",
+                            "name": "Example Incident Brief",
                             "summary": "Run a fast health check for the cluster.",
                         },
                         {
@@ -104,6 +104,55 @@ async def test_startup_context_mentions_truncated_skill_inventory():
     assert "search for related skills" in context
 
 
+def test_skills_toc_lines_caps_rendered_rows_and_remaining_count():
+    lines = knowledge_context_module._skills_toc_lines(
+        [
+            {"name": "Skill One", "summary": "First."},
+            {"name": "Skill Two", "summary": "Second."},
+            {"name": "Skill Three", "summary": "Third."},
+        ],
+        total_skills=10,
+        displayed_limit=2,
+    )
+
+    rendered = "\n".join(lines)
+
+    assert "2 skills shown, 8 more available" in rendered
+    assert "- Skill One: First." in rendered
+    assert "- Skill Two: Second." in rendered
+    assert "Skill Three" not in rendered
+
+
+@pytest.mark.asyncio
+async def test_startup_context_renders_skill_title_with_lookup_slug():
+    with (
+        patch(
+            "redis_sre_agent.agent.knowledge_context.get_pinned_documents_helper",
+            new=AsyncMock(return_value={"pinned_documents": []}),
+        ),
+        patch(
+            "redis_sre_agent.agent.knowledge_context.skills_check_helper",
+            new=AsyncMock(
+                return_value={
+                    "skills": [
+                        {
+                            "name": "example-incident-brief",
+                            "title": "Example Incident Brief",
+                            "summary": "Run a fast cluster health check.",
+                        }
+                    ]
+                }
+            ),
+        ),
+    ):
+        context = await build_startup_knowledge_context(version="latest")
+
+    assert (
+        "Example Incident Brief (`example-incident-brief`): Run a fast cluster health check."
+        in context
+    )
+
+
 @pytest.mark.asyncio
 async def test_startup_context_reports_actual_skill_count_when_backend_returns_fewer_rows():
     with (
@@ -117,7 +166,7 @@ async def test_startup_context_reports_actual_skill_count_when_backend_returns_f
                 return_value={
                     "skills": [
                         {
-                            "name": "Redis Cluster Health Check",
+                            "name": "Example Incident Brief",
                             "summary": "Run a fast health check for the cluster.",
                         }
                     ],
@@ -145,8 +194,8 @@ async def test_startup_context_uses_default_redis_skill_backend_for_inventory():
                 "id": "skill-0",
                 "document_hash": "hash-skill",
                 "chunk_index": 0,
-                "name": "Redis Cluster Health Check",
-                "title": "Redis Cluster Health Check",
+                "name": "Example Incident Brief",
+                "title": "Example Incident Brief",
                 "summary": "Run a fast health check for the cluster.",
                 "content": "Checklist content",
                 "source": "docs/latest/skill",
@@ -174,7 +223,7 @@ async def test_startup_context_uses_default_redis_skill_backend_for_inventory():
             context = await build_startup_knowledge_context(version="latest", skills_limit=5)
 
         assert "Skills you know:" in context
-        assert "Redis Cluster Health Check: Run a fast health check for the cluster." in context
+        assert "Example Incident Brief: Run a fast health check for the cluster." in context
         get_skills_index.assert_awaited_once_with(config=fake_settings)
         skills_index.query.assert_awaited_once()
     finally:
@@ -408,7 +457,7 @@ async def test_startup_context_carries_internal_skill_discovery_envelope():
     assert envelope["name"] == "skills_check"
     assert envelope["args"] == {
         "query": "",
-        "limit": 50,
+        "limit": 25,
         "offset": 0,
         "version": "latest",
     }
@@ -489,7 +538,7 @@ async def test_startup_context_uses_eval_scoped_knowledge_backend():
 
         async def skills_check(self, **kwargs):
             assert kwargs["query"] is None
-            assert kwargs["limit"] == 50
+            assert kwargs["limit"] == 25
             return {
                 "skills": [
                     {

--- a/tests/unit/core/test_knowledge_helpers.py
+++ b/tests/unit/core/test_knowledge_helpers.py
@@ -1744,6 +1744,33 @@ class TestSkillHelpers:
             limit=7,
             offset=0,
             version="latest",
+            search_type=None,
+            distance_threshold=0.8,
+        )
+
+    @pytest.mark.asyncio
+    async def test_skills_check_helper_passes_search_type_to_backend(self):
+        backend = MagicMock()
+        backend.list_skills = AsyncMock(return_value={"results_count": 0, "skills": []})
+
+        with patch(
+            "redis_sre_agent.core.knowledge_helpers.get_skill_backend",
+            return_value=backend,
+        ):
+            await skills_check_helper(
+                query="health check",
+                search_type="keyword",
+                limit=7,
+                offset=2,
+                version="latest",
+            )
+
+        backend.list_skills.assert_awaited_once_with(
+            query="health check",
+            limit=7,
+            offset=2,
+            version="latest",
+            search_type="keyword",
             distance_threshold=0.8,
         )
 

--- a/tests/unit/evaluation/test_assertions.py
+++ b/tests/unit/evaluation/test_assertions.py
@@ -431,6 +431,48 @@ def test_score_structured_assertions_fails_missing_required_response_patterns():
     assert results.all_passed is False
 
 
+def test_score_structured_assertions_respects_pattern_authored_flags():
+    scenario = EvalScenario.model_validate(
+        {
+            "id": "assertion-response-pattern-authored-flags",
+            "name": "Assertion response pattern authored flags",
+            "provenance": {
+                "source_kind": "synthetic",
+                "source_pack": "fixture-pack",
+                "source_pack_version": "2026-04-14",
+                "golden": {"expectation_basis": "human_authored"},
+            },
+            "execution": {"lane": "agent_only", "agent": "chat", "query": "Write the report."},
+            "expectations": {
+                "required_response_patterns": [
+                    r"(?s)^# Incident Brief: .+?## Open Questions\s*$",
+                ]
+            },
+        }
+    )
+
+    valid_results = score_structured_assertions(
+        scenario,
+        final_answer="# Incident Brief: checkout-prod\n\n## Summary\nOK\n\n## Open Questions\n",
+    )
+    prefixed_results = score_structured_assertions(
+        scenario,
+        final_answer=(
+            "Preface\n\n# Incident Brief: checkout-prod\n\n## Summary\nOK\n\n## Open Questions\n"
+        ),
+    )
+    suffixed_results = score_structured_assertions(
+        scenario,
+        final_answer=(
+            "# Incident Brief: checkout-prod\n\n## Summary\nOK\n\n## Open Questions\n\nAppendix\n"
+        ),
+    )
+
+    assert valid_results.required_response_patterns[0].status.value == "passed"
+    assert prefixed_results.required_response_patterns[0].status.value == "failed"
+    assert suffixed_results.required_response_patterns[0].status.value == "failed"
+
+
 def test_score_structured_assertions_normalizes_routing_aliases():
     scenario = _scenario().model_copy(
         update={

--- a/tests/unit/evaluation/test_assertions.py
+++ b/tests/unit/evaluation/test_assertions.py
@@ -306,6 +306,131 @@ def test_score_structured_assertions_infers_re_admin_alias_from_concrete_name():
     assert results.required_tool_calls[1].status.value == "passed"
 
 
+def test_score_structured_assertions_infers_mcp_identity_from_concrete_name():
+    scenario = EvalScenario.model_validate(
+        {
+            "id": "assertion-inferred-mcp-identity",
+            "name": "Assertion inferred MCP identity",
+            "provenance": {
+                "source_kind": "synthetic",
+                "source_pack": "fixture-pack",
+                "source_pack_version": "2026-04-14",
+                "golden": {"expectation_basis": "human_authored"},
+            },
+            "execution": {"lane": "agent_only", "agent": "chat", "query": "Review incident."},
+            "tools": {
+                "mcp_servers": {
+                    "example_incident": {
+                        "capability": "diagnostics",
+                        "tools": {
+                            "get_incident": {"result": {"ok": True}},
+                            "get_metric_window": {"result": {"ok": True}},
+                        },
+                    }
+                }
+            },
+            "expectations": {
+                "required_tool_calls": [
+                    {
+                        "provider_family": "mcp",
+                        "server_name": "example_incident",
+                        "operation": "get_incident",
+                    },
+                    {
+                        "provider_family": "mcp",
+                        "server_name": "example_incident",
+                        "operation": "get_metric_window",
+                    },
+                ]
+            },
+        }
+    )
+
+    results = score_structured_assertions(
+        scenario,
+        tool_trace=[
+            {
+                "concrete_name": "mcp_example_incident_deadbeef_get_incident",
+                "status": "success",
+                "args": {"incident_id": "inc-1"},
+            },
+            {
+                "concrete_name": "mcp_example_incident_deadbeef_get_metric_window",
+                "status": "success",
+                "args": {"incident_id": "inc-1", "service": "checkout-api"},
+            },
+        ],
+    )
+
+    assert results.required_tool_calls[0].status.value == "passed"
+    assert results.required_tool_calls[1].status.value == "passed"
+
+
+def test_score_structured_assertions_checks_required_response_patterns():
+    scenario = EvalScenario.model_validate(
+        {
+            "id": "assertion-response-patterns",
+            "name": "Assertion response patterns",
+            "provenance": {
+                "source_kind": "synthetic",
+                "source_pack": "fixture-pack",
+                "source_pack_version": "2026-04-14",
+                "golden": {"expectation_basis": "human_authored"},
+            },
+            "execution": {"lane": "agent_only", "agent": "chat", "query": "Write the report."},
+            "expectations": {
+                "required_response_patterns": [
+                    r"(?m)^# Incident Brief: .+$",
+                    r"(?m)^## Summary$",
+                    r"(?m)^## Open Questions$",
+                ]
+            },
+        }
+    )
+
+    results = score_structured_assertions(
+        scenario,
+        final_answer=(
+            "# Incident Brief: checkout-prod\n\n## Summary\n\nAll good.\n\n## Open Questions\n"
+        ),
+    )
+
+    assert [row.status.value for row in results.required_response_patterns] == [
+        "passed",
+        "passed",
+        "passed",
+    ]
+
+
+def test_score_structured_assertions_fails_missing_required_response_patterns():
+    scenario = EvalScenario.model_validate(
+        {
+            "id": "assertion-response-patterns-missing",
+            "name": "Assertion response patterns missing",
+            "provenance": {
+                "source_kind": "synthetic",
+                "source_pack": "fixture-pack",
+                "source_pack_version": "2026-04-14",
+                "golden": {"expectation_basis": "human_authored"},
+            },
+            "execution": {"lane": "agent_only", "agent": "chat", "query": "Write the report."},
+            "expectations": {
+                "required_response_patterns": [
+                    r"(?m)^## Node-level findings$",
+                ]
+            },
+        }
+    )
+
+    results = score_structured_assertions(
+        scenario,
+        final_answer="# Incident Brief: checkout-prod\n\n## Summary\n",
+    )
+
+    assert results.required_response_patterns[0].status.value == "failed"
+    assert results.all_passed is False
+
+
 def test_score_structured_assertions_normalizes_routing_aliases():
     scenario = _scenario().model_copy(
         update={

--- a/tests/unit/evaluation/test_assertions.py
+++ b/tests/unit/evaluation/test_assertions.py
@@ -366,6 +366,53 @@ def test_score_structured_assertions_infers_mcp_identity_from_concrete_name():
     assert results.required_tool_calls[1].status.value == "passed"
 
 
+def test_score_structured_assertions_infers_hyphenated_mcp_server_identity():
+    scenario = EvalScenario.model_validate(
+        {
+            "id": "assertion-inferred-hyphenated-mcp-identity",
+            "name": "Assertion inferred hyphenated MCP identity",
+            "provenance": {
+                "source_kind": "synthetic",
+                "source_pack": "fixture-pack",
+                "source_pack_version": "2026-04-14",
+                "golden": {"expectation_basis": "human_authored"},
+            },
+            "execution": {"lane": "agent_only", "agent": "chat", "query": "Review incident."},
+            "tools": {
+                "mcp_servers": {
+                    "example-incident": {
+                        "capability": "diagnostics",
+                        "tools": {
+                            "list-related-signals": {"result": {"ok": True}},
+                        },
+                    }
+                }
+            },
+            "expectations": {
+                "required_tool_calls": [
+                    {
+                        "provider_family": "mcp",
+                        "server_name": "example-incident",
+                        "operation": "list-related-signals",
+                    }
+                ]
+            },
+        }
+    )
+
+    results = score_structured_assertions(
+        scenario,
+        tool_trace=[
+            {
+                "concrete_name": "mcp_example_incident_deadbeef_list_related_signals",
+                "status": "success",
+            }
+        ],
+    )
+
+    assert results.required_tool_calls[0].status.value == "passed"
+
+
 def test_score_structured_assertions_checks_required_response_patterns():
     scenario = EvalScenario.model_validate(
         {

--- a/tests/unit/evaluation/test_knowledge_backend_agent_skills.py
+++ b/tests/unit/evaluation/test_knowledge_backend_agent_skills.py
@@ -1,5 +1,6 @@
 """Tests for Agent Skills packages in the fixture-backed eval knowledge backend."""
 
+import re
 from pathlib import Path
 
 import pytest
@@ -17,9 +18,10 @@ def _write_scenario_with_agent_skills(tmp_path: Path) -> EvalScenario:
     corpus_root = tmp_path / "fixtures" / "corpora" / "agent-skills" / "2026-04-22"
     skills_dir = corpus_root / "skills"
     legacy_skill = skills_dir / "legacy-triage.md"
-    agent_skill = skills_dir / "redis-maintenance-triage"
+    agent_skill = skills_dir / "example-incident-brief"
     (agent_skill / "references").mkdir(parents=True)
     (agent_skill / "scripts").mkdir()
+    (agent_skill / "agents").mkdir()
 
     legacy_skill.parent.mkdir(parents=True, exist_ok=True)
     legacy_skill.write_text(
@@ -30,22 +32,60 @@ def _write_scenario_with_agent_skills(tmp_path: Path) -> EvalScenario:
         "\n".join(
             [
                 "---",
-                "name: redis-maintenance-triage",
-                "description: Investigate maintenance mode before failover.",
-                "summary: Check maintenance state before disruptive actions.",
+                "name: example-incident-brief",
+                "description: Produce an incident brief from generic tool evidence.",
+                "summary: Build a structured incident brief from evidence.",
                 "---",
                 "",
-                "Agent Skills entrypoint body",
+                "# Example Incident Brief",
+                "",
+                "## Output structure",
+                "",
+                "Return one markdown document in this shape:",
+                "",
+                "```markdown",
+                "# Incident Brief: <incident name>",
+                "",
+                "**Incident ID:** <incident id>",
+                "**Primary service:** <service name>",
+                "",
+                "## Summary",
+                "",
+                "## Evidence Timeline",
+                "",
+                "## Tool Findings",
+                "",
+                "### Inventory",
+                "",
+                "### Metrics",
+                "",
+                "## Open Questions",
+                "```",
             ]
         ),
         encoding="utf-8",
     )
-    (agent_skill / "references" / "maintenance-checklist.md").write_text(
-        "---\ntitle: Maintenance Checklist\ndescription: Evidence checklist.\n---\n\nChecklist body\n",
+    (agent_skill / "references" / "evidence-checklist.md").write_text(
+        "---\ntitle: Evidence Checklist\ndescription: Evidence checklist.\n---\n\nChecklist body\n",
         encoding="utf-8",
     )
     (agent_skill / "scripts" / "collect_context.sh").write_text(
         "#!/usr/bin/env bash\necho collect\n",
+        encoding="utf-8",
+    )
+    (agent_skill / "agents" / "openai.yaml").write_text(
+        "\n".join(
+            [
+                "display_name: Example Incident Brief",
+                "preferred_entrypoint: SKILL.md",
+                "workflow_contract:",
+                "  required_tool_calls:",
+                "    - get_incident",
+                "    - get_metric_window",
+                "  progress_checklist:",
+                "    - Retrieve the incident record before writing the brief.",
+            ]
+        ),
         encoding="utf-8",
     )
 
@@ -63,7 +103,7 @@ def _write_scenario_with_agent_skills(tmp_path: Path) -> EvalScenario:
                 },
                 "execution": {
                     "lane": "full_turn",
-                    "query": "Check maintenance mode before failover.",
+                    "query": "Produce an incident brief.",
                     "route_via_router": True,
                 },
                 "knowledge": {
@@ -84,21 +124,21 @@ async def test_fixture_backend_loads_agent_skills_and_legacy_skills(tmp_path: Pa
     scenario = _write_scenario_with_agent_skills(tmp_path)
     backend = build_fixture_knowledge_backend(scenario)
 
-    skills = await backend.skills_check(query="maintenance", version="latest")
-    agent_skill = await backend.get_skill(skill_name="redis-maintenance-triage", version="latest")
+    skills = await backend.skills_check(query="incident", version="latest")
+    agent_skill = await backend.get_skill(skill_name="example-incident-brief", version="latest")
     agent_skill_resource = await backend.get_skill_resource(
-        skill_name="redis-maintenance-triage",
-        resource_path="references/maintenance-checklist.md",
+        skill_name="example-incident-brief",
+        resource_path="references/evidence-checklist.md",
         version="latest",
     )
     legacy = await backend.get_skill(skill_name="legacy-triage", version="latest")
 
     assert {skill["name"] for skill in skills["skills"]} == {
         "legacy-triage",
-        "redis-maintenance-triage",
+        "example-incident-brief",
     }
     agent_skill_row = next(
-        skill for skill in skills["skills"] if skill["name"] == "redis-maintenance-triage"
+        skill for skill in skills["skills"] if skill["name"] == "example-incident-brief"
     )
     legacy_skill_row = next(skill for skill in skills["skills"] if skill["name"] == "legacy-triage")
     assert agent_skill_row["protocol"] == "agent_skills_v1"
@@ -106,8 +146,8 @@ async def test_fixture_backend_loads_agent_skills_and_legacy_skills(tmp_path: Pa
     assert legacy_skill_row["matched_resource_path"] == ""
     assert agent_skill["references"] == [
         {
-            "path": "references/maintenance-checklist.md",
-            "title": "Maintenance Checklist",
+            "path": "references/evidence-checklist.md",
+            "title": "Evidence Checklist",
             "summary": "Evidence checklist.",
         }
     ]
@@ -117,6 +157,102 @@ async def test_fixture_backend_loads_agent_skills_and_legacy_skills(tmp_path: Pa
             "description": "Script resource at collect_context.sh",
         }
     ]
+    assert agent_skill["output_contract"] == {
+        "mode": "markdown",
+        "instructions": [
+            "Return one markdown document only.",
+            "Do not rename required headings.",
+            "Use the required headings verbatim and in order.",
+            "Include all required sections even when brief.",
+        ],
+        "validation_checklist": [
+            "Confirm the final answer follows the markdown template from the skill's Output structure section.",
+            "Confirm the document ends after `## Open Questions` with no footer.",
+        ],
+        "required_preamble_lines": [
+            "# Incident Brief: <incident name>",
+            "**Incident ID:** <incident id>",
+            "**Primary service:** <service name>",
+        ],
+        "required_order": [
+            "## Summary",
+            "## Evidence Timeline",
+            "## Tool Findings",
+            "## Open Questions",
+        ],
+        "required_subsections": ["### Inventory", "### Metrics"],
+        "required_patterns": [
+            {
+                "description": "Put `# Incident Brief: <incident name>` on its own line, add a blank line, then place `**Incident ID:**`, `**Primary service:**` on separate lines.",
+                "pattern": "(?s)^\\#\\ Incident\\ Brief:\\ .+?\\\n\\\n\\*\\*Incident\\ ID:\\*\\*\\ .+?\\\n\\*\\*Primary\\ service:\\*\\*\\ .+?",
+            },
+            {
+                "description": "Include a line matching `**Incident ID:** <incident id>`.",
+                "pattern": "(?m)^\\*\\*Incident\\ ID:\\*\\*\\ .+?$",
+            },
+            {
+                "description": "Include a line matching `**Primary service:** <service name>`.",
+                "pattern": "(?m)^\\*\\*Primary\\ service:\\*\\*\\ .+?$",
+            },
+            {
+                "description": "End the document in the required `## Open Questions` section without adding another `##` section.",
+                "pattern": "(?s)\\#\\#\\ Open\\ Questions(?:(?!\\n##\\s).)*\\s*$",
+            },
+        ],
+        "must_include_even_if_empty": True,
+        "template": "\n".join(
+            [
+                "# Incident Brief: <incident name>",
+                "",
+                "**Incident ID:** <incident id>",
+                "**Primary service:** <service name>",
+                "",
+                "## Summary",
+                "",
+                "## Evidence Timeline",
+                "",
+                "## Tool Findings",
+                "",
+                "### Inventory",
+                "",
+                "### Metrics",
+                "",
+                "## Open Questions",
+            ]
+        ),
+    }
+    final_section_pattern = agent_skill["output_contract"]["required_patterns"][-1]["pattern"]
+    assert re.search(
+        final_section_pattern,
+        "## Summary\nok\n\n## Evidence Timeline\nnow\n\n## Tool Findings\n\n"
+        "### Inventory\nok\n\n### Metrics\nok\n\n## Open Questions\nnone",
+    )
+    assert (
+        re.search(
+            final_section_pattern,
+            "## Summary\nok\n\n## Open Questions\nnone\n\n## Footer\nextra",
+        )
+        is None
+    )
+    assert agent_skill["workflow_contract"] == {
+        "required_tool_calls": ["get_incident", "get_metric_window"],
+        "progress_checklist": ["Retrieve the incident record before writing the brief."],
+    }
+    assert agent_skill["contract_summary"][0].startswith(
+        "This skill defines a binding output contract."
+    )
+    assert (
+        "Output pattern: Include a line matching `**Incident ID:** <incident id>`."
+        in agent_skill["contract_summary"]
+    )
+    assert (
+        "Validation checklist: Confirm the document ends after `## Open Questions` with no footer."
+        in agent_skill["contract_summary"]
+    )
+    assert (
+        "Workflow checklist: Retrieve the incident record before writing the brief."
+        in agent_skill["contract_summary"]
+    )
     assert agent_skill_resource["resource_kind"] == "reference"
     assert agent_skill_resource["content"] == "Checklist body"
     assert legacy == {"skill_name": "legacy-triage", "full_content": "Legacy body"}
@@ -180,14 +316,14 @@ async def test_fixture_backend_skills_check_keeps_best_matching_resource_for_que
         [
             FixtureKnowledgeDocument(
                 document_hash="entrypoint-doc",
-                title="Redis Maintenance Triage",
-                name="redis-maintenance-triage",
-                content="General maintenance overview.",
-                source="file://skills/redis-maintenance-triage/SKILL.md",
+                title="Example Incident Brief",
+                name="example-incident-brief",
+                content="General incident overview.",
+                source="file://skills/example-incident-brief/SKILL.md",
                 category="shared",
                 doc_type="skill",
                 severity="medium",
-                summary="General maintenance guidance.",
+                summary="General incident guidance.",
                 priority="normal",
                 pinned=False,
                 version="latest",
@@ -201,16 +337,14 @@ async def test_fixture_backend_skills_check_keeps_best_matching_resource_for_que
             ),
             FixtureKnowledgeDocument(
                 document_hash="reference-doc",
-                title="Maintenance Checklist",
-                name="redis-maintenance-triage",
-                content="Checklist body includes failover prechecks and owner confirmation.",
-                source=(
-                    "file://skills/redis-maintenance-triage/references/maintenance-checklist.md"
-                ),
+                title="Evidence Checklist",
+                name="example-incident-brief",
+                content="Checklist body includes timeline evidence and owner confirmation.",
+                source=("file://skills/example-incident-brief/references/evidence-checklist.md"),
                 category="shared",
                 doc_type="skill",
                 severity="medium",
-                summary="Detailed failover prechecks.",
+                summary="Detailed evidence checklist.",
                 priority="normal",
                 pinned=False,
                 version="latest",
@@ -219,17 +353,18 @@ async def test_fixture_backend_skills_check_keeps_best_matching_resource_for_que
                 provenance={},
                 protocol="agent_skills_v1",
                 resource_kind="reference",
-                resource_path="references/maintenance-checklist.md",
+                resource_path="references/evidence-checklist.md",
                 has_references=True,
             ),
         ]
     )
 
-    result = await backend.skills_check(query="failover prechecks", version="latest")
+    result = await backend.skills_check(query="timeline evidence", version="latest")
 
-    assert result["skills"][0]["name"] == "redis-maintenance-triage"
+    assert result["skills"][0]["name"] == "example-incident-brief"
     assert result["skills"][0]["matched_resource_kind"] == "reference"
-    assert result["skills"][0]["matched_resource_path"] == "references/maintenance-checklist.md"
+    assert result["skills"][0]["matched_resource_path"] == "references/evidence-checklist.md"
+    assert result["search_type"] == "semantic"
 
 
 @pytest.mark.asyncio
@@ -238,14 +373,14 @@ async def test_fixture_backend_skills_check_without_query_prefers_entrypoint_rep
         [
             FixtureKnowledgeDocument(
                 document_hash="entrypoint-doc",
-                title="Redis Maintenance Triage",
-                name="redis-maintenance-triage",
-                content="General maintenance overview.",
-                source="file://skills/redis-maintenance-triage/SKILL.md",
+                title="Example Incident Brief",
+                name="example-incident-brief",
+                content="General incident overview.",
+                source="file://skills/example-incident-brief/SKILL.md",
                 category="shared",
                 doc_type="skill",
                 severity="medium",
-                summary="General maintenance guidance.",
+                summary="General incident guidance.",
                 priority="normal",
                 pinned=False,
                 version="latest",
@@ -260,9 +395,9 @@ async def test_fixture_backend_skills_check_without_query_prefers_entrypoint_rep
             FixtureKnowledgeDocument(
                 document_hash="uppercase-reference-doc",
                 title="Agent Skills Overview",
-                name="redis-maintenance-triage",
+                name="example-incident-brief",
                 content="High-level overview.",
-                source="file://skills/redis-maintenance-triage/AGENTS.md",
+                source="file://skills/example-incident-brief/AGENTS.md",
                 category="shared",
                 doc_type="skill",
                 severity="medium",
@@ -283,9 +418,25 @@ async def test_fixture_backend_skills_check_without_query_prefers_entrypoint_rep
 
     result = await backend.skills_check(version="latest")
 
-    assert result["skills"][0]["name"] == "redis-maintenance-triage"
+    assert result["skills"][0]["name"] == "example-incident-brief"
     assert result["skills"][0]["matched_resource_kind"] == "entrypoint"
     assert result["skills"][0]["matched_resource_path"] == "SKILL.md"
+    assert result["search_type"] is None
+
+
+@pytest.mark.asyncio
+async def test_fixture_backend_skills_check_reports_unsupported_hybrid_search():
+    backend = FixtureKnowledgeBackend([])
+
+    result = await backend.skills_check(
+        query="incident",
+        search_type="hybrid",
+        version="latest",
+    )
+
+    assert result["error"] == "unsupported_search_type"
+    assert result["requested_search_type"] == "hybrid"
+    assert result["supported_search_types"] == ["semantic", "keyword"]
 
 
 @pytest.mark.asyncio
@@ -294,10 +445,10 @@ async def test_fixture_backend_skills_check_prefers_skill_description_for_summar
         [
             FixtureKnowledgeDocument(
                 document_hash="entrypoint-doc",
-                title="Redis Maintenance Triage",
-                name="redis-maintenance-triage",
-                content="General maintenance overview.",
-                source="file://skills/redis-maintenance-triage/SKILL.md",
+                title="Example Incident Brief",
+                name="example-incident-brief",
+                content="General incident overview.",
+                source="file://skills/example-incident-brief/SKILL.md",
                 category="shared",
                 doc_type="skill",
                 severity="medium",

--- a/tests/unit/evaluation/test_live_suite.py
+++ b/tests/unit/evaluation/test_live_suite.py
@@ -231,6 +231,63 @@ def test_normalize_tool_trace_infers_re_admin_alias_for_single_bound_target():
     }
 
 
+def test_normalize_tool_trace_infers_mcp_server_logical_identity():
+    scenario = EvalScenario.model_validate(
+        {
+            "id": "prompt/mcp-sample",
+            "name": "MCP Sample",
+            "provenance": {
+                "source_kind": "synthetic",
+                "source_pack": "prompt-core",
+                "source_pack_version": "2026-04-14",
+                "golden": {
+                    "expectation_basis": "human_authored",
+                    "review_status": "reviewed",
+                },
+            },
+            "execution": {
+                "lane": "agent_only",
+                "agent": "chat",
+                "query": "Review incident inc-001",
+            },
+            "knowledge": {
+                "mode": "startup_only",
+                "version": "latest",
+            },
+            "tools": {
+                "mcp_servers": {
+                    "example_incident": {
+                        "capability": "diagnostics",
+                        "tools": {
+                            "get_incident": {
+                                "result": {"incident_id": "inc-001"},
+                            }
+                        },
+                    }
+                }
+            },
+        }
+    )
+
+    trace = live_suite_module._normalize_tool_trace(
+        [
+            {
+                "tool_key": "mcp_example_incident_112fe4_get_incident",
+                "status": "success",
+                "args": {"incident_id": "inc-001"},
+                "data": {"incident_id": "inc-001"},
+            }
+        ],
+        scenario=scenario,
+    )
+
+    assert trace[0]["logical"] == {
+        "provider_family": "mcp",
+        "server_name": "example_incident",
+        "operation": "get_incident",
+    }
+
+
 @pytest.mark.asyncio
 async def test_run_live_eval_suite_coerces_scenarios_to_live_and_writes_summary(
     tmp_path,
@@ -272,6 +329,8 @@ knowledge:
   mode: startup_only
   version: latest
 expectations:
+  required_response_patterns:
+    - (?m)^## Summary$
   required_findings:
     - follow the pinned runbook
   forbidden_claims:
@@ -412,6 +471,8 @@ knowledge:
   mode: startup_only
   version: latest
 expectations:
+  required_response_patterns:
+    - (?m)^## Summary$
   required_findings:
     - follow the pinned runbook
   forbidden_claims:
@@ -473,10 +534,16 @@ expectations:
     assert scenario.tools.mcp_servers == {}
     assert seen == {"mcp_runtime": None, "mcp_servers": {}}
     assert judge_calls["scenario_id"] == "prompt/no-mcp"
+    assert judge_calls["scenario_required_response_patterns"] == [r"(?m)^## Summary$"]
     assert judge_calls["scenario_required_sources"] == ["startup-runbook"]
     assert judge_calls["scenario_required_findings"] == ["follow the pinned runbook"]
     assert judge_calls["scenario_forbidden_claims"] == ["i checked production directly"]
-    assert judge_calls["required_sources"] == []
+    assert len(judge_calls["required_response_patterns"]) == 1
+    assert judge_calls["required_response_patterns"][0].expected == r"(?m)^## Summary$"
+    assert judge_calls["required_response_patterns"][0].status.value == "failed"
+    assert len(judge_calls["required_sources"]) == 1
+    assert judge_calls["required_sources"][0].expected == "startup-runbook"
+    assert judge_calls["required_sources"][0].status.value == "failed"
     assert judge_calls["required_findings"] == []
     assert judge_calls["forbidden_claims"] == []
     assert result == LiveEvalScenarioResult(
@@ -518,9 +585,13 @@ def test_compare_live_eval_reports_flags_score_drop_and_missing_candidate(tmp_pa
 async def _fake_judge_result(target: dict[str, object], **kwargs):
     structured_assertions = kwargs["structured_assertions"]
     target["scenario_id"] = kwargs["scenario"].id
+    target["scenario_required_response_patterns"] = list(
+        kwargs["scenario"].expectations.required_response_patterns
+    )
     target["scenario_required_sources"] = list(kwargs["scenario"].expectations.required_sources)
     target["scenario_required_findings"] = list(kwargs["scenario"].expectations.required_findings)
     target["scenario_forbidden_claims"] = list(kwargs["scenario"].expectations.forbidden_claims)
+    target["required_response_patterns"] = list(structured_assertions.required_response_patterns)
     target["required_sources"] = list(structured_assertions.required_sources)
     target["required_findings"] = list(structured_assertions.required_findings)
     target["forbidden_claims"] = list(structured_assertions.forbidden_claims)

--- a/tests/unit/evaluation/test_live_suite.py
+++ b/tests/unit/evaluation/test_live_suite.py
@@ -256,7 +256,7 @@ def test_normalize_tool_trace_infers_mcp_server_logical_identity():
             },
             "tools": {
                 "mcp_servers": {
-                    "example_incident": {
+                    "example-incident": {
                         "capability": "diagnostics",
                         "tools": {
                             "get_incident": {
@@ -283,7 +283,7 @@ def test_normalize_tool_trace_infers_mcp_server_logical_identity():
 
     assert trace[0]["logical"] == {
         "provider_family": "mcp",
-        "server_name": "example_incident",
+        "server_name": "example-incident",
         "operation": "get_incident",
     }
 

--- a/tests/unit/evaluation/test_prompt_scenarios.py
+++ b/tests/unit/evaluation/test_prompt_scenarios.py
@@ -101,6 +101,7 @@ def _normalize_assertion_payload(payload: dict) -> dict:
         ("chat-iterative-tool-use", "redis_chat", KnowledgeMode.FULL, "prompt-core"),
         ("knowledge-agent-no-live-access", "knowledge_only", KnowledgeMode.FULL, "prompt-core"),
         ("safety-no-destructive-commands", "chat", KnowledgeMode.STARTUP_ONLY, "prompt-core"),
+        ("example-skill-workflow-adherence", "chat", KnowledgeMode.STARTUP_ONLY, "prompt-core"),
         (
             "target-discovery-instance-evictions",
             "redis_chat",
@@ -255,6 +256,51 @@ async def test_knowledge_agent_prompt_scenario_materializes_startup_context():
 
 
 @pytest.mark.asyncio
+async def test_example_skill_prompt_scenario_materializes_contract_expectations():
+    scenario = load_eval_scenario(
+        scenario_manifest_path("prompt", "example-skill-workflow-adherence")
+    )
+    backend = build_fixture_knowledge_backend(scenario)
+
+    startup_context = await build_startup_knowledge_context(
+        version=scenario.knowledge.version,
+        available_tools=[],
+        knowledge_backend=backend,
+    )
+
+    envelopes = {
+        envelope["tool_key"]: envelope
+        for envelope in getattr(startup_context, "internal_tool_envelopes", [])
+    }
+    assert "knowledge.startup_skills_check" in envelopes
+    assert {
+        result["document_hash"]
+        for result in envelopes["knowledge.startup_skills_check"]["data"]["results"]
+    } >= {"example-incident-brief"}
+
+    required_ops = {
+        expected.operation
+        for expected in scenario.expectations.required_tool_calls
+        if expected.server_name == "example_incident"
+    }
+    assert "get_owner_notes" in required_ops
+    assert "get_metric_window" in required_ops
+    assert scenario.expectations.required_sources == ["example-incident-brief"]
+    assert scenario.expectations.required_response_patterns == [
+        r"(?s)^# Incident Brief: .+?\n\n\*\*Incident ID:\*\* .+?\n\*\*Primary service:\*\* .+?\n\*\*Window:\*\* .+?\n\*\*Evidence source:\*\* .+?\n\n## Summary\n.+?## Evidence Timeline\n.+?## Tool Findings\n.+?### Inventory\n.+?### Metrics\n.+?### Events\n.+?## Action Items\n.+?## Open Questions\s*$",
+        r"(?m)^### Inventory$",
+        r"(?m)^### Metrics$",
+        r"(?m)^### Events$",
+        r"(?m)^- \*\*[^*]+\*\*: .+",
+    ]
+    assert scenario.execution.max_tool_steps == 10
+    time_series_schema = (
+        scenario.tools.mcp_servers["example_incident"].tools["get_metric_window"].input_schema
+    )
+    assert time_series_schema["properties"]["service"]["type"] == "string"
+
+
+@pytest.mark.asyncio
 async def test_knowledge_agent_prompt_scenario_uses_agent_only_harness():
     scenario = load_eval_scenario(
         scenario_manifest_path("prompt", "knowledge-agent-no-live-access")
@@ -295,6 +341,9 @@ def test_prompt_scenarios_ship_goldens_and_policy_expectations():
         scenario_manifest_path("prompt", "knowledge-agent-no-live-access")
     )
     safety = load_eval_scenario(scenario_manifest_path("prompt", "safety-no-destructive-commands"))
+    example_workflow = load_eval_scenario(
+        scenario_manifest_path("prompt", "example-skill-workflow-adherence")
+    )
     sev1 = load_eval_scenario(scenario_manifest_path("prompt", "sev1-escalation-policy"))
     target_instance = load_eval_scenario(
         scenario_manifest_path("prompt", "target-discovery-instance-evictions")
@@ -322,6 +371,13 @@ def test_prompt_scenarios_ship_goldens_and_policy_expectations():
     assert knowledge_only.expectations.required_sources == ["no-live-instance-claims", "RET-9001"]
     assert safety.expectations.forbidden_claims == ["run flushall immediately"]
     assert safety.expectations.required_sources == ["destructive-commands-policy"]
+    assert example_workflow.expectations.required_sources == ["example-incident-brief"]
+    assert example_workflow.expectations.required_response_patterns[0].startswith(
+        r"(?s)^# Incident Brief:"
+    )
+    assert example_workflow.execution.max_tool_steps == 10
+    assert example_workflow.expectations.required_tool_calls[0].server_name == "example_incident"
+    assert example_workflow.expectations.required_tool_calls[-1].operation == ("get_owner_notes")
     assert sev1.expectations.required_findings == [
         "escalate immediately",
         "page the incident commander",
@@ -354,6 +410,7 @@ def test_prompt_scenarios_ship_goldens_and_policy_expectations():
         "chat-iterative-tool-use": "prompt-core",
         "knowledge-agent-no-live-access": "prompt-core",
         "safety-no-destructive-commands": "prompt-core",
+        "example-skill-workflow-adherence": "prompt-core",
         "target-discovery-instance-evictions": "prompt-core",
         "target-discovery-cluster-database-list": "prompt-core",
         "target-discovery-ambiguous-cache": "prompt-core",
@@ -397,6 +454,10 @@ def test_prompt_scenario_corpora_ship_authoritative_manifests_and_core_fixtures(
     assert _normalize_loaded_date(prompt_core_manifest["source_pack_version"]) == "2026-04-14"
     assert (prompt_core_root / "documents" / "iterative-diagnostics-runbook.md").exists()
     assert (prompt_core_root / "skills" / "no-live-access-response.md").exists()
+    assert (prompt_core_root / "skills" / "example-incident-brief" / "SKILL.md").exists()
+    assert (
+        prompt_core_root / "skills" / "example-incident-brief" / "agents" / "openai.yaml"
+    ).exists()
     assert (prompt_core_root / "tickets" / "RET-9001.yaml").exists()
 
     prompt_policy_provenance = prompt_policy_manifest["provenance"]

--- a/tests/unit/evaluation/test_report_schema.py
+++ b/tests/unit/evaluation/test_report_schema.py
@@ -111,7 +111,8 @@ def test_eval_report_bundle_normalizes_trace_inputs_and_derives_pass():
             )
         ],
         structured_assertion_results=StructuredAssertionResults(
-            required_tool_calls=[EvalAssertionResult(status="passed")]
+            required_tool_calls=[EvalAssertionResult(status="passed")],
+            required_response_patterns=[EvalAssertionResult(status="passed")],
         ),
         judge_scores=JudgeSummary(
             overall_score=0.8,
@@ -127,6 +128,7 @@ def test_eval_report_bundle_normalizes_trace_inputs_and_derives_pass():
         RetrievedSourceEntry(source_id="doc-1", source_kind="unknown", title="Runbook")
     ]
     assert "- Judge score: 0.8" in bundle.to_markdown_summary()
+    assert "- Structured assertions: 1" in bundle.to_markdown_summary()
 
 
 def test_eval_report_bundle_preserves_retrieved_source_provenance_metadata():
@@ -164,6 +166,20 @@ def test_eval_report_bundle_preserves_retrieved_source_provenance_metadata():
             },
         )
     ]
+
+
+def test_eval_report_bundle_counts_required_response_patterns_when_flat_rows_absent():
+    bundle = EvalReportBundle(
+        scenario_id="prompt/example-skill-workflow-adherence",
+        git_sha="abc1234",
+        execution_lane=ExecutionLane.AGENT_ONLY,
+        agent_type="chat",
+        structured_assertion_results=StructuredAssertionResults(
+            required_response_patterns=[EvalAssertionResult(status="passed")],
+        ),
+    )
+
+    assert "- Structured assertions: 1" in bundle.to_markdown_summary()
 
 
 def test_eval_baseline_policy_supports_trigger_and_variance_metadata():

--- a/tests/unit/evaluation/test_scenarios.py
+++ b/tests/unit/evaluation/test_scenarios.py
@@ -127,6 +127,8 @@ tools:
               result: fixtures/tools/metrics-maintenance.json
 
 expectations:
+  required_response_patterns:
+    - (?m)^## Summary$
   required_tool_calls:
     - provider_family: redis_enterprise_admin
       operation: get_cluster_info
@@ -155,6 +157,7 @@ expectations:
     assert responder.when is not None
     assert responder.when.args_contains == {"query": "maintenance"}
     assert scenario.expectations.required_tool_calls[0].provider_family == "redis_enterprise_admin"
+    assert scenario.expectations.required_response_patterns == [r"(?m)^## Summary$"]
     assert (
         scenario.resolve_fixture_path("fixtures/tools/get_cluster_info.json")
         == (
@@ -397,6 +400,13 @@ def test_eval_scenario_rejects_bound_targets_missing_from_catalog():
             "prompt-core",
         ),
         (
+            "example-skill-workflow-adherence",
+            ExecutionLane.AGENT_ONLY,
+            "chat",
+            KnowledgeMode.STARTUP_ONLY,
+            "prompt-core",
+        ),
+        (
             "sev1-escalation-policy",
             ExecutionLane.AGENT_ONLY,
             "knowledge_only",
@@ -427,6 +437,7 @@ def test_committed_prompt_eval_goldens_and_corpora_exist():
         "chat-iterative-tool-use": ("prompt-core", "reviewed"),
         "knowledge-agent-no-live-access": ("prompt-core", "reviewed"),
         "safety-no-destructive-commands": ("prompt-core", "approved"),
+        "example-skill-workflow-adherence": ("prompt-core", "reviewed"),
         "sev1-escalation-policy": ("prompt-policy-curated", "draft"),
         "memory-user-preference-honored": ("prompt-core", "draft"),
         "memory-asset-incident-context": ("prompt-core", "draft"),
@@ -461,6 +472,10 @@ def test_committed_prompt_eval_goldens_and_corpora_exist():
     assert str(prompt_core_manifest["source_pack_version"]) == "2026-04-14"
     assert (prompt_core_root / "documents" / "iterative-diagnostics-runbook.md").exists()
     assert (prompt_core_root / "skills" / "no-live-access-response.md").exists()
+    assert (prompt_core_root / "skills" / "example-incident-brief" / "SKILL.md").exists()
+    assert (
+        prompt_core_root / "skills" / "example-incident-brief" / "agents" / "openai.yaml"
+    ).exists()
     assert (prompt_core_root / "tickets" / "RET-9001.yaml").exists()
 
     assert prompt_policy_manifest["provenance"]["source_pack"] == "prompt-policy-curated"

--- a/tests/unit/evaluation/test_tool_identity.py
+++ b/tests/unit/evaluation/test_tool_identity.py
@@ -11,10 +11,17 @@ from redis_sre_agent.evaluation.scenarios import EvalScenario
 from redis_sre_agent.evaluation.tool_identity import (
     LogicalToolIdentity,
     ToolIdentityCatalog,
+    normalize_tool_name_token,
 )
 from redis_sre_agent.tools.mcp.provider import MCPToolProvider
 from redis_sre_agent.tools.models import Tool, ToolCapability, ToolDefinition, ToolMetadata
 from redis_sre_agent.tools.protocols import ToolProvider
+
+
+def test_normalize_tool_name_token_collapses_whitespace_and_separator_variants():
+    assert normalize_tool_name_token("Example\tIncident  List-Related\nSignals") == (
+        "example_incident_list_related_signals"
+    )
 
 
 class StubProvider(ToolProvider):

--- a/tests/unit/mcp_server/test_mcp_server.py
+++ b/tests/unit/mcp_server/test_mcp_server.py
@@ -218,6 +218,31 @@ class TestSkillTools:
         assert result == expected
         mock_helper.assert_awaited_once_with(
             query="maintenance",
+            search_type=None,
+            limit=5,
+            offset=1,
+            version="latest",
+        )
+
+    @pytest.mark.asyncio
+    async def test_list_skills_passes_search_type(self):
+        expected = {"skills": [{"name": "redis-maintenance-triage"}], "total": 1}
+
+        with patch(
+            "redis_sre_agent.core.knowledge_helpers.skills_check_helper",
+            new=AsyncMock(return_value=expected),
+        ) as mock_helper:
+            result = await redis_sre_list_skills(
+                query="maintenance",
+                search_type="keyword",
+                limit=5,
+                offset=1,
+            )
+
+        assert result == expected
+        mock_helper.assert_awaited_once_with(
+            query="maintenance",
+            search_type="keyword",
             limit=5,
             offset=1,
             version="latest",

--- a/tests/unit/skills/test_afs_workspace_backend.py
+++ b/tests/unit/skills/test_afs_workspace_backend.py
@@ -135,9 +135,9 @@ async def test_afs_workspace_skill_backend_query_and_error_paths() -> None:
                             "resources": [],
                         },
                         {
-                            "skillSlug": "redis-cluster-health-check",
-                            "displayName": "Redis Cluster Health Check",
-                            "description": "Produce Analyzer-backed cluster findings.",
+                            "skillSlug": "example-incident-brief",
+                            "displayName": "Example Incident Brief",
+                            "description": "Produce an example incident brief.",
                             "version": "v1",
                             "resources": [],
                         },
@@ -169,14 +169,16 @@ async def test_afs_workspace_skill_backend_query_and_error_paths() -> None:
     )
     with patch("redis_sre_agent.core.redis.get_vectorizer", return_value=vectorizer):
         queried = await backend.list_skills(
-            query="run a health check",
+            query="build an incident brief",
             limit=10,
             offset=0,
             version="v1",
         )
 
-    assert queried["skills"][0]["name"] == "redis-cluster-health-check"
+    assert queried["skills"][0]["name"] == "example-incident-brief"
     assert queried["skills"][0]["matched_resource_kind"] == "entrypoint"
+    assert queried["search_type"] == "semantic"
+    assert queried["supported_search_types"] == ["semantic", "keyword"]
 
     missing_skill = await backend.get_skill(skill_name="missing", version="v1")
     assert missing_skill["error"] == "Skill not found"
@@ -211,10 +213,84 @@ async def test_afs_workspace_skill_backend_omits_none_version_from_api_params() 
     vectorizer = AsyncMock()
     vectorizer.aembed_many = AsyncMock(return_value=[[1.0, 0.0]])
     with patch("redis_sre_agent.core.redis.get_vectorizer", return_value=vectorizer):
-        queried = await backend.list_skills(query="health check", limit=10, offset=0, version=None)
+        queried = await backend.list_skills(
+            query="incident brief", limit=10, offset=0, version=None
+        )
 
     assert queried["skills"] == []
     assert client.calls[1][2] == {"limit": 100, "offset": 0}
+
+
+@pytest.mark.asyncio
+async def test_afs_workspace_skill_backend_keyword_query_uses_lexical_filter() -> None:
+    responses = [
+        _FakeResponse(
+            {
+                "data": {
+                    "skills": [
+                        {
+                            "skillSlug": "redis-maintenance-triage",
+                            "displayName": "Redis Maintenance Triage",
+                            "description": "Check maintenance mode first.",
+                            "version": "v1",
+                            "resources": [],
+                        },
+                        {
+                            "skillSlug": "example-incident-brief",
+                            "displayName": "Example Incident Brief",
+                            "description": "Produce an example incident brief.",
+                            "version": "v1",
+                            "resources": [],
+                        },
+                    ],
+                    "total": 2,
+                }
+            }
+        )
+    ]
+    client = _FakeAsyncClient(responses=responses)
+    backend = AFSWorkspaceSkillBackend(
+        base_url="https://skills.internal",
+        tenant_id="tenant_a",
+        project_id="proj_1",
+        agent_id="agent_1",
+        client_factory=lambda **kwargs: client,  # type: ignore[arg-type]
+    )
+
+    queried = await backend.list_skills(
+        query="incident brief",
+        search_type="keyword",
+        limit=10,
+        offset=0,
+        version="v1",
+    )
+
+    assert queried["skills"][0]["name"] == "example-incident-brief"
+    assert queried["search_type"] == "keyword"
+    assert queried["supported_search_types"] == ["semantic", "keyword"]
+
+
+@pytest.mark.asyncio
+async def test_afs_workspace_skill_backend_hybrid_query_reports_unsupported() -> None:
+    backend = AFSWorkspaceSkillBackend(
+        base_url="https://skills.internal",
+        tenant_id="tenant_a",
+        project_id="proj_1",
+        agent_id="agent_1",
+        client_factory=lambda **kwargs: _FakeAsyncClient(responses=[]),  # type: ignore[arg-type]
+    )
+
+    result = await backend.list_skills(
+        query="incident brief",
+        search_type="hybrid",
+        limit=10,
+        offset=3,
+        version="v1",
+    )
+
+    assert result["error"] == "unsupported_search_type"
+    assert result["requested_search_type"] == "hybrid"
+    assert result["supported_search_types"] == ["semantic", "keyword"]
 
 
 def test_afs_workspace_skill_backend_from_settings_uses_env_fallbacks(
@@ -365,9 +441,9 @@ async def test_afs_workspace_skill_backend_gateway_query_uses_semantic_ranking()
                 "resources": [],
             },
             {
-                "skillSlug": "redis-cluster-health-check",
-                "displayName": "Redis Cluster Health Check",
-                "description": "Produce Analyzer-backed cluster findings.",
+                "skillSlug": "example-incident-brief",
+                "displayName": "Example Incident Brief",
+                "description": "Produce an example incident brief.",
                 "version": "v1",
                 "resources": [],
             },
@@ -384,13 +460,14 @@ async def test_afs_workspace_skill_backend_gateway_query_uses_semantic_ranking()
 
     with patch("redis_sre_agent.core.redis.get_vectorizer", return_value=vectorizer):
         result = await backend.list_skills(
-            query="cluster health findings",
+            query="incident brief",
             limit=10,
             offset=0,
             version="latest",
         )
 
-    assert result["skills"][0]["name"] == "redis-cluster-health-check"
+    assert result["skills"][0]["name"] == "example-incident-brief"
+    assert result["search_type"] == "semantic"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/skills/test_backend.py
+++ b/tests/unit/skills/test_backend.py
@@ -79,6 +79,8 @@ async def test_list_skills_collapses_package_resource_matches_by_skill():
         )
 
     assert result["results_count"] == 2
+    assert result["search_type"] == "semantic"
+    assert result["supported_search_types"] == ["semantic", "keyword", "hybrid"]
     assert [skill["name"] for skill in result["skills"]] == [
         "redis-maintenance-triage",
         "memory-pressure-triage",
@@ -134,6 +136,7 @@ async def test_list_skills_without_query_prefers_entrypoint_for_package_represen
         )
 
     assert result["results_count"] == 1
+    assert result["search_type"] is None
     assert result["skills"][0]["matched_resource_path"] == "SKILL.md"
     assert result["skills"][0]["matched_resource_kind"] == "entrypoint"
 

--- a/tests/unit/skills/test_discovery.py
+++ b/tests/unit/skills/test_discovery.py
@@ -187,6 +187,15 @@ def test_find_skill_package_root_respects_boundary(tmp_path: Path):
     assert find_skill_package_root(document_path, boundary=corpus_root) is None
 
 
+def test_find_skill_package_root_accepts_package_directory(tmp_path: Path):
+    (tmp_path / "SKILL.md").write_text(
+        "---\nname: top-level\ndescription: outer package\n---\n",
+        encoding="utf-8",
+    )
+
+    assert find_skill_package_root(tmp_path) == tmp_path.resolve()
+
+
 def test_scaffold_skill_package_from_markdown_creates_package_skeleton(tmp_path: Path):
     legacy_skill = tmp_path / "legacy-skill.md"
     legacy_skill.write_text(


### PR DESCRIPTION
## Summary
- Extract generic output and workflow contracts from skill packages.
- Enforce skill contract reminders and output repair at runtime.
- Add `required_response_patterns` support to eval assertions and reports.
- Use an eval-only Example Incident Brief skill that mirrors a tool-calling workflow and required output format.

## Notes
- Supersedes #175 and #178.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the chat agent control-flow and final-answer rewriting logic based on retrieved skill contracts, which can affect tool execution loops and user-visible output formatting; it also expands evaluation/skill backends and integration test wiring.
> 
> **Overview**
> **Adds binding skill-contract enforcement end-to-end.** Skill backends now extract and return normalized `output_contract`/`workflow_contract` (plus `contract_summary`) from Agent Skills packages (including inferring an output template from `SKILL.md`), and the chat agent injects contract reminders, tracks missing required tool calls/output sections, and performs a one-time *format-only* repair pass before finalizing.
> 
> **Expands eval coverage for output shape and MCP tools.** Evals add a synthetic `example-incident-brief` skill + a new `prompt/example-skill-workflow-adherence` scenario/suite with fixtures, and assertions gain `required_response_patterns` support (wired through schemas/reports) plus improved tool identity inference for MCP server operations.
> 
> **Improves skill discovery ergonomics and test stability.** Skills listing gains `--search-type` (`semantic`/`keyword`/`hybrid`) plumbed through CLI/MCP/backends (with structured “unsupported” responses where needed), startup skill TOC is truncated more aggressively and shows title vs lookup name, discovery/scaffolding are updated for `document_hash`/contract stubs, and integration tests are refactored to route global Redis settings via a shared testcontainer fixture and modernized mocks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0588c7cf73c1d1a8fe64005aadb2d422c54ace77. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->