### PR TITLE
Preserve JSON Schema type in tool adapter args model

### DIFF
--- a/redis_sre_agent/agent/helpers.py
+++ b/redis_sre_agent/agent/helpers.py
@@ -338,8 +338,20 @@ async def build_adapters_for_tooldefs(tool_manager: Any, tooldefs: List[Any]) ->
     }
 
     def _python_type_for(spec: dict, is_required: bool):
-        py_type = _json_type_map.get((spec or {}).get("type"), _Any)
-        if not is_required and py_type is not _Any:
+        raw_type = (spec or {}).get("type")
+        if isinstance(raw_type, list):
+            # Type-union form, e.g. ["string", "null"]. Map the first concrete
+            # type; treat "null" in the union as the nullability signal.
+            concrete = next((t for t in raw_type if isinstance(t, str) and t != "null"), None)
+            py_type = _json_type_map.get(concrete, _Any)
+            nullable = "null" in raw_type
+        elif isinstance(raw_type, str):
+            py_type = _json_type_map.get(raw_type, _Any)
+            nullable = not is_required
+        else:
+            py_type = _Any
+            nullable = not is_required
+        if nullable and py_type is not _Any:
             py_type = Optional[py_type]
         return py_type
 

--- a/redis_sre_agent/agent/helpers.py
+++ b/redis_sre_agent/agent/helpers.py
@@ -328,15 +328,31 @@ async def build_adapters_for_tooldefs(tool_manager: Any, tooldefs: List[Any]) ->
             return spec.get("default")
         return None
 
+    _json_type_map: dict[str, type] = {
+        "string": str,
+        "integer": int,
+        "number": float,
+        "boolean": bool,
+        "array": list,
+        "object": dict,
+    }
+
+    def _python_type_for(spec: dict, is_required: bool):
+        py_type = _json_type_map.get((spec or {}).get("type"), _Any)
+        if not is_required and py_type is not _Any:
+            py_type = Optional[py_type]
+        return py_type
+
     def _args_model_from_parameters(tool_name: str, params: dict) -> type[_BaseModel]:
         props = (params or {}).get("properties", {}) or {}
         required = set((params or {}).get("required", []) or [])
         fields: dict[str, tuple[_Any, _Any]] = {}
         for k, spec in props.items():
-            default = _field_default(spec or {}, k in required)
+            spec = spec or {}
+            default = _field_default(spec, k in required)
             fields[k] = (
-                _Any,
-                _Field(default, description=(spec or {}).get("description")),
+                _python_type_for(spec, k in required),
+                _Field(default, description=spec.get("description")),
             )
         args_model = _create_model(f"{tool_name}_Args", __base__=_BaseModel, **fields)
         # allow extra to be resilient to provider-side schema drift

--- a/redis_sre_agent/agent/helpers.py
+++ b/redis_sre_agent/agent/helpers.py
@@ -341,10 +341,12 @@ async def build_adapters_for_tooldefs(tool_manager: Any, tooldefs: List[Any]) ->
         raw_type = (spec or {}).get("type")
         if isinstance(raw_type, list):
             # Type-union form, e.g. ["string", "null"]. Map the first concrete
-            # type; treat "null" in the union as the nullability signal.
+            # type; treat the field as nullable when "null" is in the union OR
+            # when the field is non-required, so the Pydantic default of None
+            # validates against the resulting annotation.
             concrete = next((t for t in raw_type if isinstance(t, str) and t != "null"), None)
             py_type = _json_type_map.get(concrete, _Any)
-            nullable = "null" in raw_type
+            nullable = (not is_required) or ("null" in raw_type)
         elif isinstance(raw_type, str):
             py_type = _json_type_map.get(raw_type, _Any)
             nullable = not is_required

--- a/tests/unit/agent/test_helpers_tool_schema.py
+++ b/tests/unit/agent/test_helpers_tool_schema.py
@@ -60,9 +60,7 @@ async def test_build_adapters_preserves_property_types_on_wire():
 
     assert _property_has_type(props["query"], "string"), props["query"]
     assert _property_has_type(props["limit"], "integer"), props["limit"]
-    assert _property_has_type(
-        props["distance_threshold"], "number"
-    ), props["distance_threshold"]
+    assert _property_has_type(props["distance_threshold"], "number"), props["distance_threshold"]
 
 
 async def test_build_adapters_falls_back_to_any_when_source_has_no_type():

--- a/tests/unit/agent/test_helpers_tool_schema.py
+++ b/tests/unit/agent/test_helpers_tool_schema.py
@@ -87,3 +87,29 @@ async def test_build_adapters_falls_back_to_any_when_source_has_no_type():
 
     assert "payload" in props
     assert "type" not in props["payload"] and "anyOf" not in props["payload"]
+
+
+async def test_build_adapters_accepts_type_union_form():
+    """Properties declared as `{"type": ["string", "null"]}` (the strict-mode
+    and common MCP form) must not crash adapter construction, and the concrete
+    type should survive the round-trip."""
+    tdef = ToolDefinition(
+        name="union_type_fixture",
+        description="Fixture for type-union nullable property",
+        capability=ToolCapability.UTILITIES,
+        parameters={
+            "type": "object",
+            "properties": {
+                "label": {"type": ["string", "null"], "description": "Nullable label"},
+            },
+            "required": [],
+        },
+    )
+
+    adapters = await build_adapters_for_tooldefs(None, [tdef])
+    assert len(adapters) == 1
+
+    schema = convert_to_openai_tool(adapters[0])
+    props = schema["function"]["parameters"]["properties"]
+
+    assert _property_has_type(props["label"], "string"), props["label"]

--- a/tests/unit/agent/test_helpers_tool_schema.py
+++ b/tests/unit/agent/test_helpers_tool_schema.py
@@ -1,0 +1,91 @@
+"""Round-trip tests for build_adapters_for_tooldefs schema generation.
+
+Regression coverage for the case where ToolDefinition.parameters declared
+JSON Schema property types but those types were stripped on the wire because
+_args_model_from_parameters used a blanket Any annotation.
+"""
+
+from langchain_core.utils.function_calling import convert_to_openai_tool
+
+from redis_sre_agent.agent.helpers import build_adapters_for_tooldefs
+from redis_sre_agent.tools.models import ToolCapability, ToolDefinition
+
+
+def _property_has_type(prop: dict, expected: str) -> bool:
+    """True if ``prop`` declares ``expected`` as its JSON Schema type.
+
+    Accepts both the direct form ``{"type": "string"}`` and the
+    ``Optional[T]`` form Pydantic emits, ``{"anyOf": [{"type": "string"},
+    {"type": "null"}]}``.
+    """
+    if prop.get("type") == expected:
+        return True
+    for branch in prop.get("anyOf", []) or []:
+        if isinstance(branch, dict) and branch.get("type") == expected:
+            return True
+    return False
+
+
+async def test_build_adapters_preserves_property_types_on_wire():
+    tdef = ToolDefinition(
+        name="kb_search_fixture",
+        description="Fixture tool for schema round-trip test",
+        capability=ToolCapability.KNOWLEDGE,
+        parameters={
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "description": "Search query",
+                },
+                "limit": {
+                    "type": "integer",
+                    "description": "Max results",
+                    "default": 10,
+                },
+                "distance_threshold": {
+                    "type": "number",
+                    "description": "Optional distance threshold",
+                },
+            },
+            "required": ["query"],
+        },
+    )
+
+    adapters = await build_adapters_for_tooldefs(None, [tdef])
+    assert len(adapters) == 1
+
+    schema = convert_to_openai_tool(adapters[0])
+    props = schema["function"]["parameters"]["properties"]
+
+    assert _property_has_type(props["query"], "string"), props["query"]
+    assert _property_has_type(props["limit"], "integer"), props["limit"]
+    assert _property_has_type(
+        props["distance_threshold"], "number"
+    ), props["distance_threshold"]
+
+
+async def test_build_adapters_falls_back_to_any_when_source_has_no_type():
+    """MCP-published schemas can omit `type`. We should keep the field
+    callable rather than fabricating a type the source did not declare."""
+    tdef = ToolDefinition(
+        name="mcp_untyped_fixture",
+        description="Fixture for property with no declared type",
+        capability=ToolCapability.UTILITIES,
+        parameters={
+            "type": "object",
+            "properties": {
+                "payload": {"description": "Free-form payload, no type"},
+            },
+            "required": [],
+        },
+    )
+
+    adapters = await build_adapters_for_tooldefs(None, [tdef])
+    assert len(adapters) == 1
+
+    schema = convert_to_openai_tool(adapters[0])
+    props = schema["function"]["parameters"]["properties"]
+
+    assert "payload" in props
+    assert "type" not in props["payload"] and "anyOf" not in props["payload"]

--- a/tests/unit/agent/test_helpers_tool_schema.py
+++ b/tests/unit/agent/test_helpers_tool_schema.py
@@ -113,3 +113,29 @@ async def test_build_adapters_accepts_type_union_form():
     props = schema["function"]["parameters"]["properties"]
 
     assert _property_has_type(props["label"], "string"), props["label"]
+
+
+async def test_non_required_single_type_list_accepts_default_none():
+    """A non-required property declared as `{"type": ["string"]}` (no "null"
+    in the union) must still be Optional[T] so the Pydantic field default of
+    None validates against the annotation when the LLM omits the parameter."""
+    tdef = ToolDefinition(
+        name="single_type_list_fixture",
+        description="Fixture for non-required single-element type-list",
+        capability=ToolCapability.UTILITIES,
+        parameters={
+            "type": "object",
+            "properties": {
+                "label": {"type": ["string"], "description": "Non-required label"},
+            },
+            "required": [],
+        },
+    )
+
+    adapters = await build_adapters_for_tooldefs(None, [tdef])
+    assert len(adapters) == 1
+
+    # Instantiating with no args must not raise; default None must validate.
+    model = adapters[0].args_schema
+    instance = model()
+    assert instance.label is None


### PR DESCRIPTION
## Summary

`_args_model_from_parameters` in `redis_sre_agent/agent/helpers.py` typed every dynamic Pydantic field as `Any`, which dropped the JSON Schema `type` key from each property when LangChain converted the args model into an OpenAI function-call schema. Strict-validating LLM endpoints rejected the resulting tools with 422.

This change maps source JSON Schema `type` to concrete Python types (`string→str`, `integer→int`, `number→float`, `boolean→bool`, `array→list`, `object→dict`). Non-required typed fields wrap as `Optional[T]`. Properties whose source schema has no `type` continue to fall back to `Any` so MCP-published schemas without declared types remain callable. `extra="allow"` is preserved.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes dynamic tool-arg Pydantic model typing, which affects the generated OpenAI/LangChain tool schema and runtime validation; risk is moderate but bounded by explicit type mapping and new regression tests.
> 
> **Overview**
> Fixes tool adapter schema generation so JSON Schema property `type` survives conversion to OpenAI tool schemas. `_args_model_from_parameters` now maps JSON Schema types to concrete Python annotations (wrapping non-required/nullable fields in `Optional[T]`) instead of always using `Any`, while still falling back to `Any` when no type is provided and keeping `extra="allow"`.
> 
> Adds unit tests that round-trip `ToolDefinition.parameters` through `build_adapters_for_tooldefs`/`convert_to_openai_tool`, covering typed properties, untyped properties, union `type` lists (e.g. `["string","null"]`), and ensuring omitted optional params validate with default `None`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 961fdfd2406fdf7221caa6a8febf481b1ecf508c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->