### PR TITLE
Add user feedback on agent responses across HTTP, MCP, CLI, and UI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,25 @@ make local-services-logs # Tail logs
 - Written specs: `specs/`
 - Source documents: `source_documents/`
 
+## Feedback
+
+### HTTP endpoints
+- `POST /api/v1/tasks/{task_id}/feedback` — submit or update feedback; body `{"verdict":"up"|"down"|"withdrawn","comment":"..."}` (comment optional, max 2048 chars); returns `FeedbackRecord` (200) or 404 when task absent; invalid verdict or oversized comment → 422.
+- `GET /api/v1/tasks/{task_id}/feedback` — retrieve current feedback; returns `FeedbackRecord` (200) or 404 when no feedback exists.
+
+### MCP tool
+- `redis_sre_submit_feedback(task_id, verdict, comment?)` — thin wrapper around `submit_feedback()`; propagates `pydantic.ValidationError` and `TaskNotFoundError` as native MCP errors (not success-shaped error dicts).
+
+### CLI commands
+- `redis-sre-agent feedback up <task_id> [--comment "..."]`
+- `redis-sre-agent feedback down <task_id> [--comment "..."]`
+- `redis-sre-agent feedback withdraw <task_id>`
+- `redis-sre-agent feedback show <task_id>`
+- `redis-sre-agent feedback list [--since <Ns|m|h|d>] [--verdict up|down|withdrawn] [--limit N]`
+
+### How feedback works
+All feedback writes go through `submit_feedback()` in `redis_sre_agent/core/feedback.py`. HTTP, MCP, and CLI surfaces are thin wrappers. The Redis hash at `sre:feedback:task:{task_id}` is the source of truth; `created_at` is `HSETNX`-anchored to be concurrency-safe; a `feedback_submitted` event is published to `sre:stream:task:{thread_id}` after every successful write. To add a new surface, wrap `submit_feedback()` — do not write to the Redis hash directly.
+
 ## Specs
 - Put newly written design specs and implementation specs in `specs/`.
 - Prefer `specs/` over `docs/` for work-in-progress or review-oriented specification documents.

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Documentation: <https://redis-applied-ai.github.io/redis-sre-agent/>
 - Route work through a background worker and persist tasks, threads, and citations.
 - Analyze Redis Enterprise support packages alongside live targets.
 - Expose the same core capabilities through a CLI, REST API, Docker stack, and MCP server.
+- **Response feedback**: Capture 👍 / 👎 / withdrawn user feedback on agent responses from any interface (UI, HTTP, MCP, CLI). See [docs/how-to/feedback.md](./docs/how-to/feedback.md).
 
 ## Five-Minute Quickstart
 

--- a/docs/how-to/api.md
+++ b/docs/how-to/api.md
@@ -259,6 +259,7 @@ curl -fsS http://localhost:8080/api/v1/schedules/<schedule_id>/runs | jq
 - Tasks: `GET /api/v1/tasks/{task_id}`
 - Threads: `GET /api/v1/threads`, `GET /api/v1/threads/{thread_id}`
 - WebSocket: `ws://localhost:8080/api/v1/ws/tasks/{thread_id}`
+- **Feedback**: `POST/GET /api/v1/tasks/{task_id}/feedback` — see [feedback.md](./feedback.md).
 
 #### Approval-driven tasks
 Some write actions pause a task in `awaiting_approval`. When that happens:

--- a/docs/how-to/cli.md
+++ b/docs/how-to/cli.md
@@ -249,7 +249,10 @@ docker compose exec -T sre-agent uv run redis-sre-agent support-package list
 docker compose exec -T sre-agent uv run redis-sre-agent query -p <package_id> "Show database memory usage"
 ```
 
-### 9) See task status and thread contents
+### 9) Feedback on agent responses
+**feedback**: 👍 / 👎 / withdraw on any task — see [feedback.md](./feedback.md).
+
+### 10) See task status and thread contents
 Tasks track execution; threads hold the conversation + context.
 ```bash
 # Tasks

--- a/docs/how-to/feedback.md
+++ b/docs/how-to/feedback.md
@@ -1,0 +1,166 @@
+## Response Feedback
+
+### What this is
+
+The feedback system lets you record a thumbs-up, thumbs-down, or withdrawal on any completed agent task. The rating is available from your web UI, third-party HTTP clients, MCP-connected clients (Claude, Cursor, and similar), and the `redis-sre-agent` CLI. Feedback is anonymous — no authentication is required — and follows last-write-wins semantics, so any surface can update or retract a previous rating at any time.
+
+### HTTP usage
+
+**Port note**: Docker Compose exposes the API on port **8080**; local uvicorn uses port **8000**. Examples below use port 8080. Replace with 8000 if running locally.
+
+#### Submit or update feedback
+
+```bash
+# Thumbs-up
+curl -fsS -X POST http://localhost:8080/api/v1/tasks/<task_id>/feedback \
+  -H 'Content-Type: application/json' \
+  -d '{"verdict":"up"}' | jq
+
+# Thumbs-down with an optional comment
+curl -fsS -X POST http://localhost:8080/api/v1/tasks/<task_id>/feedback \
+  -H 'Content-Type: application/json' \
+  -d '{"verdict":"down","comment":"Missed the eviction policy angle"}' | jq
+```
+
+Expected 200 response:
+
+```json
+{
+  "task_id": "task-abc123",
+  "verdict": "down",
+  "comment": "Missed the eviction policy angle",
+  "created_at": "2026-05-18T10:00:00.000000+00:00",
+  "updated_at": "2026-05-18T10:05:00.000000+00:00"
+}
+```
+
+#### Retrieve current feedback
+
+```bash
+curl -fsS http://localhost:8080/api/v1/tasks/<task_id>/feedback | jq
+```
+
+Returns the `FeedbackRecord` JSON above (200) or a 404 when no feedback has been submitted yet.
+
+#### Validation errors (422)
+
+Invalid input returns a standard Pydantic 422 response. Each problem appears as an item in the `detail` array:
+
+```json
+{
+  "detail": [
+    {
+      "type": "literal_error",
+      "loc": ["body", "verdict"],
+      "msg": "Input should be 'up', 'down' or 'withdrawn'",
+      "input": "meh",
+      "ctx": {"expected": "'up', 'down' or 'withdrawn'"}
+    }
+  ]
+}
+```
+
+### MCP usage
+
+Call `redis_sre_submit_feedback` from any MCP-connected client:
+
+```python
+redis_sre_submit_feedback(
+    task_id="task-abc123",
+    verdict="up",
+    comment="Exactly the right diagnosis",   # optional
+)
+```
+
+Returns the same `FeedbackRecord` dict on success. Unlike most other tools in this server, validation errors (`verdict` outside the enum, `comment` exceeding 2048 chars) and `TaskNotFoundError` propagate as native MCP errors rather than success-shaped `{"error": ..., "status": "failed"}` dicts. Handle them accordingly in your MCP client.
+
+### CLI usage
+
+All feedback commands are under the `feedback` subgroup:
+
+```bash
+# Submit thumbs-up
+uv run redis-sre-agent feedback up <task_id>
+uv run redis-sre-agent feedback up <task_id> --comment "Great diagnosis"
+
+# Submit thumbs-down
+uv run redis-sre-agent feedback down <task_id>
+uv run redis-sre-agent feedback down <task_id> --comment "Missed the eviction policy angle"
+
+# Withdraw (sets verdict to 'withdrawn'; preserves history)
+uv run redis-sre-agent feedback withdraw <task_id>
+
+# Show current feedback for a task
+uv run redis-sre-agent feedback show <task_id>
+
+# List recent feedback with optional filters
+uv run redis-sre-agent feedback list
+uv run redis-sre-agent feedback list --since 24h --verdict down --limit 50
+```
+
+**`feedback show` exit-code contract**: exits 0 and prints `null` when the task exists but has no feedback yet; exits non-zero only on hard errors (task not found, Redis error).
+
+**`--since` format**: accepts `<N>{s,m,h,d}` only — for example `30m`, `24h`, `7d`. ISO-8601 dates are rejected in Phase 1.
+
+**`--limit`**: defaults to 50, accepts values up to 500. Values above 500 are clamped to 500.
+
+### Semantics
+
+- **Last-write-wins**: any surface can overwrite a previous rating, including changing from `down` to `up` or withdrawing entirely.
+- **Anonymous**: no user identity is recorded; the hash stores only the verdict, optional comment, and timestamps.
+- **Withdrawal preserves history**: `withdraw` sets `verdict` to `"withdrawn"` — it does not delete the Redis hash. `created_at` and `updated_at` remain.
+- **`created_at` is anchored**: the first write locks `created_at` via `HSETNX`; resubmissions only update `updated_at`.
+- **No rating yet**: the absence of the feedback key means no feedback has been submitted. `GET /api/v1/tasks/{task_id}/feedback` returns 404; `feedback show` prints `null`.
+- **Idempotent resubmits**: if the verdict and comment are identical to the stored record, the write is short-circuited and the existing record is returned without touching `updated_at` or publishing a stream event.
+
+### Storage layout
+
+Each task's feedback is stored as a single Redis hash:
+
+```
+sre:feedback:task:{task_id}
+```
+
+Fields:
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `task_id` | string | Same as the key suffix |
+| `verdict` | string | `"up"`, `"down"`, or `"withdrawn"` |
+| `comment` | string | Empty string when no comment was provided |
+| `created_at` | string | ISO-8601; anchored on first write via `HSETNX` |
+| `updated_at` | string | ISO-8601; overwritten on every change |
+
+This layout is the public-ish contract. Tooling that reads feedback directly should treat the hash fields above as stable.
+
+### WebSocket event
+
+After every successful write, a `feedback_submitted` event is published to the task's stream channel:
+
+```
+sre:stream:task:{thread_id}
+```
+
+Event payload:
+
+```json
+{
+  "update_type": "feedback_submitted",
+  "task_id": "<task_id>",
+  "verdict": "down",
+  "has_comment": true
+}
+```
+
+WebSocket subscribers (for example, the web UI) can listen for `update_type == "feedback_submitted"` to refresh the feedback widget in real time. If a task's `thread_id` is missing or malformed, the hash write still succeeds and only the stream publish is skipped (fail-open).
+
+### Phase 2 (not yet available)
+
+The following capabilities are planned but not implemented in the current release:
+
+- Aggregate analytics endpoints (verdict counts, comment trends per asset or time window).
+- Learning-loop integration with Agent Memory Service — down-rated answers feed into memory correction signals.
+- Eval auto-labeling via the CLI (`feedback list` output as a labeling source for `make test-eval-pr`).
+- Optional rate limiting per IP or session.
+- Optional categorical reason codes alongside free-text comments.
+- Optional `message_id` anchoring to tie feedback to a specific assistant turn within a thread.

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -99,6 +99,8 @@ For copy/paste workflows, see [Using the API](../how-to/api.md).
 | `DELETE` | `/api/v1/tasks/{task_id}` | delete_task |
 | `GET` | `/api/v1/tasks/{task_id}` | get_task |
 | `GET` | `/api/v1/tasks/{task_id}/approvals` | list_task_approvals |
+| `GET` | `/api/v1/tasks/{task_id}/feedback` | get_task_feedback |
+| `POST` | `/api/v1/tasks/{task_id}/feedback` | submit_task_feedback |
 | `POST` | `/api/v1/tasks/{task_id}/resume` | resume_task |
 | `GET` | `/api/v1/tasks/{thread_id}/stream-info` | get_task_stream_info |
 | `GET` | `/api/v1/threads` | list_threads |
@@ -121,4 +123,5 @@ For copy/paste workflows, see [Using the API](../how-to/api.md).
 
 | Method | Path | Summary |
 |---|---|---|
+| `GET` | `/api/v1/feedback` | list_feedback |
 | `GET` | `/api/v1/memory/thread/{thread_id}` | get_thread_memory |

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -99,6 +99,12 @@ Generated from the Click command tree.
 - eval list — List known eval scenario ids.
 - eval live-suite — Run one configured live-model eval suite.
 - eval run — Run one mocked eval scenario.
+- feedback — Agent response feedback commands (up / down / withdraw / show / list).
+- feedback down — Submit a thumbs-down for TASK_ID.
+- feedback list — List feedback views with optional filters.
+- feedback show — Show current feedback for TASK_ID (joined view with task info).
+- feedback up — Submit a thumbs-up for TASK_ID.
+- feedback withdraw — Withdraw feedback for TASK_ID (sets verdict to 'withdrawn').
 - version — Show the Redis SRE Agent version.
 
 See How-to guides for examples.

--- a/redis_sre_agent/api/app.py
+++ b/redis_sre_agent/api/app.py
@@ -9,6 +9,8 @@ from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
 
 from redis_sre_agent import __version__
 from redis_sre_agent.api.clusters import router as clusters_router
+from redis_sre_agent.api.feedback import list_router as feedback_list_router
+from redis_sre_agent.api.feedback import router as feedback_router
 from redis_sre_agent.api.health import router as health_router
 from redis_sre_agent.api.instances import router as instances_router
 from redis_sre_agent.api.knowledge import router as knowledge_router
@@ -199,6 +201,8 @@ app.include_router(knowledge_router, tags=["Knowledge"])
 # Mount the Threads/Tasks APIs under /api/v1
 app.include_router(threads_router, prefix="/api/v1", tags=["Threads"])
 app.include_router(tasks_api_router, prefix="/api/v1", tags=["Tasks"])
+app.include_router(feedback_router)
+app.include_router(feedback_list_router)
 app.include_router(memory_router, prefix="/api/v1", tags=["Memory"])
 
 app.include_router(schedules_router, tags=["Schedules"])

--- a/redis_sre_agent/api/feedback.py
+++ b/redis_sre_agent/api/feedback.py
@@ -1,0 +1,98 @@
+"""Feedback API endpoints for submitting and retrieving task feedback."""
+
+from typing import Literal, Optional
+
+from fastapi import APIRouter, HTTPException, Query
+from fastapi import status as http_status
+
+from redis_sre_agent.api.schemas import FeedbackRecord, FeedbackSubmitRequest, FeedbackView
+from redis_sre_agent.core.feedback import TaskNotFoundError
+from redis_sre_agent.core.feedback import get_feedback_view as core_get_feedback_view
+from redis_sre_agent.core.feedback import list_feedback_views as core_list_feedback_views
+from redis_sre_agent.core.feedback import submit_feedback as core_submit_feedback
+from redis_sre_agent.core.tasks import TaskStatus
+
+router = APIRouter(prefix="/api/v1/tasks", tags=["feedback"])
+
+# Second router for the collection endpoint at /api/v1/feedback.
+# Kept separate from `router` so the prefix doesn't have to be /api/v1/tasks.
+list_router = APIRouter(prefix="/api/v1/feedback", tags=["feedback"])
+
+# Valid status values derived from the TaskStatus enum — used in Query validation.
+_VALID_STATUSES = {s.value for s in TaskStatus}
+
+
+@router.post(
+    "/{task_id}/feedback",
+    response_model=FeedbackRecord,
+    status_code=http_status.HTTP_200_OK,
+)
+async def submit_task_feedback(task_id: str, body: FeedbackSubmitRequest) -> FeedbackRecord:
+    """Submit or update feedback for a task.
+
+    Pydantic validation errors (invalid verdict, comment too long) propagate
+    as 422 via default FastAPI behaviour — do not catch them here.
+    """
+    try:
+        return await core_submit_feedback(task_id, body.verdict, body.comment)
+    except TaskNotFoundError as exc:
+        raise HTTPException(status_code=http_status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+
+
+@router.get(
+    "/{task_id}/feedback",
+    response_model=FeedbackView,
+    status_code=http_status.HTTP_200_OK,
+)
+async def get_task_feedback(task_id: str) -> FeedbackView:
+    """Retrieve the joined feedback view for a task, or 404 when absent.
+
+    Returns a FeedbackView with both `feedback` and `task` keys.
+    The POST endpoint above still returns a bare FeedbackRecord (AC-17).
+    """
+    try:
+        view = await core_get_feedback_view(task_id)
+    except TaskNotFoundError as exc:
+        raise HTTPException(status_code=http_status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+    if view is None:
+        raise HTTPException(
+            status_code=http_status.HTTP_404_NOT_FOUND,
+            detail=f"No feedback found for task {task_id}",
+        )
+    return view
+
+
+@list_router.get("")
+async def list_feedback(
+    since: Optional[str] = Query(None, pattern=r"^(\d+)([smhd])$"),
+    verdict: Optional[Literal["up", "down", "withdrawn"]] = Query(None),
+    # `status` validated manually: FastAPI/Pydantic rejects unknown values → 422
+    # with loc=["query","status"], which matches AC-9.
+    status: Optional[str] = Query(None),
+    # limit is clamped via ge/le: values outside [1,500] return 422 (not silently
+    # clamped), so callers get an explicit error rather than a surprising truncation.
+    limit: int = Query(50, ge=1, le=500),
+) -> dict:
+    """List feedback views with optional filters.
+
+    Filters:
+    - since: time window in the form Ns/Nm/Nh/Nd (e.g. 24h, 30m).
+    - verdict: up | down | withdrawn.
+    - status: any TaskStatus value; unknown values return 422.
+    - limit: 1–500 (default 50). Values outside that range return 422.
+    """
+    if status is not None and status not in _VALID_STATUSES:
+        raise HTTPException(
+            status_code=http_status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=[
+                {
+                    "type": "literal_error",
+                    "loc": ["query", "status"],
+                    "msg": f"Input should be one of {sorted(_VALID_STATUSES)}",
+                    "input": status,
+                }
+            ],
+        )
+
+    views = await core_list_feedback_views(since=since, verdict=verdict, status=status, limit=limit)
+    return {"items": [v.model_dump(mode="json") for v in views], "count": len(views)}

--- a/redis_sre_agent/api/schemas.py
+++ b/redis_sre_agent/api/schemas.py
@@ -11,6 +11,14 @@ from redis_sre_agent.core.approvals import (
     ApprovalRecord,
     PendingApprovalSummary,
 )
+from redis_sre_agent.core.feedback import (  # noqa: F401 — re-exported for API consumers
+    ConversationMessage,
+    FeedbackRecord,
+    FeedbackSubmitRequest,
+    FeedbackView,
+    TaskInfo,
+    ToolCallSummary,
+)
 from redis_sre_agent.core.tasks import TaskStatus
 
 
@@ -107,6 +115,7 @@ class TaskResponse(BaseModel):
     subject: Optional[str] = None
     created_at: Optional[str] = None
     updated_at: Optional[str] = None
+    feedback: Optional[FeedbackRecord] = None
 
 
 class TaskResumeRequest(BaseModel):

--- a/redis_sre_agent/api/tasks.py
+++ b/redis_sre_agent/api/tasks.py
@@ -9,6 +9,7 @@ import logging
 
 from docket import Docket
 from fastapi import APIRouter, HTTPException, status
+from redis.exceptions import RedisError
 
 from redis_sre_agent.api.schemas import (
     TaskApprovalListResponse,
@@ -40,7 +41,11 @@ async def _build_task_response(task_id: str, task_manager: TaskManager) -> TaskR
         raise HTTPException(status_code=404, detail="Task not found")
 
     tool_calls = await task_manager.get_task_tool_calls(state)
-    feedback = await get_feedback(task_id)
+    # Feedback is an optional sidecar; a Redis hiccup must not fail the task GET.
+    try:
+        feedback = await get_feedback(task_id)
+    except RedisError:
+        feedback = None
 
     return TaskResponse(
         task_id=state.task_id,

--- a/redis_sre_agent/api/tasks.py
+++ b/redis_sre_agent/api/tasks.py
@@ -24,6 +24,7 @@ from redis_sre_agent.core.docket_tasks import (
     resume_task_after_approval,
     validate_task_resume_request,
 )
+from redis_sre_agent.core.feedback import get_feedback
 from redis_sre_agent.core.redis import get_redis_client
 from redis_sre_agent.core.tasks import TaskManager, TaskStatus, create_task
 from redis_sre_agent.core.tasks import delete_task as delete_task_core
@@ -39,6 +40,7 @@ async def _build_task_response(task_id: str, task_manager: TaskManager) -> TaskR
         raise HTTPException(status_code=404, detail="Task not found")
 
     tool_calls = await task_manager.get_task_tool_calls(state)
+    feedback = await get_feedback(task_id)
 
     return TaskResponse(
         task_id=state.task_id,
@@ -53,6 +55,7 @@ async def _build_task_response(task_id: str, task_manager: TaskManager) -> TaskR
         subject=state.metadata.subject if state.metadata else None,
         created_at=state.metadata.created_at if state.metadata else None,
         updated_at=state.metadata.updated_at if state.metadata else None,
+        feedback=feedback,
     )
 
 

--- a/redis_sre_agent/cli/feedback.py
+++ b/redis_sre_agent/cli/feedback.py
@@ -1,0 +1,316 @@
+"""Feedback CLI subgroup — thin wrapper around core.feedback."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import re
+import sys
+from datetime import datetime, timedelta, timezone
+
+import click
+
+from redis_sre_agent.cli.logging_utils import log_cli_exception
+
+_SINCE_RE = re.compile(r"^(\d+)([smhd])$")
+_SINCE_UNITS = {"s": "seconds", "m": "minutes", "h": "hours", "d": "days"}
+
+_VERDICT_CHOICES = click.Choice(["up", "down", "withdrawn"], case_sensitive=False)
+
+_LIMIT_MAX = 500
+
+_VALID_STATUSES = {"queued", "in_progress", "awaiting_approval", "done", "failed", "cancelled"}
+
+
+def _parse_since(value: str) -> datetime:
+    """Parse a duration string like '24h', '30m', '7d' into a UTC cutoff datetime.
+
+    Raises click.BadParameter for ISO-8601 dates or unrecognised formats.
+    """
+    # Reject ISO-8601 explicitly (contains '-' digit pattern or 'T')
+    if re.search(r"\d{4}-\d{2}-\d{2}", value) or "T" in value:
+        raise click.BadParameter(
+            "ISO-8601 dates are not supported in Phase 1. Use a duration like '24h', '30m', '7d'."
+        )
+    m = _SINCE_RE.match(value.strip())
+    if not m:
+        raise click.BadParameter(
+            f"Invalid duration '{value}'. Expected format: <number><unit> where unit is s/m/h/d "
+            "(e.g. '24h', '30m', '7d')."
+        )
+    amount = int(m.group(1))
+    unit = _SINCE_UNITS[m.group(2)]
+    delta = timedelta(**{unit: amount})
+    return datetime.now(timezone.utc) - delta
+
+
+@click.group()
+def feedback():
+    """Agent response feedback commands (up / down / withdraw / show / list)."""
+    pass
+
+
+@feedback.command("up")
+@click.argument("task_id")
+@click.option("--comment", default=None, help="Optional comment (max 2048 chars).")
+def feedback_up(task_id: str, comment: str | None):
+    """Submit a thumbs-up for TASK_ID."""
+
+    async def _run():
+        from redis_sre_agent.core.feedback import (
+            FeedbackError,
+            TaskNotFoundError,
+            submit_feedback,
+        )
+
+        try:
+            record = await submit_feedback(task_id, "up", comment)
+        except TaskNotFoundError as exc:
+            click.echo(str(exc), err=True)
+            sys.exit(1)
+        except FeedbackError as exc:
+            log_cli_exception(__name__, "feedback CLI command failed", exc)
+            click.echo(str(exc), err=True)
+            sys.exit(1)
+        except Exception as exc:
+            log_cli_exception(__name__, "feedback CLI command failed", exc)
+            click.echo(str(exc), err=True)
+            sys.exit(1)
+
+        print(record.model_dump_json(indent=2))
+
+    asyncio.run(_run())
+
+
+@feedback.command("down")
+@click.argument("task_id")
+@click.option("--comment", default=None, help="Optional comment (max 2048 chars).")
+def feedback_down(task_id: str, comment: str | None):
+    """Submit a thumbs-down for TASK_ID."""
+
+    async def _run():
+        from redis_sre_agent.core.feedback import (
+            FeedbackError,
+            TaskNotFoundError,
+            submit_feedback,
+        )
+
+        try:
+            record = await submit_feedback(task_id, "down", comment)
+        except TaskNotFoundError as exc:
+            click.echo(str(exc), err=True)
+            sys.exit(1)
+        except FeedbackError as exc:
+            log_cli_exception(__name__, "feedback CLI command failed", exc)
+            click.echo(str(exc), err=True)
+            sys.exit(1)
+        except Exception as exc:
+            log_cli_exception(__name__, "feedback CLI command failed", exc)
+            click.echo(str(exc), err=True)
+            sys.exit(1)
+
+        print(record.model_dump_json(indent=2))
+
+    asyncio.run(_run())
+
+
+@feedback.command("withdraw")
+@click.argument("task_id")
+def feedback_withdraw(task_id: str):
+    """Withdraw feedback for TASK_ID (sets verdict to 'withdrawn')."""
+
+    async def _run():
+        from redis_sre_agent.core.feedback import (
+            FeedbackError,
+            TaskNotFoundError,
+            submit_feedback,
+        )
+
+        try:
+            record = await submit_feedback(task_id, "withdrawn")
+        except TaskNotFoundError as exc:
+            click.echo(str(exc), err=True)
+            sys.exit(1)
+        except FeedbackError as exc:
+            log_cli_exception(__name__, "feedback CLI command failed", exc)
+            click.echo(str(exc), err=True)
+            sys.exit(1)
+        except Exception as exc:
+            log_cli_exception(__name__, "feedback CLI command failed", exc)
+            click.echo(str(exc), err=True)
+            sys.exit(1)
+
+        print(record.model_dump_json(indent=2))
+
+    asyncio.run(_run())
+
+
+@feedback.command("show")
+@click.argument("task_id")
+def feedback_show(task_id: str):
+    """Show current feedback for TASK_ID (joined view with task info).
+
+    Prints JSON of the FeedbackView (with 'feedback' and 'task' keys), or
+    literal 'null' when no feedback has been submitted yet.  Exits 0 in both
+    cases.  Exits non-zero when the task does not exist or a Redis / validation
+    error occurs.
+    """
+
+    async def _run():
+        from redis_sre_agent.core.feedback import (
+            TaskNotFoundError,
+            get_feedback_view,
+        )
+
+        try:
+            view = await get_feedback_view(task_id)
+        except TaskNotFoundError as exc:
+            click.echo(str(exc), err=True)
+            sys.exit(1)
+        except Exception as exc:
+            log_cli_exception(__name__, "feedback CLI command failed", exc)
+            click.echo(str(exc), err=True)
+            sys.exit(1)
+
+        if view is None:
+            print("null")
+        else:
+            print(view.model_dump_json(indent=2))
+
+    asyncio.run(_run())
+
+
+@feedback.command("list")
+@click.option(
+    "--since",
+    default=None,
+    help="Only include records updated within this duration (e.g. '24h', '30m', '7d'). ISO-8601 dates are rejected.",
+)
+@click.option(
+    "--verdict",
+    type=_VERDICT_CHOICES,
+    default=None,
+    help="Filter by verdict: up, down, or withdrawn.",
+)
+@click.option(
+    "--limit",
+    default=50,
+    show_default=True,
+    help=f"Maximum rows to return (default 50, max {_LIMIT_MAX}). Values above {_LIMIT_MAX} are clamped.",
+)
+@click.option(
+    "--table",
+    "use_table",
+    is_flag=True,
+    default=False,
+    help="Render output as a Rich table instead of JSON Lines.",
+)
+@click.option(
+    "--status",
+    default=None,
+    help=("Filter by task status. Accepted values: " + ", ".join(sorted(_VALID_STATUSES)) + "."),
+)
+def feedback_list(
+    since: str | None, verdict: str | None, limit: int, use_table: bool, status: str | None
+):
+    """List feedback views with optional filters.
+
+    Default output is JSON Lines (one FeedbackView JSON object per line).
+    Use --table for a Rich table.
+    Results are sorted by feedback.updated_at descending before the limit is applied.
+    --limit values above 500 are clamped to 500.
+    --since rejects ISO-8601 dates; use durations like '24h', '7d', '30m'.
+    """
+    # Validate --since before entering async context so Click surfaces a clean error.
+    cutoff_str: str | None = since
+    if since is not None:
+        try:
+            _parse_since(since)
+        except click.BadParameter as exc:
+            click.echo(f"Error: {exc.format_message()}", err=True)
+            sys.exit(1)
+
+    # Validate --status before entering async context.
+    if status is not None and status not in _VALID_STATUSES:
+        click.echo(
+            f"Error: invalid status {status!r}. Valid values: {', '.join(sorted(_VALID_STATUSES))}",
+            err=True,
+        )
+        sys.exit(1)
+
+    # Clamp --limit
+    effective_limit = min(limit, _LIMIT_MAX)
+
+    async def _run():
+        from redis_sre_agent.core.feedback import FeedbackView, list_feedback_views
+
+        try:
+            views: list[FeedbackView] = await list_feedback_views(
+                since=cutoff_str,
+                verdict=verdict,
+                status=status,
+                limit=effective_limit,
+            )
+        except Exception as exc:
+            log_cli_exception(__name__, "feedback list failed", exc)
+            click.echo(str(exc), err=True)
+            sys.exit(1)
+
+        if use_table:
+            _render_table(views)
+        else:
+            _render_jsonl(views)
+
+    asyncio.run(_run())
+
+
+def _truncate(text: str | None, max_len: int = 40) -> str:
+    """Truncate text to max_len chars, appending ellipsis if truncated."""
+    if not text:
+        return ""
+    if len(text) <= max_len:
+        return text
+    return text[:max_len] + "…"
+
+
+def _render_jsonl(views: list) -> None:
+    """Print one FeedbackView JSON object per line (no surrounding array)."""
+    for view in views:
+        print(json.dumps(view.model_dump(mode="json")))
+
+
+def _render_table(views: list) -> None:
+    """Render feedback views as a Rich table with six columns."""
+    from rich.console import Console
+    from rich.table import Table
+
+    console = Console(width=200)
+
+    if not views:
+        console.print("[yellow]No feedback records found.[/yellow]")
+        return
+
+    table = Table(title="Feedback Records", show_lines=False)
+    table.add_column("task_id", no_wrap=True)
+    table.add_column("status", no_wrap=True)
+    table.add_column("subject_preview")
+    table.add_column("verdict", no_wrap=True)
+    table.add_column("comment_preview")
+    table.add_column("updated_at", no_wrap=True)
+
+    _verdict_colors = {"up": "green", "down": "red", "withdrawn": "yellow"}
+
+    for view in views:
+        fb = view.feedback
+        task = view.task
+        color = _verdict_colors.get(fb.verdict, "white")
+        table.add_row(
+            fb.task_id,
+            task.status,
+            _truncate(task.subject),
+            f"[{color}]{fb.verdict}[/{color}]",
+            _truncate(fb.comment),
+            fb.updated_at,
+        )
+
+    console.print(table)

--- a/redis_sre_agent/cli/main.py
+++ b/redis_sre_agent/cli/main.py
@@ -32,6 +32,7 @@ _COMMANDS = {
     "knowledge-pack": "redis_sre_agent.cli.knowledge_pack:knowledge_pack",
     "support-package": "redis_sre_agent.cli.support_package:support_package",
     "eval": "redis_sre_agent.cli.eval:eval",
+    "feedback": "redis_sre_agent.cli.feedback:feedback",
 }
 
 # Built-in commands that don't need lazy loading

--- a/redis_sre_agent/core/cli_mcp_parity.py
+++ b/redis_sre_agent/core/cli_mcp_parity.py
@@ -17,6 +17,8 @@ EXCLUDED_CLI_COMMAND_PATHS = frozenset(
         "eval list",
         "eval live-suite",
         "eval run",
+        "feedback list",
+        "feedback show",
         "knowledge-pack build",
         "knowledge-pack inspect",
         "knowledge-pack load",
@@ -29,6 +31,9 @@ EXCLUDED_CLI_COMMAND_PATHS = frozenset(
 )
 
 CLI_TO_MCP_TOOL_NAMES = {
+    "feedback down": "redis_sre_submit_feedback",
+    "feedback up": "redis_sre_submit_feedback",
+    "feedback withdraw": "redis_sre_submit_feedback",
     "cache clear": "redis_sre_cache_clear",
     "cache stats": "redis_sre_cache_stats",
     "cluster backfill-instance-links": "redis_sre_backfill_instance_links",

--- a/redis_sre_agent/core/feedback.py
+++ b/redis_sre_agent/core/feedback.py
@@ -1,0 +1,664 @@
+"""Canonical feedback module — single source of truth for agent feedback.
+
+All feedback writes go through `submit_feedback()` in this module. HTTP, MCP,
+and CLI surfaces are thin wrappers. The Redis hash at
+`sre:feedback:task:{task_id}` is the source of truth; `created_at` is anchored
+with `HSETNX` to be race-immune across concurrent first writes.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, List, Literal, Optional
+
+from opentelemetry import trace
+from pydantic import BaseModel, Field
+from typing_extensions import Annotated
+
+from redis_sre_agent.core.approvals import PendingApprovalSummary
+from redis_sre_agent.core.keys import RedisKeys
+from redis_sre_agent.core.redis import get_redis_client
+from redis_sre_agent.observability.tracing import ATTR_CATEGORY, SpanCategory, get_tracer
+
+logger = logging.getLogger(__name__)
+tracer = get_tracer(__name__)
+
+# Stream update_type for feedback events (documented constant for reuse).
+FEEDBACK_SUBMITTED_UPDATE_TYPE = "feedback_submitted"
+
+# Comment length cap (chars). Enforced via Pydantic validation on input.
+COMMENT_MAX_LENGTH = 2048
+
+
+# ---------------------------------------------------------------------------
+# Exceptions
+# ---------------------------------------------------------------------------
+
+
+class FeedbackError(Exception):
+    """Base exception for feedback-related errors."""
+
+
+class TaskNotFoundError(FeedbackError):
+    """Raised when feedback is submitted for a task that does not exist."""
+
+
+# ---------------------------------------------------------------------------
+# Pydantic models (single source of truth for all surfaces).
+# ---------------------------------------------------------------------------
+
+
+class FeedbackRecord(BaseModel):
+    """A single feedback row materialized from the Redis hash."""
+
+    task_id: str
+    verdict: Literal["up", "down", "withdrawn"]
+    comment: Optional[str] = None
+    created_at: str
+    updated_at: str
+
+
+class FeedbackSubmitRequest(BaseModel):
+    """Request body for submitting feedback (HTTP / MCP / CLI shared shape)."""
+
+    verdict: Literal["up", "down", "withdrawn"]
+    comment: Optional[str] = Field(default=None, max_length=COMMENT_MAX_LENGTH)
+
+
+class ConversationMessage(BaseModel):
+    """A trimmed user/assistant message in a FeedbackView."""
+
+    role: Literal["user", "assistant"]
+    content: str
+
+
+class ToolCallSummary(BaseModel):
+    """Compact summary of a single assistant-level tool call (no raw outputs)."""
+
+    tool: str
+    args_summary: Annotated[str, Field(max_length=256)]
+
+
+class TaskInfo(BaseModel):
+    """Subset of task fields embedded in a FeedbackView.
+
+    Explicitly EXCLUDES `updates`, raw `tool_calls`, and `resume_supported`
+    per the Phase 2 joined-view spec.
+    """
+
+    task_id: str
+    thread_id: str
+    status: str
+    subject: Optional[str] = None
+    created_at: Optional[str] = None
+    updated_at: Optional[str] = None
+    error_message: Optional[str] = None
+    pending_approval: Optional[PendingApprovalSummary] = None
+    messages: List[ConversationMessage] = Field(default_factory=list)
+    tool_calls: List[ToolCallSummary] = Field(default_factory=list)
+
+
+class FeedbackView(BaseModel):
+    """Joined view of a feedback record + its associated task info."""
+
+    feedback: FeedbackRecord
+    task: TaskInfo
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _decode(value: Any) -> Any:
+    """Decode bytes from Redis to str; pass through other types."""
+    if isinstance(value, bytes):
+        return value.decode("utf-8")
+    return value
+
+
+def hash_to_dict(raw: Any) -> Dict[str, str]:
+    """Normalize an HGETALL response (possibly bytes-keyed) into a str/str dict."""
+    if not raw:
+        return {}
+    out: Dict[str, str] = {}
+    if isinstance(raw, dict):
+        for k, v in raw.items():
+            out[_decode(k)] = _decode(v)
+    return out
+
+
+def _record_from_hash(task_id: str, raw: Any) -> Optional[FeedbackRecord]:
+    """Build a FeedbackRecord from an HGETALL hash, or None if empty."""
+    data = hash_to_dict(raw)
+    if not data or "verdict" not in data:
+        return None
+    # Comment is stored as "" when absent — surface as None to match request shape.
+    comment_value: Optional[str] = data.get("comment") or None
+    return FeedbackRecord(
+        task_id=data.get("task_id", task_id),
+        verdict=data["verdict"],  # type: ignore[arg-type]
+        comment=comment_value,
+        created_at=data.get("created_at", ""),
+        updated_at=data.get("updated_at", ""),
+    )
+
+
+async def _resolve_thread_id(redis_client: Any, task_id: str) -> Optional[str]:
+    """Look up the task's thread_id, returning None when missing or malformed."""
+    try:
+        raw = await redis_client.hget(RedisKeys.task_metadata(task_id), "thread_id")
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.warning("feedback: failed reading thread_id for task=%s: %s", task_id, exc)
+        return None
+    thread_id = _decode(raw) if raw is not None else None
+    if not thread_id or not isinstance(thread_id, str):
+        logger.warning(
+            "feedback: thread_id missing or malformed for task=%s; "
+            "feedback hash will still be written, stream publish skipped",
+            task_id,
+        )
+        return None
+    return thread_id
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+async def submit_feedback(
+    task_id: str,
+    verdict: str,
+    comment: Optional[str] = None,
+) -> FeedbackRecord:
+    """Submit / update / withdraw feedback for a task.
+
+    - Validates `verdict` and `comment` via :class:`FeedbackSubmitRequest`
+      (pydantic ValidationError propagates so FastAPI maps it to 422).
+    - Raises :class:`TaskNotFoundError` when the task itself is absent.
+    - When the task exists but `thread_id` is missing/malformed, the feedback
+      hash is still written; the stream publish is skipped with a logged
+      warning (fail-open per plan §AC-5).
+    - `created_at` is anchored by `HSETNX` — concurrent first-writers all
+      observe the same value (plan §AC-7).
+    - Idempotent: identical resubmissions short-circuit and return the
+      existing record without rewriting or republishing.
+    - After a successful pipeline commit, publishes a stream event
+      (`feedback_submitted`) carrying `{task_id, verdict, has_comment}`.
+      Publish failures emit an OTel span event and a warning log; they do
+      NOT raise (the write is authoritative — plan §AC-13, Risk #10).
+    """
+    # Validate input (raises pydantic.ValidationError → FastAPI 422 on the HTTP path).
+    request = FeedbackSubmitRequest(verdict=verdict, comment=comment)
+    verdict_str = request.verdict
+    comment_str = request.comment
+
+    with tracer.start_as_current_span(
+        "feedback.submit",
+        attributes={
+            "task_id": task_id,
+            "verdict": verdict_str,
+            "comment_length": len(comment_str or ""),
+            ATTR_CATEGORY: SpanCategory.FEEDBACK.value,
+        },
+    ) as span:
+        redis_client = get_redis_client()
+
+        # 1. Verify the task exists. Missing task → 404 (TaskNotFoundError).
+        status_raw = await redis_client.get(RedisKeys.task_status(task_id))
+        if status_raw is None:
+            raise TaskNotFoundError(f"Task {task_id} not found")
+
+        # 2. Resolve thread_id (fail-open if missing/malformed — see AC-5).
+        thread_id = await _resolve_thread_id(redis_client, task_id)
+
+        key = RedisKeys.feedback_task(task_id)
+        now = datetime.now(timezone.utc).isoformat()
+
+        # 3. Idempotency short-circuit — identical resubmit returns existing
+        #    record without rewriting `updated_at` or republishing the event.
+        existing_raw = await redis_client.hgetall(key)
+        existing_record = _record_from_hash(task_id, existing_raw)
+        if existing_record is not None:
+            same_verdict = existing_record.verdict == verdict_str
+            same_comment = (existing_record.comment or "") == (comment_str or "")
+            if same_verdict and same_comment:
+                span.set_attribute("feedback.idempotent_short_circuit", True)
+                return existing_record
+
+        # 4. Atomic write — HSETNX anchors created_at; HSET overwrites mutables.
+        pipe = redis_client.pipeline(transaction=False)
+        pipe.hsetnx(key, "created_at", now)
+        pipe.hset(
+            key,
+            mapping={
+                "task_id": task_id,
+                "verdict": verdict_str,
+                "comment": comment_str or "",
+                "updated_at": now,
+            },
+        )
+        pipe.hgetall(key)
+        results = await pipe.execute()
+
+        final_raw = results[-1]
+        final_record = _record_from_hash(task_id, final_raw)
+        if final_record is None:
+            # Defensive: shouldn't happen since we just wrote the row.
+            raise FeedbackError(f"Feedback hash unexpectedly empty after write for task {task_id}")
+
+        # 5. Publish stream event AFTER successful commit. Failures are
+        #    observable (span event + warning log) but never raise.
+        if thread_id:
+            try:
+                # Deferred import to avoid api → core layering cycle
+                # (mirrors core/tasks.py:148 precedent).
+                from redis_sre_agent.api.websockets import get_stream_manager
+
+                stream_manager = await get_stream_manager()
+                await stream_manager.publish_task_update(
+                    thread_id=thread_id,
+                    update_type=FEEDBACK_SUBMITTED_UPDATE_TYPE,
+                    data={
+                        "task_id": task_id,
+                        "verdict": verdict_str,
+                        "has_comment": bool(comment_str),
+                    },
+                )
+            except Exception as exc:  # noqa: BLE001 — publish failure is non-fatal
+                current_span = trace.get_current_span()
+                if current_span is not None:
+                    current_span.add_event(
+                        "feedback.stream_publish_failed",
+                        attributes={"task_id": task_id, "error": str(exc)},
+                    )
+                logger.warning("feedback.stream_publish_failed task_id=%s error=%s", task_id, exc)
+
+        return final_record
+
+
+async def get_feedback(task_id: str) -> Optional[FeedbackRecord]:
+    """Return the current feedback record for a task, or None if absent.
+
+    The Redis client is obtained internally via :func:`get_redis_client` —
+    callers MUST NOT supply one (matches the established pattern at
+    `api/tasks.py:127,134,146`).
+    """
+    # TODO(perf): pipelined batch fetch for future list endpoints (N+1 risk).
+    redis_client = get_redis_client()
+    raw = await redis_client.hgetall(RedisKeys.feedback_task(task_id))
+    return _record_from_hash(task_id, raw)
+
+
+# ---------------------------------------------------------------------------
+# Joined-view (FeedbackView) helpers — Phase 2 read paths.
+# ---------------------------------------------------------------------------
+
+
+# Allowed `since` window pattern — shared by HTTP/CLI/MCP filter validation.
+SINCE_PATTERN = re.compile(r"^(\d+)([smhd])$")
+
+
+def _trim_task_messages(result: Optional[Dict[str, Any]]) -> List[ConversationMessage]:
+    """Return only user/assistant text messages from a task result.
+
+    Tool envelopes, system messages, and per-message metadata are dropped. Raw
+    `tool_calls` payloads on assistant messages are surfaced via the separate
+    :func:`_compact_tool_calls` helper.
+    """
+    if not isinstance(result, dict):
+        return []
+    raw_messages = result.get("messages")
+    if not isinstance(raw_messages, list):
+        return []
+
+    trimmed: List[ConversationMessage] = []
+    for entry in raw_messages:
+        if not isinstance(entry, dict):
+            continue
+        role = entry.get("role")
+        if role not in ("user", "assistant"):
+            continue
+        content = entry.get("content")
+        if not isinstance(content, str) or not content:
+            continue
+        trimmed.append(ConversationMessage(role=role, content=content))
+    return trimmed
+
+
+def _compact_tool_calls(result: Optional[Dict[str, Any]]) -> List[ToolCallSummary]:
+    """Walk a task result and return a compact list of (tool, args_summary).
+
+    Looks at both inline assistant-message `tool_calls` metadata entries and the
+    top-level `tool_envelopes` list (the canonical agent shape). Raw outputs
+    are never included; `args_summary` is `json.dumps(...)`-encoded and clipped
+    to 256 chars.
+    """
+    if not isinstance(result, dict):
+        return []
+
+    out: List[ToolCallSummary] = []
+
+    def _summarize_args(args: Any) -> str:
+        if args is None:
+            return ""
+        try:
+            text = args if isinstance(args, str) else json.dumps(args, default=str, sort_keys=True)
+        except Exception:  # noqa: BLE001 — defensive against odd payloads
+            text = str(args)
+        return text[:256]
+
+    # 1) Inline assistant-message tool_calls metadata entries (LangChain-style
+    #    AIMessage envelopes carried through the agent's conversation_state).
+    raw_messages = result.get("messages")
+    if isinstance(raw_messages, list):
+        for entry in raw_messages:
+            if not isinstance(entry, dict) or entry.get("role") != "assistant":
+                continue
+            # `tool_calls` may live directly on the entry or inside `metadata`.
+            candidates: List[Any] = []
+            direct = entry.get("tool_calls")
+            if isinstance(direct, list):
+                candidates.extend(direct)
+            metadata = entry.get("metadata")
+            if isinstance(metadata, dict):
+                inner = metadata.get("tool_calls")
+                if isinstance(inner, list):
+                    candidates.extend(inner)
+            for call in candidates:
+                if not isinstance(call, dict):
+                    continue
+                tool_name = call.get("name") or call.get("tool") or call.get("function") or ""
+                if not isinstance(tool_name, str) or not tool_name:
+                    continue
+                args = call.get("args")
+                if args is None:
+                    args = call.get("arguments")
+                out.append(ToolCallSummary(tool=tool_name, args_summary=_summarize_args(args)))
+
+    # 2) Top-level `tool_envelopes` list (the canonical agent shape — see
+    #    docket_tasks.py:2100). Envelopes carry `tool_name` and `tool_args`.
+    envelopes = result.get("tool_envelopes")
+    if isinstance(envelopes, list):
+        for env in envelopes:
+            if not isinstance(env, dict):
+                continue
+            tool_name = env.get("tool_name") or env.get("name") or env.get("tool") or ""
+            if not isinstance(tool_name, str) or not tool_name:
+                continue
+            args = env.get("tool_args")
+            if args is None:
+                args = env.get("args")
+            out.append(ToolCallSummary(tool=tool_name, args_summary=_summarize_args(args)))
+
+    return out
+
+
+async def _fetch_task_info(redis_client: Any, task_id: str) -> Optional[TaskInfo]:
+    """Pipelined fetch of a single task's metadata/status/result into a TaskInfo.
+
+    Returns None when the task does not exist (status key missing).
+    """
+    pipe = redis_client.pipeline(transaction=False)
+    pipe.get(RedisKeys.task_status(task_id))
+    pipe.hgetall(RedisKeys.task_metadata(task_id))
+    pipe.get(RedisKeys.task_result(task_id))
+    pipe.get(RedisKeys.task_error(task_id))
+    results = await pipe.execute()
+    return _build_task_info(task_id, *results)
+
+
+def _build_task_info(
+    task_id: str,
+    status_raw: Any,
+    metadata_raw: Any,
+    result_raw: Any,
+    error_raw: Any,
+) -> Optional[TaskInfo]:
+    """Assemble a TaskInfo from the four canonical task keys.
+
+    Returns None when the task's status key is missing.
+    """
+    status_val = _decode(status_raw) if status_raw is not None else None
+    if not status_val:
+        return None
+
+    md = hash_to_dict(metadata_raw)
+    thread_id = md.get("thread_id") or ""
+    subject = md.get("subject") or None
+    created_at = md.get("created_at") or None
+    updated_at = md.get("updated_at") or None
+
+    pending_approval: Optional[PendingApprovalSummary] = None
+    pending_raw = md.get("pending_approval")
+    if pending_raw:
+        try:
+            pending_approval = PendingApprovalSummary(**json.loads(pending_raw))
+        except Exception:  # noqa: BLE001 — match TaskManager.get_task_state behavior
+            pending_approval = None
+
+    error_message: Optional[str] = None
+    decoded_error = _decode(error_raw) if error_raw is not None else None
+    if decoded_error:
+        error_message = decoded_error
+
+    result_dict: Optional[Dict[str, Any]] = None
+    decoded_result = _decode(result_raw) if result_raw is not None else None
+    if decoded_result:
+        try:
+            parsed = json.loads(decoded_result)
+            if isinstance(parsed, dict):
+                result_dict = parsed
+        except Exception:  # noqa: BLE001 — corrupt result blobs shouldn't break reads
+            result_dict = None
+
+    return TaskInfo(
+        task_id=task_id,
+        thread_id=thread_id,
+        status=status_val,
+        subject=subject,
+        created_at=created_at,
+        updated_at=updated_at,
+        error_message=error_message,
+        pending_approval=pending_approval,
+        messages=_trim_task_messages(result_dict),
+        tool_calls=_compact_tool_calls(result_dict),
+    )
+
+
+def _parse_since(since: Optional[str]) -> Optional[datetime]:
+    """Parse a `since` window string like '24h' into a UTC datetime cutoff.
+
+    Returns None when `since` is None. Raises ValueError when the string does
+    not match `^(\\d+)([smhd])$` — callers translate to 422 / non-zero exit.
+    """
+    if since is None:
+        return None
+    m = SINCE_PATTERN.match(since)
+    if not m:
+        raise ValueError(f"Invalid `since` value: {since!r}; expected ^(\\d+)([smhd])$")
+    value = int(m.group(1))
+    unit = m.group(2)
+    seconds = {"s": 1, "m": 60, "h": 3600, "d": 86400}[unit]
+    return datetime.now(timezone.utc) - timedelta(seconds=value * seconds)
+
+
+def _filter_feedback_views(
+    views: List[FeedbackView],
+    *,
+    since: Optional[str] = None,
+    verdict: Optional[str] = None,
+    status: Optional[str] = None,
+    limit: int = 50,
+) -> List[FeedbackView]:
+    """Apply AND-semantics filters to a list of joined views, sort, and slice.
+
+    All three surfaces (HTTP list, CLI list, MCP list_feedback) route through
+    this helper for drift protection (plan §AC-2 / spec §Technical Context).
+    """
+    cutoff = _parse_since(since)
+
+    filtered: List[FeedbackView] = []
+    for view in views:
+        if verdict is not None and view.feedback.verdict != verdict:
+            continue
+        if status is not None and view.task.status != status:
+            continue
+        if cutoff is not None:
+            try:
+                ts = datetime.fromisoformat(view.feedback.updated_at.replace("Z", "+00:00"))
+            except Exception:  # noqa: BLE001 — malformed timestamp → skip
+                continue
+            if ts < cutoff:
+                continue
+        filtered.append(view)
+
+    filtered.sort(key=lambda v: v.feedback.updated_at, reverse=True)
+
+    effective_limit = min(max(int(limit), 0), 500)
+    return filtered[:effective_limit]
+
+
+async def get_feedback_view(task_id: str) -> Optional[FeedbackView]:
+    """Return the joined FeedbackView for a task.
+
+    - Returns None when the task exists but has no feedback record.
+    - Raises :class:`TaskNotFoundError` when the task itself does not exist.
+
+    Wrapped in an OTel span ``feedback.get`` carrying ``task_id``.
+    """
+    with tracer.start_as_current_span(
+        "feedback.get",
+        attributes={
+            "task_id": task_id,
+            ATTR_CATEGORY: SpanCategory.FEEDBACK.value,
+        },
+    ):
+        redis_client = get_redis_client()
+
+        # Single pipelined read of the four task keys (status + md + result + error).
+        task_info = await _fetch_task_info(redis_client, task_id)
+        if task_info is None:
+            raise TaskNotFoundError(f"Task {task_id} not found")
+
+        feedback_raw = await redis_client.hgetall(RedisKeys.feedback_task(task_id))
+        record = _record_from_hash(task_id, feedback_raw)
+        if record is None:
+            return None
+
+        return FeedbackView(feedback=record, task=task_info)
+
+
+async def list_feedback_views(
+    *,
+    since: Optional[str] = None,
+    verdict: Optional[str] = None,
+    status: Optional[str] = None,
+    limit: int = 50,
+) -> List[FeedbackView]:
+    """Return joined FeedbackView rows matching the given filters.
+
+    - Uses ``SCAN`` over ``sre:feedback:task:*`` (never ``KEYS``).
+    - Batches task metadata / status / result / error fetches in a single
+      Redis pipeline (no N+1 sequential round-trips).
+    - Sorts by ``feedback.updated_at`` desc in-process.
+    - Clamps ``limit`` to the inclusive [0, 500] range.
+
+    Wrapped in an OTel span ``feedback.list`` carrying ``verdict_filter``,
+    ``status_filter``, ``since_filter``, and ``result_count``.
+    """
+    # Validate `since` up-front so the span carries the rejected value.
+    _parse_since(since)  # raises ValueError on malformed input
+
+    with tracer.start_as_current_span(
+        "feedback.list",
+        attributes={
+            "verdict_filter": verdict or "",
+            "status_filter": status or "",
+            "since_filter": since or "",
+            ATTR_CATEGORY: SpanCategory.FEEDBACK.value,
+        },
+    ) as span:
+        redis_client = get_redis_client()
+
+        # 1. Discover feedback keys via SCAN (NOT KEYS).
+        feedback_keys: List[str] = []
+        async for key in redis_client.scan_iter(match="sre:feedback:task:*"):
+            feedback_keys.append(_decode(key))
+
+        if not feedback_keys:
+            span.set_attribute("result_count", 0)
+            return []
+
+        # 2. Pipelined fetch of every feedback hash.
+        feedback_pipe = redis_client.pipeline(transaction=False)
+        for key in feedback_keys:
+            feedback_pipe.hgetall(key)
+        feedback_raws = await feedback_pipe.execute()
+
+        # 3. Parse feedback records, collect (record, task_id) pairs.
+        pairs: List[tuple[FeedbackRecord, str]] = []
+        for key, raw in zip(feedback_keys, feedback_raws):
+            # key is "sre:feedback:task:{task_id}"
+            task_id = key.rsplit(":", 1)[-1]
+            record = _record_from_hash(task_id, raw)
+            if record is None:
+                continue
+            pairs.append((record, task_id))
+
+        if not pairs:
+            span.set_attribute("result_count", 0)
+            return []
+
+        # 4. Pipelined batch read of all task keys (status, metadata, result, error)
+        #    so we never do N sequential round-trips.
+        task_pipe = redis_client.pipeline(transaction=False)
+        for _, task_id in pairs:
+            task_pipe.get(RedisKeys.task_status(task_id))
+            task_pipe.hgetall(RedisKeys.task_metadata(task_id))
+            task_pipe.get(RedisKeys.task_result(task_id))
+            task_pipe.get(RedisKeys.task_error(task_id))
+        task_raws = await task_pipe.execute()
+
+        # 5. Assemble joined views.
+        views: List[FeedbackView] = []
+        for idx, (record, task_id) in enumerate(pairs):
+            base = idx * 4
+            status_raw = task_raws[base]
+            metadata_raw = task_raws[base + 1]
+            result_raw = task_raws[base + 2]
+            error_raw = task_raws[base + 3]
+            task_info = _build_task_info(task_id, status_raw, metadata_raw, result_raw, error_raw)
+            if task_info is None:
+                # Feedback row references a task that no longer exists — skip.
+                continue
+            views.append(FeedbackView(feedback=record, task=task_info))
+
+        # 6. Apply filters + sort + slice via the shared helper.
+        result = _filter_feedback_views(
+            views, since=since, verdict=verdict, status=status, limit=limit
+        )
+        span.set_attribute("result_count", len(result))
+        return result
+
+
+__all__ = [
+    "COMMENT_MAX_LENGTH",
+    "FEEDBACK_SUBMITTED_UPDATE_TYPE",
+    "ConversationMessage",
+    "FeedbackError",
+    "FeedbackRecord",
+    "FeedbackSubmitRequest",
+    "FeedbackView",
+    "TaskInfo",
+    "TaskNotFoundError",
+    "ToolCallSummary",
+    "get_feedback",
+    "get_feedback_view",
+    "list_feedback_views",
+    "submit_feedback",
+]

--- a/redis_sre_agent/core/keys.py
+++ b/redis_sre_agent/core/keys.py
@@ -148,6 +148,11 @@ class RedisKeys:
         return f"sre:task:{task_id}:resume_state"
 
     @staticmethod
+    def feedback_task(task_id: str) -> str:
+        """Key for agent feedback associated with a task."""
+        return f"sre:feedback:task:{task_id}"
+
+    @staticmethod
     def approval(approval_id: str) -> str:
         """Key for a serialized approval record."""
         return f"sre:approval:{approval_id}"

--- a/redis_sre_agent/mcp_server/server.py
+++ b/redis_sre_agent/mcp_server/server.py
@@ -3089,6 +3089,92 @@ async def redis_sre_delete_instance(instance_id: str, confirm: bool = False) -> 
         }
 
 
+@mcp.tool()
+async def redis_sre_submit_feedback(
+    task_id: str,
+    verdict: str,
+    comment: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Submit, update, or withdraw feedback for a completed task.
+
+    Records a thumbs-up / thumbs-down / withdrawal against a task so the
+    SRE team can track agent quality over time.
+
+    Args:
+        task_id: The task ID returned by redis_sre_deep_triage / redis_sre_general_chat
+        verdict: One of "up", "down", or "withdrawn"
+        comment: Optional free-text explanation (max 2048 chars)
+
+    Returns:
+        FeedbackRecord dict with task_id, verdict, comment, created_at, updated_at
+
+    Raises:
+        pydantic.ValidationError: verdict is not one of "up"/"down"/"withdrawn",
+            or comment exceeds 2048 chars.
+        TaskNotFoundError: the task_id does not exist in Redis.
+
+    Note: Unlike redis_sre_general_chat and redis_sre_deep_triage, this tool
+    deliberately does NOT catch exceptions into success-shaped error dicts
+    ({"error": ..., "status": "failed"}). Validation errors and TaskNotFoundError
+    are meaningful signals that MCP callers should handle — swallowing them would
+    hide misuse (wrong verdict value, stale task_id) behind a silent "failed" dict.
+    """
+    # Deferred import — avoids potential import cycles (matches pattern at server.py:338+).
+    from redis_sre_agent.core.feedback import submit_feedback
+
+    record = await submit_feedback(task_id, verdict, comment)
+    return record.model_dump(mode="json")
+
+
+@mcp.tool()
+async def redis_sre_get_feedback(task_id: str) -> Optional[Dict[str, Any]]:
+    """Fetch the joined feedback view for a single task.
+
+    Returns the FeedbackView dict (feedback + task) when feedback exists for the task,
+    or null when the task is known but has not been rated yet.
+    Raises TaskNotFoundError (propagated as a native MCP error) when the task itself does not exist.
+
+    Note: Like redis_sre_submit_feedback (and unlike redis_sre_general_chat), this tool
+    deliberately does NOT catch exceptions into success-shaped error dicts
+    ({"error": ..., "status": "failed"}). TaskNotFoundError is a meaningful signal
+    that MCP callers should handle.
+    """
+    # Deferred import — avoids potential import cycles (matches pattern at server.py:338+).
+    from redis_sre_agent.core.feedback import get_feedback_view
+
+    view = await get_feedback_view(task_id)
+    return view.model_dump(mode="json") if view is not None else None
+
+
+@mcp.tool()
+async def redis_sre_list_feedback(
+    since: Optional[str] = None,
+    verdict: Optional[str] = None,
+    status: Optional[str] = None,
+    limit: int = 50,
+) -> Dict[str, Any]:
+    """List feedback views with optional filters.
+
+    Filters apply AND-semantics; results are sorted by feedback.updated_at descending and clamped to a max of 500.
+    Validation errors propagate as MCP-native errors (e.g. invalid `since` format or unknown `verdict`/`status`).
+
+    Returns: {"items": [<FeedbackView dict>, ...], "count": int}
+
+    Note: Like redis_sre_submit_feedback (and unlike redis_sre_general_chat), this tool
+    deliberately does NOT catch exceptions into success-shaped error dicts
+    ({"error": ..., "status": "failed"}). Validation errors are meaningful signals
+    that MCP callers should handle.
+    """
+    # Deferred import — avoids potential import cycles (matches pattern at server.py:338+).
+    from redis_sre_agent.core.feedback import list_feedback_views
+
+    views = await list_feedback_views(since=since, verdict=verdict, status=status, limit=limit)
+    return {
+        "items": [v.model_dump(mode="json") for v in views],
+        "count": len(views),
+    }
+
+
 # ============================================================================
 # Server runners
 # ============================================================================

--- a/redis_sre_agent/observability/tracing.py
+++ b/redis_sre_agent/observability/tracing.py
@@ -46,6 +46,7 @@ class SpanCategory(str, Enum):
     KNOWLEDGE = "knowledge"
     HTTP = "http"
     REDIS = "redis"  # Infrastructure - can be filtered out
+    FEEDBACK = "feedback"
 
 
 # Attribute keys

--- a/tests/api/test_feedback_route.py
+++ b/tests/api/test_feedback_route.py
@@ -1,0 +1,527 @@
+"""Integration tests for the feedback HTTP API layer (US-003, US-004, US-006).
+
+Tests exercise real Redis (docker-compose port 7843) via the FastAPI TestClient.
+Each test is skipped if Redis is unreachable — mirrors the pattern in
+tests/unit/core/test_feedback.py.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import AsyncIterator
+from unittest.mock import AsyncMock, patch
+
+import pytest
+import pytest_asyncio
+from fastapi.testclient import TestClient
+
+from redis_sre_agent.api.app import app
+from redis_sre_agent.core.keys import RedisKeys
+from redis_sre_agent.core.redis import get_redis_client
+
+# ---------------------------------------------------------------------------
+# Shared client fixture
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def client():
+    """TestClient for the full FastAPI app (lifespan bypassed by TestClient)."""
+    return TestClient(app)
+
+
+# ---------------------------------------------------------------------------
+# Redis availability + task factory
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def redis_client() -> AsyncIterator:
+    """Real Redis client; skip test if Redis is unreachable."""
+    rc = get_redis_client()
+    try:
+        await rc.ping()
+    except Exception as exc:
+        pytest.skip(f"Redis unavailable: {exc}")
+    try:
+        yield rc
+    finally:
+        await rc.aclose()
+
+
+@pytest_asyncio.fixture
+async def task_factory(redis_client):
+    """Create a minimal task in Redis so feedback endpoints accept the task_id."""
+    created: list[str] = []
+
+    async def _make(*, thread_id: str | None = "thr-test") -> str:
+        task_id = f"tsk-{uuid.uuid4().hex[:12]}"
+        await redis_client.set(RedisKeys.task_status(task_id), "done")
+        mapping: dict = {"created_at": "2026-01-01T00:00:00+00:00"}
+        if thread_id is not None:
+            mapping["thread_id"] = thread_id
+        await redis_client.hset(RedisKeys.task_metadata(task_id), mapping=mapping)
+        created.append(task_id)
+        return task_id
+
+    yield _make
+
+    for task_id in created:
+        await redis_client.delete(
+            RedisKeys.task_status(task_id),
+            RedisKeys.task_metadata(task_id),
+            RedisKeys.feedback_task(task_id),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Mute stream publish for all tests in this module
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def _mute_stream():
+    mock_manager = AsyncMock()
+    mock_manager.publish_task_update = AsyncMock(return_value=True)
+
+    async def _get_manager():
+        return mock_manager
+
+    with patch("redis_sre_agent.api.websockets.get_stream_manager", side_effect=_get_manager):
+        yield mock_manager
+
+
+# ---------------------------------------------------------------------------
+# US-003 / AC-POST — POST up and down verdicts
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_post_up_and_down(client, task_factory):
+    """POST up then down; both return 200 with valid FeedbackRecord."""
+    task_id = await task_factory()
+
+    resp = client.post(f"/api/v1/tasks/{task_id}/feedback", json={"verdict": "up"})
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["task_id"] == task_id
+    assert data["verdict"] == "up"
+    assert data["comment"] is None
+    assert data["created_at"]
+    assert data["updated_at"]
+
+    resp2 = client.post(
+        f"/api/v1/tasks/{task_id}/feedback", json={"verdict": "down", "comment": "foo"}
+    )
+    assert resp2.status_code == 200, resp2.text
+    data2 = resp2.json()
+    assert data2["verdict"] == "down"
+    assert data2["comment"] == "foo"
+    # created_at must be anchored from the first write
+    assert data2["created_at"] == data["created_at"]
+
+
+# ---------------------------------------------------------------------------
+# US-004 / AC-GET — GET existing and missing feedback
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_existing_and_missing(client, task_factory):
+    """GET returns 200 after POST; GET 404 for task with no feedback."""
+    task_id = await task_factory()
+
+    # POST first
+    client.post(f"/api/v1/tasks/{task_id}/feedback", json={"verdict": "up"})
+
+    # GET should return the joined FeedbackView
+    resp = client.get(f"/api/v1/tasks/{task_id}/feedback")
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["feedback"]["verdict"] == "up"
+
+    # A different task with no feedback → 404
+    task_id_no_fb = await task_factory()
+    resp_miss = client.get(f"/api/v1/tasks/{task_id_no_fb}/feedback")
+    assert resp_miss.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# US-003 / AC-5 — POST to unknown task → 404, nothing written
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_unknown_task_returns_404(client, redis_client):
+    """POST feedback for a non-existent task returns 404; hash not written."""
+    bogus_id = f"tsk-ghost-{uuid.uuid4().hex[:8]}"
+    await redis_client.delete(RedisKeys.task_status(bogus_id))
+
+    resp = client.post(f"/api/v1/tasks/{bogus_id}/feedback", json={"verdict": "up"})
+    assert resp.status_code == 404, resp.text
+
+    exists = await redis_client.hexists(RedisKeys.feedback_task(bogus_id), "verdict")
+    assert exists == 0
+
+
+# ---------------------------------------------------------------------------
+# US-003 / AC-validation — comment too long → 422
+# ---------------------------------------------------------------------------
+
+
+def test_validation_errors_comment_too_long(client):
+    """POST with 2049-char comment returns 422 with string_too_long detail."""
+    resp = client.post(
+        "/api/v1/tasks/any-task-id/feedback",
+        json={"verdict": "up", "comment": "x" * 2049},
+    )
+    assert resp.status_code == 422, resp.text
+    detail = resp.json()["detail"]
+    assert isinstance(detail, list) and len(detail) > 0
+    first = detail[0]
+    assert first["type"] == "string_too_long"
+    assert first["loc"][-1] == "comment"
+
+
+# ---------------------------------------------------------------------------
+# US-003 / AC-validation — invalid verdict → 422
+# ---------------------------------------------------------------------------
+
+
+def test_validation_errors_invalid_verdict(client):
+    """POST with verdict='maybe' returns 422 with literal_error detail."""
+    resp = client.post(
+        "/api/v1/tasks/any-task-id/feedback",
+        json={"verdict": "maybe"},
+    )
+    assert resp.status_code == 422, resp.text
+    detail = resp.json()["detail"]
+    assert isinstance(detail, list) and len(detail) > 0
+    first = detail[0]
+    assert first["type"] == "literal_error"
+    assert first["loc"][-1] == "verdict"
+
+
+# ---------------------------------------------------------------------------
+# US-006 — GET /tasks/{task_id} includes feedback field
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_taskresponse_includes_feedback(client, task_factory):
+    """GET /api/v1/tasks/{task_id} response includes feedback after POST."""
+    task_id = await task_factory()
+
+    # POST feedback
+    post_resp = client.post(
+        f"/api/v1/tasks/{task_id}/feedback", json={"verdict": "down", "comment": "needs work"}
+    )
+    assert post_resp.status_code == 200
+
+    # GET task — must include feedback
+    # Patch TaskManager so the task-state lookup succeeds without a full task scaffold
+    from unittest.mock import MagicMock
+
+    class FakeMeta:
+        subject = "Test"
+        created_at = "2026-01-01T00:00:00+00:00"
+        updated_at = "2026-01-01T00:00:00+00:00"
+
+    fake_state = MagicMock()
+    fake_state.task_id = task_id
+    fake_state.thread_id = "thr-test"
+    fake_state.status = "done"
+    fake_state.updates = []
+    fake_state.result = None
+    fake_state.error_message = None
+    fake_state.metadata = FakeMeta()
+    fake_state.pending_approval = None
+    fake_state.resume_supported = False
+
+    mock_tm = MagicMock()
+    mock_tm.get_task_state = AsyncMock(return_value=fake_state)
+    mock_tm.get_task_tool_calls = AsyncMock(return_value=None)
+
+    with patch("redis_sre_agent.api.tasks.TaskManager", return_value=mock_tm):
+        resp = client.get(f"/api/v1/tasks/{task_id}")
+
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["feedback"] is not None
+    assert data["feedback"]["verdict"] == "down"
+    assert data["feedback"]["comment"] == "needs work"
+    assert data["feedback"]["task_id"] == task_id
+
+
+# ---------------------------------------------------------------------------
+# US-003 / US-004 — GET returns FeedbackView (joined shape)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_returns_feedback_view(client, task_factory):
+    """GET /tasks/{task_id}/feedback returns FeedbackView with feedback + task keys."""
+    task_id = await task_factory()
+
+    client.post(f"/api/v1/tasks/{task_id}/feedback", json={"verdict": "up", "comment": "nice"})
+
+    resp = client.get(f"/api/v1/tasks/{task_id}/feedback")
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+
+    # Top-level keys
+    assert "feedback" in data, "response must have 'feedback' key"
+    assert "task" in data, "response must have 'task' key"
+
+    fb = data["feedback"]
+    assert fb["verdict"] == "up"
+    assert fb["comment"] == "nice"
+    assert fb["task_id"] == task_id
+    assert fb["created_at"]
+    assert fb["updated_at"]
+
+    task = data["task"]
+    assert task["task_id"] == task_id
+    assert task["thread_id"] == "thr-test"
+    assert task["status"] == "done"
+    assert "messages" in task
+    assert "tool_calls" in task
+
+
+# ---------------------------------------------------------------------------
+# AC-17 — GET /tasks/{task_id} feedback field stays bare FeedbackRecord
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_taskresponse_feedback_field_is_bare_record(client, task_factory):
+    """GET /api/v1/tasks/{task_id} feedback field is bare FeedbackRecord, not nested FeedbackView."""
+    task_id = await task_factory()
+
+    client.post(
+        f"/api/v1/tasks/{task_id}/feedback", json={"verdict": "down", "comment": "needs work"}
+    )
+
+    from unittest.mock import MagicMock
+
+    class FakeMeta:
+        subject = "Test"
+        created_at = "2026-01-01T00:00:00+00:00"
+        updated_at = "2026-01-01T00:00:00+00:00"
+
+    fake_state = MagicMock()
+    fake_state.task_id = task_id
+    fake_state.thread_id = "thr-test"
+    fake_state.status = "done"
+    fake_state.updates = []
+    fake_state.result = None
+    fake_state.error_message = None
+    fake_state.metadata = FakeMeta()
+    fake_state.pending_approval = None
+    fake_state.resume_supported = False
+
+    mock_tm = MagicMock()
+    mock_tm.get_task_state = AsyncMock(return_value=fake_state)
+    mock_tm.get_task_tool_calls = AsyncMock(return_value=None)
+
+    with patch("redis_sre_agent.api.tasks.TaskManager", return_value=mock_tm):
+        resp = client.get(f"/api/v1/tasks/{task_id}")
+
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    fb = data["feedback"]
+    assert fb is not None
+
+    # Must be bare record: top-level verdict/comment/task_id keys
+    assert fb["verdict"] == "down"
+    assert fb["comment"] == "needs work"
+    assert fb["task_id"] == task_id
+
+    # Must NOT be a nested FeedbackView shape
+    assert "feedback" not in fb, "feedback field must be bare record, not nested FeedbackView"
+    assert "task" not in fb, "feedback field must be bare record, not nested FeedbackView"
+
+
+# ---------------------------------------------------------------------------
+# US-004 — GET /api/v1/feedback (list)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_returns_feedback_views(client, task_factory):
+    """GET /api/v1/feedback returns items list and count."""
+    task_id_1 = await task_factory()
+    task_id_2 = await task_factory()
+    client.post(f"/api/v1/tasks/{task_id_1}/feedback", json={"verdict": "up"})
+    client.post(f"/api/v1/tasks/{task_id_2}/feedback", json={"verdict": "down"})
+
+    resp = client.get("/api/v1/feedback")
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert "items" in data
+    assert "count" in data
+
+    # Both tasks should appear (may be more from other tests; check >= 2)
+    our_ids = {task_id_1, task_id_2}
+    returned_ids = {item["feedback"]["task_id"] for item in data["items"]}
+    assert our_ids.issubset(returned_ids), f"Expected {our_ids} in {returned_ids}"
+
+    # Each item has the joined shape
+    for item in data["items"]:
+        assert "feedback" in item
+        assert "task" in item
+
+
+@pytest.mark.asyncio
+async def test_list_filter_verdict(client, task_factory):
+    """GET /api/v1/feedback?verdict=down returns only down-verdict items."""
+    task_up = await task_factory()
+    task_down = await task_factory()
+    client.post(f"/api/v1/tasks/{task_up}/feedback", json={"verdict": "up"})
+    client.post(f"/api/v1/tasks/{task_down}/feedback", json={"verdict": "down"})
+
+    resp = client.get("/api/v1/feedback?verdict=down")
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    for item in data["items"]:
+        assert item["feedback"]["verdict"] == "down"
+
+    returned_ids = {item["feedback"]["task_id"] for item in data["items"]}
+    assert task_down in returned_ids
+    assert task_up not in returned_ids
+
+
+@pytest.mark.asyncio
+async def test_list_filter_status(client, task_factory, redis_client):
+    """GET /api/v1/feedback?status=done returns only tasks with status=done."""
+    task_done = await task_factory()  # task_factory sets status="done"
+    task_queued = await task_factory()
+    # Override second task's status to queued
+    await redis_client.set(f"sre:task:{task_queued}:status", "queued")
+    client.post(f"/api/v1/tasks/{task_done}/feedback", json={"verdict": "up"})
+    client.post(f"/api/v1/tasks/{task_queued}/feedback", json={"verdict": "up"})
+
+    resp = client.get("/api/v1/feedback?status=done")
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    for item in data["items"]:
+        assert item["task"]["status"] == "done"
+
+    returned_ids = {item["feedback"]["task_id"] for item in data["items"]}
+    assert task_done in returned_ids
+    assert task_queued not in returned_ids
+
+
+@pytest.mark.asyncio
+async def test_list_filter_since(client, task_factory, redis_client):
+    """GET /api/v1/feedback?since=1h returns only feedback updated in the last hour."""
+    from redis_sre_agent.core.keys import RedisKeys
+
+    task_old = await task_factory()
+    task_recent = await task_factory()
+
+    # Write old feedback with a timestamp far in the past
+    old_ts = "2020-01-01T00:00:00+00:00"
+    await redis_client.hset(
+        RedisKeys.feedback_task(task_old),
+        mapping={
+            "task_id": task_old,
+            "verdict": "up",
+            "comment": "",
+            "created_at": old_ts,
+            "updated_at": old_ts,
+        },
+    )
+
+    # Write recent feedback via the API (uses current time)
+    client.post(f"/api/v1/tasks/{task_recent}/feedback", json={"verdict": "up"})
+
+    resp = client.get("/api/v1/feedback?since=1h")
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    returned_ids = {item["feedback"]["task_id"] for item in data["items"]}
+    assert task_recent in returned_ids
+    assert task_old not in returned_ids
+
+
+@pytest.mark.asyncio
+async def test_list_filter_combination(client, task_factory, redis_client):
+    """GET /api/v1/feedback?verdict=down&status=done uses AND semantics."""
+    task_down_done = await task_factory()  # status=done (default), verdict=down
+    task_up_done = await task_factory()  # status=done, verdict=up
+    client.post(f"/api/v1/tasks/{task_down_done}/feedback", json={"verdict": "down"})
+    client.post(f"/api/v1/tasks/{task_up_done}/feedback", json={"verdict": "up"})
+
+    resp = client.get("/api/v1/feedback?verdict=down&status=done")
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    returned_ids = {item["feedback"]["task_id"] for item in data["items"]}
+    assert task_down_done in returned_ids
+    assert task_up_done not in returned_ids
+
+
+def test_list_limit_bounds(client):
+    """limit=0 and limit=1000 return 422; no limit uses default of 50."""
+    resp_zero = client.get("/api/v1/feedback?limit=0")
+    assert resp_zero.status_code == 422, resp_zero.text
+
+    resp_over = client.get("/api/v1/feedback?limit=1000")
+    assert resp_over.status_code == 422, resp_over.text
+
+    # Default (no limit param) should succeed
+    resp_default = client.get("/api/v1/feedback")
+    assert resp_default.status_code == 200, resp_default.text
+
+
+def test_list_since_iso_rejected(client):
+    """since= with ISO date format (not Ns/Nm/Nh/Nd) returns 422."""
+    resp = client.get("/api/v1/feedback?since=2026-05-20")
+    assert resp.status_code == 422, resp.text
+    detail = resp.json()["detail"]
+    # FastAPI pattern validation puts the field name in loc
+    locs = [d["loc"][-1] for d in detail if isinstance(d, dict) and "loc" in d]
+    assert "since" in locs, f"Expected 'since' in locs, got {locs}"
+
+
+# ---------------------------------------------------------------------------
+# US-005 — stream event only emitted after successful commit
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_stream_event_emitted_after_commit(client, task_factory, redis_client):
+    """Stream publish is called only after the HSET pipeline commits.
+
+    TestClient runs the ASGI app in a separate thread/loop, so we cannot await
+    the same redis_client inside the publish callback (different event loop).
+    Instead we record the update_type at publish time and verify post-hoc that
+    the hash exists in Redis — proving the write was committed before the HTTP
+    response returned.
+    """
+    from redis_sre_agent.core.feedback import FEEDBACK_SUBMITTED_UPDATE_TYPE
+
+    task_id = await task_factory()
+    observed: dict = {}
+
+    async def _capture(thread_id, update_type, data):
+        # Record that publish was called; cannot touch redis_client here
+        # (different event loop from TestClient's thread).
+        observed["update_type"] = update_type
+        observed["data"] = data
+        return True
+
+    mock_manager = AsyncMock()
+    mock_manager.publish_task_update = AsyncMock(side_effect=_capture)
+
+    async def _get_manager():
+        return mock_manager
+
+    with patch("redis_sre_agent.api.websockets.get_stream_manager", side_effect=_get_manager):
+        resp = client.post(f"/api/v1/tasks/{task_id}/feedback", json={"verdict": "up"})
+
+    assert resp.status_code == 200
+    # Publish was called with the correct update_type
+    assert observed.get("update_type") == FEEDBACK_SUBMITTED_UPDATE_TYPE
+    assert observed.get("data", {}).get("task_id") == task_id
+    # The hash must be in Redis by the time the response returned
+    hash_after = await redis_client.hgetall(RedisKeys.feedback_task(task_id))
+    assert hash_after, "feedback hash must be committed before stream publish"

--- a/tests/contracts/test_feedback_read_surfaces.py
+++ b/tests/contracts/test_feedback_read_surfaces.py
@@ -1,0 +1,307 @@
+"""Cross-surface contract test for feedback joined-view reads (US-007).
+
+Asserts that HTTP, MCP, and CLI read surfaces return equivalent FeedbackView
+dicts for the same underlying Redis data. Guards against future drift across
+the three surfaces.
+
+AC-15 (single-record parity): HTTP GET, CLI `feedback show`, and MCP
+    `redis_sre_get_feedback` all return the same canonical FeedbackView dict,
+    and all three produce the documented "no feedback" signal for a task with
+    no feedback record.
+
+AC-12 (list parity): HTTP GET /api/v1/feedback, CLI `feedback list`, and MCP
+    `redis_sre_list_feedback` return the same set of task_ids and per-row
+    payloads for identical filter combinations.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import uuid
+from concurrent.futures import ThreadPoolExecutor
+from typing import AsyncIterator
+
+import pytest
+import pytest_asyncio
+from click.testing import CliRunner
+from fastapi.testclient import TestClient
+
+from redis_sre_agent.api.app import app
+from redis_sre_agent.cli.feedback import feedback
+from redis_sre_agent.core.keys import RedisKeys
+from redis_sre_agent.core.redis import get_redis_client
+from redis_sre_agent.mcp_server.server import redis_sre_get_feedback, redis_sre_list_feedback
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _canonicalize(obj: object) -> object:
+    """Round-trip through JSON with sort_keys so field order doesn't affect equality."""
+    return json.loads(json.dumps(obj, sort_keys=True, default=str))
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def redis_client() -> AsyncIterator:
+    """Real Redis client; skip test if Redis is unreachable."""
+    client = get_redis_client()
+    try:
+        await client.ping()
+    except Exception as exc:
+        pytest.skip(f"Redis unavailable: {exc}")
+    try:
+        yield client
+    finally:
+        await client.aclose()
+
+
+@pytest_asyncio.fixture
+async def four_tasks(redis_client):
+    """Create four tasks in Redis for the read-surface contract tests.
+
+    Task A: status=done, feedback verdict=up
+    Task B: status=done, feedback verdict=down with comment
+    Task C: status=failed, feedback verdict=down (no comment)
+    Task D: status=done, NO feedback (for the None/404 path)
+    """
+    created: list[str] = []
+
+    async def _make_task(status: str) -> str:
+        task_id = f"tsk-{uuid.uuid4().hex[:12]}"
+        await redis_client.set(RedisKeys.task_status(task_id), status)
+        await redis_client.hset(
+            RedisKeys.task_metadata(task_id),
+            mapping={"created_at": "2026-01-01T00:00:00+00:00", "thread_id": "thr-contract-read"},
+        )
+        created.append(task_id)
+        return task_id
+
+    async def _write_feedback(task_id: str, verdict: str, comment: str = "") -> None:
+        now = "2026-01-01T12:00:00+00:00"
+        await redis_client.hset(
+            RedisKeys.feedback_task(task_id),
+            mapping={
+                "task_id": task_id,
+                "verdict": verdict,
+                "comment": comment,
+                "created_at": now,
+                "updated_at": now,
+            },
+        )
+
+    task_a = await _make_task("done")
+    await _write_feedback(task_a, "up")
+
+    task_b = await _make_task("done")
+    await _write_feedback(task_b, "down", "needs improvement")
+
+    task_c = await _make_task("failed")
+    await _write_feedback(task_c, "down")
+
+    task_d = await _make_task("done")  # no feedback written
+
+    yield task_a, task_b, task_c, task_d
+
+    for task_id in created:
+        await redis_client.delete(
+            RedisKeys.task_status(task_id),
+            RedisKeys.task_metadata(task_id),
+            RedisKeys.feedback_task(task_id),
+        )
+
+
+@pytest.fixture
+def http_client():
+    """FastAPI TestClient."""
+    return TestClient(app)
+
+
+# ---------------------------------------------------------------------------
+# Contract tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_feedback_view_parity_across_surfaces(four_tasks, http_client):
+    """AC-15: HTTP, CLI, and MCP single-record reads return equivalent FeedbackView dicts.
+
+    Also verifies the "no feedback" signal for a task with no feedback record.
+    """
+    task_a, _task_b, _task_c, task_d = four_tasks
+    runner = CliRunner()
+    loop = asyncio.get_event_loop()
+
+    # ---- Task A: has feedback (verdict=up) ----
+
+    # HTTP
+    resp = http_client.get(f"/api/v1/tasks/{task_a}/feedback")
+    assert resp.status_code == 200, f"HTTP single GET failed: {resp.text}"
+    http_view = _canonicalize(resp.json())
+
+    # CLI — must run in a thread to avoid "cannot call asyncio.run from running loop"
+    def _cli_show_a():
+        return runner.invoke(feedback, ["show", task_a])
+
+    with ThreadPoolExecutor(max_workers=1) as pool:
+        cli_result = await loop.run_in_executor(pool, _cli_show_a)
+    assert cli_result.exit_code == 0, f"CLI show failed: {cli_result.output}"
+    cli_view = _canonicalize(json.loads(cli_result.output.strip()))
+
+    # MCP (in-process)
+    mcp_raw = await redis_sre_get_feedback(task_a)
+    assert mcp_raw is not None, "MCP get_feedback returned None for task with feedback"
+    mcp_view = _canonicalize(mcp_raw)
+
+    # All three must be equivalent
+    assert http_view == cli_view, (
+        f"HTTP vs CLI FeedbackView mismatch for task_a:\nHTTP={http_view}\nCLI={cli_view}"
+    )
+    assert http_view == mcp_view, (
+        f"HTTP vs MCP FeedbackView mismatch for task_a:\nHTTP={http_view}\nMCP={mcp_view}"
+    )
+
+    # ---- Task D: no feedback record ----
+
+    # HTTP → 404
+    resp_d = http_client.get(f"/api/v1/tasks/{task_d}/feedback")
+    assert resp_d.status_code == 404, (
+        f"HTTP should return 404 for task with no feedback, got {resp_d.status_code}"
+    )
+
+    # CLI → prints "null", exit 0
+    def _cli_show_d():
+        return runner.invoke(feedback, ["show", task_d])
+
+    with ThreadPoolExecutor(max_workers=1) as pool:
+        cli_result_d = await loop.run_in_executor(pool, _cli_show_d)
+    assert cli_result_d.exit_code == 0, (
+        f"CLI show (no feedback) should exit 0: {cli_result_d.output}"
+    )
+    assert cli_result_d.output.strip() == "null", (
+        f"CLI show (no feedback) should print 'null', got: {cli_result_d.output!r}"
+    )
+
+    # MCP → None
+    mcp_none = await redis_sre_get_feedback(task_d)
+    assert mcp_none is None, (
+        f"MCP get_feedback should return None for task with no feedback, got {mcp_none}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_list_feedback_parity_across_surfaces(four_tasks, http_client):
+    """AC-12: HTTP, CLI, and MCP list surfaces return the same task_ids and payloads
+    for verdict=down filter (matches Task B and Task C).
+    """
+    _task_a, task_b, task_c, _task_d = four_tasks
+    expected_ids = {task_b, task_c}
+    runner = CliRunner()
+    loop = asyncio.get_event_loop()
+
+    # HTTP
+    resp = http_client.get("/api/v1/feedback?verdict=down")
+    assert resp.status_code == 200, f"HTTP list failed: {resp.text}"
+    http_data = resp.json()
+    http_items = http_data["items"]
+    http_ids = {item["feedback"]["task_id"] for item in http_items}
+    assert expected_ids.issubset(http_ids), (
+        f"HTTP list missing expected ids. Expected {expected_ids} subset of {http_ids}"
+    )
+
+    # CLI
+    def _cli_list():
+        return runner.invoke(feedback, ["list", "--verdict", "down"])
+
+    with ThreadPoolExecutor(max_workers=1) as pool:
+        cli_result = await loop.run_in_executor(pool, _cli_list)
+    assert cli_result.exit_code == 0, f"CLI list failed: {cli_result.output}"
+    cli_lines = [ln for ln in cli_result.output.strip().splitlines() if ln.strip()]
+    cli_items = [json.loads(ln) for ln in cli_lines]
+    cli_ids = {item["feedback"]["task_id"] for item in cli_items}
+    assert expected_ids.issubset(cli_ids), (
+        f"CLI list missing expected ids. Expected {expected_ids} subset of {cli_ids}"
+    )
+
+    # MCP
+    mcp_result = await redis_sre_list_feedback(verdict="down")
+    mcp_items = mcp_result["items"]
+    mcp_ids = {item["feedback"]["task_id"] for item in mcp_items}
+    assert expected_ids.issubset(mcp_ids), (
+        f"MCP list missing expected ids. Expected {expected_ids} subset of {mcp_ids}"
+    )
+
+    # Per-row payload parity: for each expected task_id, all three surfaces return same canonical dict
+    for task_id in expected_ids:
+        http_row = _canonicalize(next(i for i in http_items if i["feedback"]["task_id"] == task_id))
+        cli_row = _canonicalize(next(i for i in cli_items if i["feedback"]["task_id"] == task_id))
+        mcp_row = _canonicalize(next(i for i in mcp_items if i["feedback"]["task_id"] == task_id))
+
+        assert http_row == cli_row, (
+            f"HTTP vs CLI payload mismatch for {task_id}:\nHTTP={http_row}\nCLI={cli_row}"
+        )
+        assert http_row == mcp_row, (
+            f"HTTP vs MCP payload mismatch for {task_id}:\nHTTP={http_row}\nMCP={mcp_row}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_list_combined_filters_parity(four_tasks, http_client):
+    """AC-12: verdict=down AND status=done filter returns only Task B across all three surfaces."""
+    _task_a, task_b, task_c, _task_d = four_tasks
+    # Task B: status=done, verdict=down  → must appear
+    # Task C: status=failed, verdict=down → must NOT appear (filtered by status)
+    runner = CliRunner()
+    loop = asyncio.get_event_loop()
+
+    # HTTP
+    resp = http_client.get("/api/v1/feedback?verdict=down&status=done")
+    assert resp.status_code == 200, f"HTTP combined-filter list failed: {resp.text}"
+    http_items = resp.json()["items"]
+    http_ids = {item["feedback"]["task_id"] for item in http_items}
+    assert task_b in http_ids, f"HTTP: task_b should be in results, got {http_ids}"
+    assert task_c not in http_ids, (
+        f"HTTP: task_c (status=failed) should NOT be in results, got {http_ids}"
+    )
+
+    # CLI
+    def _cli_list():
+        return runner.invoke(feedback, ["list", "--verdict", "down", "--status", "done"])
+
+    with ThreadPoolExecutor(max_workers=1) as pool:
+        cli_result = await loop.run_in_executor(pool, _cli_list)
+    assert cli_result.exit_code == 0, f"CLI combined-filter list failed: {cli_result.output}"
+    cli_lines = [ln for ln in cli_result.output.strip().splitlines() if ln.strip()]
+    cli_items = [json.loads(ln) for ln in cli_lines]
+    cli_ids = {item["feedback"]["task_id"] for item in cli_items}
+    assert task_b in cli_ids, f"CLI: task_b should be in results, got {cli_ids}"
+    assert task_c not in cli_ids, (
+        f"CLI: task_c (status=failed) should NOT be in results, got {cli_ids}"
+    )
+
+    # MCP
+    mcp_result = await redis_sre_list_feedback(verdict="down", status="done")
+    mcp_items = mcp_result["items"]
+    mcp_ids = {item["feedback"]["task_id"] for item in mcp_items}
+    assert task_b in mcp_ids, f"MCP: task_b should be in results, got {mcp_ids}"
+    assert task_c not in mcp_ids, (
+        f"MCP: task_c (status=failed) should NOT be in results, got {mcp_ids}"
+    )
+
+    # All three surfaces agree on task_b's payload
+    http_row = _canonicalize(next(i for i in http_items if i["feedback"]["task_id"] == task_b))
+    cli_row = _canonicalize(next(i for i in cli_items if i["feedback"]["task_id"] == task_b))
+    mcp_row = _canonicalize(next(i for i in mcp_items if i["feedback"]["task_id"] == task_b))
+
+    assert http_row == cli_row, (
+        f"HTTP vs CLI payload mismatch for task_b:\nHTTP={http_row}\nCLI={cli_row}"
+    )
+    assert http_row == mcp_row, (
+        f"HTTP vs MCP payload mismatch for task_b:\nHTTP={http_row}\nMCP={mcp_row}"
+    )

--- a/tests/contracts/test_feedback_surfaces.py
+++ b/tests/contracts/test_feedback_surfaces.py
@@ -1,0 +1,182 @@
+"""Cross-surface contract test for feedback submission (US-010).
+
+Asserts that HTTP, MCP, and CLI surfaces produce byte-identical Redis state
+for the same logical payload. Guards against future drift across surfaces.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from concurrent.futures import ThreadPoolExecutor
+from typing import AsyncIterator
+from unittest.mock import AsyncMock, patch
+
+import pytest
+import pytest_asyncio
+from click.testing import CliRunner
+from fastapi.testclient import TestClient
+
+from redis_sre_agent.api.app import app
+from redis_sre_agent.cli.feedback import feedback
+from redis_sre_agent.core.feedback import FeedbackRecord
+from redis_sre_agent.core.keys import RedisKeys
+from redis_sre_agent.core.redis import get_redis_client
+from redis_sre_agent.mcp_server.server import redis_sre_submit_feedback
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+_COMMENT = "cross-surface contract test"
+_VERDICT = "down"
+
+
+@pytest_asyncio.fixture
+async def redis_client() -> AsyncIterator:
+    """Real Redis client; skip test if Redis is unreachable."""
+    client = get_redis_client()
+    try:
+        await client.ping()
+    except Exception as exc:
+        pytest.skip(f"Redis unavailable: {exc}")
+    try:
+        yield client
+    finally:
+        await client.aclose()
+
+
+@pytest_asyncio.fixture
+async def three_tasks(redis_client):
+    """Create three distinct real tasks in Redis, yield their IDs, clean up after."""
+    created: list[str] = []
+
+    async def _make() -> str:
+        task_id = f"tsk-{uuid.uuid4().hex[:12]}"
+        await redis_client.set(RedisKeys.task_status(task_id), "done")
+        await redis_client.hset(
+            RedisKeys.task_metadata(task_id),
+            mapping={"created_at": "2026-01-01T00:00:00+00:00", "thread_id": "thr-contract"},
+        )
+        created.append(task_id)
+        return task_id
+
+    task_a = await _make()
+    task_b = await _make()
+    task_c = await _make()
+
+    yield task_a, task_b, task_c
+
+    for task_id in created:
+        await redis_client.delete(
+            RedisKeys.task_status(task_id),
+            RedisKeys.task_metadata(task_id),
+            RedisKeys.feedback_task(task_id),
+        )
+
+
+@pytest.fixture
+def http_client():
+    """FastAPI TestClient with stream manager muted."""
+    return TestClient(app)
+
+
+# ---------------------------------------------------------------------------
+# Contract test
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_feedback_surfaces_produce_identical_redis_state(
+    three_tasks, redis_client, http_client
+):
+    """All three surfaces write the same verdict+comment to Redis for the same payload.
+
+    Task A → HTTP POST /api/v1/tasks/{task_a}/feedback
+    Task B → MCP redis_sre_submit_feedback (in-process)
+    Task C → CLI CliRunner feedback down {task_c} --comment "..."
+
+    After each submission, HGETALL the feedback hash and assert that verdict
+    and comment are identical across all three tasks.
+    """
+    task_a, task_b, task_c = three_tasks
+
+    # Mute stream publish for all three submissions to avoid event-loop issues
+    # (TestClient runs in a separate thread; publish would touch a different loop).
+    mock_manager = AsyncMock()
+    mock_manager.publish_task_update = AsyncMock(return_value=True)
+
+    async def _get_manager():
+        return mock_manager
+
+    with patch("redis_sre_agent.api.websockets.get_stream_manager", side_effect=_get_manager):
+        # --- Surface A: HTTP ---
+        resp = http_client.post(
+            f"/api/v1/tasks/{task_a}/feedback",
+            json={"verdict": _VERDICT, "comment": _COMMENT},
+        )
+        assert resp.status_code == 200, f"HTTP surface failed: {resp.text}"
+
+        # --- Surface B: MCP (in-process) ---
+        await redis_sre_submit_feedback(
+            task_id=task_b,
+            verdict=_VERDICT,
+            comment=_COMMENT,
+        )
+
+        # --- Surface C: CLI ---
+        # CliRunner calls asyncio.run() internally; running it from an async
+        # test would raise "cannot be called from a running event loop".
+        # Execute in a ThreadPoolExecutor so it gets a fresh thread/loop.
+        runner = CliRunner()
+
+        def _invoke_cli():
+            return runner.invoke(feedback, ["down", task_c, "--comment", _COMMENT])
+
+        loop = asyncio.get_event_loop()
+        with ThreadPoolExecutor(max_workers=1) as pool:
+            result = await loop.run_in_executor(pool, _invoke_cli)
+        assert result.exit_code == 0, f"CLI surface failed: {result.output}"
+
+    # --- Fetch raw Redis hashes ---
+    raw_a = await redis_client.hgetall(RedisKeys.feedback_task(task_a))
+    raw_b = await redis_client.hgetall(RedisKeys.feedback_task(task_b))
+    raw_c = await redis_client.hgetall(RedisKeys.feedback_task(task_c))
+
+    def _decode_hash(raw: dict) -> dict[str, str]:
+        return {
+            (k.decode() if isinstance(k, bytes) else k): (v.decode() if isinstance(v, bytes) else v)
+            for k, v in raw.items()
+        }
+
+    hash_a = _decode_hash(raw_a)
+    hash_b = _decode_hash(raw_b)
+    hash_c = _decode_hash(raw_c)
+
+    # Assert Redis hashes are non-empty (each surface actually wrote)
+    assert hash_a, "HTTP surface: feedback hash is empty"
+    assert hash_b, "MCP surface: feedback hash is empty"
+    assert hash_c, "CLI surface: feedback hash is empty"
+
+    # --- Primary contract assertion: verdict and comment are byte-identical ---
+    for field in ("verdict", "comment"):
+        val_a = hash_a.get(field)
+        val_b = hash_b.get(field)
+        val_c = hash_c.get(field)
+        assert val_a == val_b == val_c, (
+            f"Field '{field}' differs across surfaces: HTTP={val_a!r}, MCP={val_b!r}, CLI={val_c!r}"
+        )
+
+    # --- Bonus: parse through FeedbackRecord to catch serialization drift ---
+    record_a = FeedbackRecord.model_validate({**hash_a, "task_id": task_a})
+    record_b = FeedbackRecord.model_validate({**hash_b, "task_id": task_b})
+    record_c = FeedbackRecord.model_validate({**hash_c, "task_id": task_c})
+
+    assert record_a.verdict == record_b.verdict == record_c.verdict == _VERDICT, (
+        f"FeedbackRecord.verdict mismatch: {record_a.verdict!r}, "
+        f"{record_b.verdict!r}, {record_c.verdict!r}"
+    )
+    assert record_a.comment == record_b.comment == record_c.comment == _COMMENT, (
+        f"FeedbackRecord.comment mismatch: {record_a.comment!r}, "
+        f"{record_b.comment!r}, {record_c.comment!r}"
+    )

--- a/tests/unit/cli/test_feedback_cli.py
+++ b/tests/unit/cli/test_feedback_cli.py
@@ -1,0 +1,283 @@
+"""CLI tests for the `feedback` subgroup (US-008, US-005).
+
+These tests run against a real Redis instance (localhost:7843). Each test that
+needs Redis is guarded by the `redis_available` fixture and cleans up after
+itself. Tests that only exercise argument validation / error paths mock out
+Redis entirely and run without a live server.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import uuid
+from unittest.mock import patch
+
+import pytest
+import pytest_asyncio
+from click.testing import CliRunner
+
+from redis_sre_agent.cli.feedback import feedback
+from redis_sre_agent.core.keys import RedisKeys
+from redis_sre_agent.core.redis import get_redis_client
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def redis_client():
+    """Real Redis client; skip test if Redis unreachable."""
+    client = get_redis_client()
+    try:
+        await client.ping()
+    except Exception as exc:
+        pytest.skip(f"Redis unavailable: {exc}")
+    try:
+        yield client
+    finally:
+        await client.aclose()
+
+
+@pytest_asyncio.fixture
+async def task_factory(redis_client):
+    """Create minimal task rows so submit_feedback accepts the task_id."""
+    created: list[str] = []
+
+    async def _make(*, thread_id: str | None = "thr-test", status: str = "done") -> str:
+        task_id = f"tsk-{uuid.uuid4().hex[:12]}"
+        await redis_client.set(RedisKeys.task_status(task_id), status)
+        mapping: dict = {"created_at": "2026-01-01T00:00:00+00:00"}
+        if thread_id is not None:
+            mapping["thread_id"] = thread_id
+        await redis_client.hset(RedisKeys.task_metadata(task_id), mapping=mapping)
+        created.append(task_id)
+        return task_id
+
+    yield _make
+
+    for task_id in created:
+        await redis_client.delete(
+            RedisKeys.task_status(task_id),
+            RedisKeys.task_metadata(task_id),
+            RedisKeys.feedback_task(task_id),
+        )
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestUpDownWithdraw:
+    """AC: up / down / withdraw subcommands write JSON to stdout."""
+
+    def test_up_down_withdraw(self, runner, task_factory):
+        task_id = asyncio.get_event_loop().run_until_complete(task_factory())
+
+        # up
+        result = runner.invoke(feedback, ["up", task_id])
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        assert data["verdict"] == "up"
+        assert data["task_id"] == task_id
+
+        # down with comment
+        result = runner.invoke(feedback, ["down", task_id, "--comment", "foo"])
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        assert data["verdict"] == "down"
+        assert data["comment"] == "foo"
+
+        # withdraw
+        result = runner.invoke(feedback, ["withdraw", task_id])
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        assert data["verdict"] == "withdrawn"
+
+
+class TestShow:
+    """AC: show returns FeedbackView or null; exit contract."""
+
+    def test_show_returns_null_exit_zero_when_no_feedback(self, runner, task_factory):
+        task_id = asyncio.get_event_loop().run_until_complete(task_factory())
+        result = runner.invoke(feedback, ["show", task_id])
+        assert result.exit_code == 0, result.output
+        assert result.output.strip() == "null"
+
+    def test_show_exits_nonzero_on_unknown_task(self, runner, redis_client):
+        nonexistent = f"tsk-{uuid.uuid4().hex[:12]}"
+        result = runner.invoke(feedback, ["show", nonexistent])
+        assert result.exit_code != 0
+        assert nonexistent in result.output or "not found" in result.output.lower()
+
+    def test_show_returns_record_after_submission(self, runner, task_factory):
+        task_id = asyncio.get_event_loop().run_until_complete(task_factory())
+        runner.invoke(feedback, ["up", task_id, "--comment", "nice"])
+        result = runner.invoke(feedback, ["show", task_id])
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        # show now returns FeedbackView with feedback + task keys
+        assert data["feedback"]["verdict"] == "up"
+        assert data["feedback"]["comment"] == "nice"
+
+    def test_show_emits_feedback_view(self, runner, task_factory):
+        """AC-10: show returns FeedbackView JSON with feedback + task keys."""
+        task_id = asyncio.get_event_loop().run_until_complete(task_factory())
+        runner.invoke(feedback, ["up", task_id, "--comment", "great"])
+        result = runner.invoke(feedback, ["show", task_id])
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        assert "feedback" in data, f"Expected 'feedback' key, got: {list(data.keys())}"
+        assert "task" in data, f"Expected 'task' key, got: {list(data.keys())}"
+        assert data["feedback"]["verdict"] == "up"
+        assert data["task"]["task_id"] == task_id
+
+
+class TestList:
+    """AC: list subcommand uses SCAN, filters, and handles --limit."""
+
+    def test_list_filters_by_verdict(self, runner, task_factory):
+        """Submit feedback for 3 tasks (mix of up/down); list --verdict down shows only down."""
+
+        async def _setup():
+            t1 = await task_factory()
+            t2 = await task_factory()
+            t3 = await task_factory()
+            return t1, t2, t3
+
+        t1, t2, t3 = asyncio.get_event_loop().run_until_complete(_setup())
+
+        runner.invoke(feedback, ["up", t1])
+        runner.invoke(feedback, ["down", t2])
+        runner.invoke(feedback, ["down", t3])
+
+        result = runner.invoke(feedback, ["list", "--verdict", "down"])
+        assert result.exit_code == 0, result.output
+        # t1 (up) must NOT appear, t2 and t3 (down) must appear
+        assert t2 in result.output
+        assert t3 in result.output
+        assert t1 not in result.output
+
+    def test_list_uses_scan_not_keys(self, runner, task_factory):
+        """If the implementation calls redis.keys(), this test will fail."""
+        task_id = asyncio.get_event_loop().run_until_complete(task_factory())
+        runner.invoke(feedback, ["up", task_id])
+
+        # Patch the redis client so that calling `keys` raises an error.
+        original_get_redis_client = get_redis_client
+
+        def _patched_get_redis_client():
+            real_client = original_get_redis_client()
+
+            async def _keys_forbidden(*args, **kwargs):
+                raise AssertionError("feedback list must not call redis.keys() — use scan instead")
+
+            real_client.keys = _keys_forbidden
+            return real_client
+
+        with patch(
+            "redis_sre_agent.core.feedback.get_redis_client", side_effect=_patched_get_redis_client
+        ):
+            result = runner.invoke(feedback, ["list"])
+        assert result.exit_code == 0, result.output
+
+    def test_list_clamps_limit_500(self, runner, redis_client):
+        """--limit 1000 is clamped to 500; command succeeds."""
+        result = runner.invoke(feedback, ["list", "--limit", "1000"])
+        # Implementation choice: clamp to 500 (exit 0)
+        assert result.exit_code == 0, result.output
+
+    def test_list_default_is_jsonl(self, runner, task_factory):
+        """AC-11: default output is JSON Lines — one FeedbackView per line."""
+
+        async def _setup():
+            t1 = await task_factory()
+            t2 = await task_factory()
+            return t1, t2
+
+        t1, t2 = asyncio.get_event_loop().run_until_complete(_setup())
+        runner.invoke(feedback, ["up", t1])
+        runner.invoke(feedback, ["down", t2])
+
+        result = runner.invoke(feedback, ["list"])
+        assert result.exit_code == 0, result.output
+
+        lines = [ln for ln in result.output.strip().splitlines() if ln.strip()]
+        assert len(lines) >= 2, f"Expected at least 2 lines, got: {lines}"
+
+        for line in lines:
+            obj = json.loads(line)
+            assert "feedback" in obj, f"Missing 'feedback' key in line: {line}"
+            assert "task" in obj, f"Missing 'task' key in line: {line}"
+
+    def test_list_table_flag_columns(self, runner, task_factory):
+        """AC-12: --table renders Rich table with six column headers."""
+        task_id = asyncio.get_event_loop().run_until_complete(task_factory())
+        runner.invoke(feedback, ["up", task_id, "--comment", "test"])
+
+        result = runner.invoke(feedback, ["list", "--table"])
+        assert result.exit_code == 0, result.output
+
+        output_lower = result.output.lower()
+        assert "task_id" in output_lower, f"Missing 'task_id' column in: {result.output}"
+        assert "status" in output_lower, f"Missing 'status' column in: {result.output}"
+        assert "verdict" in output_lower, f"Missing 'verdict' column in: {result.output}"
+        assert "updated_at" in output_lower, f"Missing 'updated_at' column in: {result.output}"
+
+    def test_list_status_filter(self, runner, task_factory):
+        """AC-11: --status filters by task.status."""
+
+        async def _setup():
+            t_done = await task_factory(status="done")
+            t_failed = await task_factory(status="failed")
+            return t_done, t_failed
+
+        t_done, t_failed = asyncio.get_event_loop().run_until_complete(_setup())
+        runner.invoke(feedback, ["up", t_done])
+        runner.invoke(feedback, ["down", t_failed])
+
+        result = runner.invoke(feedback, ["list", "--status", "done"])
+        assert result.exit_code == 0, result.output
+
+        lines = [ln for ln in result.output.strip().splitlines() if ln.strip()]
+        task_ids_returned = set()
+        for line in lines:
+            obj = json.loads(line)
+            task_ids_returned.add(obj["task"]["task_id"])
+
+        assert t_done in task_ids_returned, "done task should appear"
+        assert t_failed not in task_ids_returned, "failed task should not appear with --status done"
+
+    def test_list_status_rejects_unknown(self, runner):
+        """AC-11: --status with unknown value exits non-zero and emits error to stderr."""
+        result = runner.invoke(feedback, ["list", "--status", "not-a-status"])
+        assert result.exit_code != 0
+        assert "invalid" in result.output.lower() or "not-a-status" in result.output
+
+
+class TestSinceParser:
+    """AC: --since rejects ISO-8601, accepts valid duration units."""
+
+    def test_since_parser_rejects_iso(self, runner):
+        result = runner.invoke(feedback, ["list", "--since", "2026-05-18"])
+        assert result.exit_code != 0
+        assert "ISO-8601" in result.output or "not supported" in result.output
+
+    def test_since_parser_accepts_valid_units(self, runner, redis_client):
+        for duration in ["24h", "30m", "7d", "3600s"]:
+            result = runner.invoke(feedback, ["list", "--since", duration])
+            assert result.exit_code == 0, (
+                f"--since {duration} should be accepted but got exit {result.exit_code}: "
+                f"{result.output}"
+            )
+
+    def test_since_parser_rejects_invalid_format(self, runner):
+        result = runner.invoke(feedback, ["list", "--since", "invalid"])
+        assert result.exit_code != 0

--- a/tests/unit/core/test_cli_mcp_parity.py
+++ b/tests/unit/core/test_cli_mcp_parity.py
@@ -104,6 +104,8 @@ class TestCliMcpParityHelpers:
             "eval list",
             "eval live-suite",
             "eval run",
+            "feedback list",
+            "feedback show",
             "knowledge-pack build",
             "knowledge-pack inspect",
             "knowledge-pack load",

--- a/tests/unit/core/test_feedback.py
+++ b/tests/unit/core/test_feedback.py
@@ -1,0 +1,752 @@
+"""Unit tests for `redis_sre_agent.core.feedback` (US-002 + US-005).
+
+Tests exercise real `HSETNX` / `HSET` semantics against a Redis instance.
+The default `redis_url` in `Settings` points at the project's docker-compose
+Redis (`redis://localhost:7843/0`). If Redis is unreachable each test is
+skipped via the `redis_available` fixture — tests will run cleanly in CI once
+the Redis testcontainer is wired up by the integration harness.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import subprocess
+import uuid
+from typing import AsyncIterator
+from unittest.mock import AsyncMock, patch
+
+import pytest
+import pytest_asyncio
+
+# Imports under test — module-level so AC-1 (`test_module_exports`) verifies
+# them as part of test collection itself.
+from redis_sre_agent.core.feedback import (  # noqa: F401  (also used in tests)
+    FEEDBACK_SUBMITTED_UPDATE_TYPE,
+    FeedbackError,
+    FeedbackRecord,
+    FeedbackSubmitRequest,
+    TaskNotFoundError,
+    get_feedback,
+    submit_feedback,
+)
+from redis_sre_agent.core.keys import RedisKeys
+from redis_sre_agent.core.redis import get_redis_client
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def redis_client() -> AsyncIterator:
+    """Provide a real Redis client; skip the test if Redis is unreachable.
+
+    Each test cleans up after itself by tracking task_ids it created and
+    deleting their associated keys.
+    """
+    client = get_redis_client()
+    try:
+        await client.ping()
+    except Exception as exc:
+        pytest.skip(f"Redis unavailable at default URL: {exc}")
+    try:
+        yield client
+    finally:
+        await client.aclose()
+
+
+@pytest_asyncio.fixture
+async def task_factory(redis_client):
+    """Create real task metadata rows so `submit_feedback` accepts the task_id.
+
+    Returns a callable that yields a fresh task_id and registers cleanup of
+    every Redis key associated with it (status, metadata, feedback).
+    """
+    created: list[str] = []
+
+    async def _make(*, thread_id: str | None = "thr-test", with_metadata: bool = True) -> str:
+        task_id = f"tsk-{uuid.uuid4().hex[:12]}"
+        await redis_client.set(RedisKeys.task_status(task_id), "done")
+        if with_metadata:
+            mapping = {"created_at": "2026-01-01T00:00:00+00:00"}
+            if thread_id is not None:
+                mapping["thread_id"] = thread_id
+            await redis_client.hset(RedisKeys.task_metadata(task_id), mapping=mapping)
+        created.append(task_id)
+        return task_id
+
+    yield _make
+
+    for task_id in created:
+        await redis_client.delete(
+            RedisKeys.task_status(task_id),
+            RedisKeys.task_metadata(task_id),
+            RedisKeys.feedback_task(task_id),
+        )
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def _mute_stream_publish():
+    """Replace the WebSocket stream manager with an AsyncMock so tests don't
+    require the API layer to be importable / reachable.
+
+    Returned mock is exposed via the named fixture below for assertion.
+    """
+    mock_manager = AsyncMock()
+    mock_manager.publish_task_update = AsyncMock(return_value=True)
+
+    async def _get_manager():
+        return mock_manager
+
+    with patch(
+        "redis_sre_agent.api.websockets.get_stream_manager", side_effect=_get_manager
+    ) as patched:
+        # Stash the mock on the patcher so the next fixture can grab it.
+        patched.mock_manager = mock_manager
+        yield mock_manager
+
+
+@pytest.fixture
+def stream_mock(_mute_stream_publish):
+    """Convenience alias — yields the same AsyncMock the autouse fixture
+    installed, so individual tests can assert call counts / args."""
+    return _mute_stream_publish
+
+
+# ---------------------------------------------------------------------------
+# AC-1 — Module exports
+# ---------------------------------------------------------------------------
+
+
+def test_module_exports():
+    """AC-1: canonical core fn + models are importable from core.feedback."""
+    import redis_sre_agent.core.feedback as mod
+
+    assert callable(mod.submit_feedback)
+    assert callable(mod.get_feedback)
+    assert issubclass(mod.FeedbackRecord, object)
+    assert issubclass(mod.FeedbackSubmitRequest, object)
+    assert issubclass(mod.TaskNotFoundError, mod.FeedbackError)
+
+    # Also verify the api.schemas re-export points back to the same classes.
+    from redis_sre_agent.api import schemas as api_schemas
+
+    assert api_schemas.FeedbackRecord is mod.FeedbackRecord
+    assert api_schemas.FeedbackSubmitRequest is mod.FeedbackSubmitRequest
+
+
+# ---------------------------------------------------------------------------
+# AC-2 — No external writers
+# ---------------------------------------------------------------------------
+
+
+def test_no_external_writers():
+    """AC-2: only `core/feedback.py` writes to `sre:feedback:task:*`."""
+    result = subprocess.run(
+        [
+            "grep",
+            "-rnE",
+            r"HSET .*sre:feedback:task|hset.*sre:feedback:task",
+            "redis_sre_agent/",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    # grep exits 1 when nothing matches — both 0 and 1 are acceptable here.
+    matches = [
+        line
+        for line in result.stdout.splitlines()
+        if line.strip() and "core/feedback.py" not in line
+    ]
+    assert matches == [], f"Unexpected feedback hash writers: {matches}"
+
+
+# ---------------------------------------------------------------------------
+# AC-7 — Last-write-wins preserves created_at
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_last_write_wins_preserves_created_at(redis_client, task_factory):
+    """AC-7: up → down → withdrawn leaves one row; created_at unchanged."""
+    task_id = await task_factory()
+
+    first = await submit_feedback(task_id, "up")
+    await asyncio.sleep(0.001)
+    second = await submit_feedback(task_id, "down", comment="meh")
+    await asyncio.sleep(0.001)
+    third = await submit_feedback(task_id, "withdrawn")
+
+    raw = await redis_client.hgetall(RedisKeys.feedback_task(task_id))
+    assert raw, "feedback hash must exist"
+    final = await get_feedback(task_id)
+    assert final is not None
+    assert final.verdict == "withdrawn"
+    assert final.created_at == first.created_at
+    assert second.created_at == first.created_at
+    assert third.created_at == first.created_at
+    assert final.updated_at == third.updated_at
+    assert final.updated_at >= second.updated_at >= first.updated_at
+
+
+# ---------------------------------------------------------------------------
+# AC-7 — Concurrent first-write anchors created_at
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_concurrent_first_write_anchors_created_at(redis_client, task_factory):
+    """AC-7: 10 concurrent first-writers all observe the same `created_at`."""
+    task_id = await task_factory()
+
+    results = await asyncio.gather(*[submit_feedback(task_id, "up") for _ in range(10)])
+
+    created_at_values = {r.created_at for r in results}
+    assert len(created_at_values) == 1, (
+        f"Expected single anchored created_at, got {created_at_values}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-8 — Withdrawn preserved, then up overwrites cleanly
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_withdrawn_then_up(redis_client, task_factory):
+    """AC-8: row survives `withdrawn`; subsequent `up` keeps created_at."""
+    task_id = await task_factory()
+
+    first = await submit_feedback(task_id, "up")
+    await submit_feedback(task_id, "withdrawn")
+    row = await get_feedback(task_id)
+    assert row is not None
+    assert row.verdict == "withdrawn"
+
+    after_up = await submit_feedback(task_id, "up")
+    assert after_up.verdict == "up"
+    assert after_up.created_at == first.created_at
+
+
+# ---------------------------------------------------------------------------
+# AC-5 — Malformed thread_id still writes feedback, no exception
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_malformed_thread_id_still_writes(redis_client, task_factory, stream_mock):
+    """AC-5: task exists but thread_id missing → feedback still written,
+    stream publish skipped, no exception raised."""
+    task_id = await task_factory(thread_id=None)  # metadata exists, but no thread_id field
+
+    record = await submit_feedback(task_id, "up", comment="orphan-thread")
+
+    assert record.verdict == "up"
+    assert record.comment == "orphan-thread"
+    raw = await redis_client.hgetall(RedisKeys.feedback_task(task_id))
+    assert raw, "feedback hash must be written even when thread_id is missing"
+    # Stream publish must be skipped when thread_id is absent.
+    stream_mock.publish_task_update.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# AC-5 — Unknown task raises TaskNotFoundError
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_unknown_task_raises_TaskNotFoundError(redis_client):  # noqa: N802
+    """AC-5: submitting for a non-existent task_id raises TaskNotFoundError."""
+    bogus_id = f"tsk-missing-{uuid.uuid4().hex[:8]}"
+    # Belt-and-braces: make sure no stray status key lingers from a prior run.
+    await redis_client.delete(RedisKeys.task_status(bogus_id))
+
+    with pytest.raises(TaskNotFoundError):
+        await submit_feedback(bogus_id, "up")
+
+    # Post-condition: nothing was written.
+    raw = await redis_client.hgetall(RedisKeys.feedback_task(bogus_id))
+    assert not raw
+
+
+# ---------------------------------------------------------------------------
+# AC-14 — OTel span attributes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_otel_span_attributes(redis_client, task_factory):
+    """AC-14: `feedback.submit` span carries task_id / verdict / comment_length /
+    sre_agent.category attributes."""
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+    from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+
+    # Patch the module-level tracer so the new provider is used for this test.
+    new_tracer = provider.get_tracer("test.feedback")
+    with patch("redis_sre_agent.core.feedback.tracer", new_tracer):
+        task_id = await task_factory()
+        await submit_feedback(task_id, "down", comment="needs context")
+
+    spans = [s for s in exporter.get_finished_spans() if s.name == "feedback.submit"]
+    assert spans, "expected a `feedback.submit` span"
+    attrs = dict(spans[0].attributes or {})
+    assert attrs.get("task_id") == task_id
+    assert attrs.get("verdict") == "down"
+    assert attrs.get("comment_length") == len("needs context")
+    assert attrs.get("sre_agent.category") == "feedback"
+
+
+# ---------------------------------------------------------------------------
+# US-005 — Stream-publish ordering + idempotency short-circuit
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_idempotent_resubmit_short_circuits(redis_client, task_factory, stream_mock):
+    """US-005 / AC-13: identical resubmission returns same `updated_at` and
+    publishes the stream event exactly once."""
+    task_id = await task_factory()
+
+    first = await submit_feedback(task_id, "up", comment="foo")
+    second = await submit_feedback(task_id, "up", comment="foo")
+
+    assert second.updated_at == first.updated_at, "idempotent resubmit must not rewrite updated_at"
+    assert second.created_at == first.created_at
+    # Stream publish happens only for the first write.
+    assert stream_mock.publish_task_update.await_count == 1
+    publish_kwargs = stream_mock.publish_task_update.await_args.kwargs
+    assert publish_kwargs.get("update_type") == FEEDBACK_SUBMITTED_UPDATE_TYPE
+    data = publish_kwargs.get("data") or {}
+    assert data.get("task_id") == task_id
+    assert data.get("verdict") == "up"
+    assert data.get("has_comment") is True
+
+
+@pytest.mark.asyncio
+async def test_stream_publish_ordering_after_commit(redis_client, task_factory, stream_mock):
+    """US-005: stream event is published only AFTER a successful HSET commit.
+
+    We patch `publish_task_update` so that, before returning, it reads the
+    feedback hash back out of Redis and asserts the new row is already present.
+    """
+    task_id = await task_factory()
+    observed: dict = {}
+
+    async def _capture(thread_id, update_type, data):
+        observed["thread_id"] = thread_id
+        observed["update_type"] = update_type
+        observed["data"] = data
+        # The feedback hash must already exist by the time we get called.
+        observed["hash_at_publish"] = await redis_client.hgetall(RedisKeys.feedback_task(task_id))
+        return True
+
+    stream_mock.publish_task_update.side_effect = _capture
+
+    await submit_feedback(task_id, "down", comment="late")
+
+    assert observed["update_type"] == FEEDBACK_SUBMITTED_UPDATE_TYPE
+    assert observed["hash_at_publish"], "hash must be committed before publish"
+
+
+@pytest.mark.asyncio
+async def test_stream_publish_failure_is_swallowed(redis_client, task_factory, stream_mock):
+    """US-005: stream publish errors do not raise — write is authoritative."""
+    task_id = await task_factory()
+    stream_mock.publish_task_update.side_effect = RuntimeError("stream down")
+
+    record = await submit_feedback(task_id, "up")
+
+    assert record.verdict == "up"
+    final = await get_feedback(task_id)
+    assert final is not None and final.verdict == "up"
+
+
+# ---------------------------------------------------------------------------
+# US-001 / US-002 — FeedbackView joined-view models, trim helpers, read paths.
+# ---------------------------------------------------------------------------
+
+
+import json  # noqa: E402  — local-scoped, used by the Phase-2 tests below
+
+
+@pytest_asyncio.fixture
+async def task_factory_with_result(redis_client):
+    """Task factory that ALSO writes a result blob with the given payload.
+
+    Used by Phase-2 joined-view tests that need `task.result` populated so the
+    trim helpers can extract messages / tool_calls.
+    """
+    created: list[str] = []
+
+    async def _make(
+        *,
+        thread_id: str | None = "thr-test",
+        status: str = "done",
+        subject: str | None = "Test subject",
+        result: dict | None = None,
+        error_message: str | None = None,
+        updated_at: str | None = None,
+    ) -> str:
+        task_id = f"tsk-{uuid.uuid4().hex[:12]}"
+        await redis_client.set(RedisKeys.task_status(task_id), status)
+        mapping = {"created_at": "2026-05-01T00:00:00+00:00"}
+        if thread_id is not None:
+            mapping["thread_id"] = thread_id
+        if subject is not None:
+            mapping["subject"] = subject
+        if updated_at is not None:
+            mapping["updated_at"] = updated_at
+        await redis_client.hset(RedisKeys.task_metadata(task_id), mapping=mapping)
+        if result is not None:
+            await redis_client.set(RedisKeys.task_result(task_id), json.dumps(result))
+        if error_message is not None:
+            await redis_client.set(RedisKeys.task_error(task_id), error_message)
+        created.append(task_id)
+        return task_id
+
+    yield _make
+
+    for task_id in created:
+        await redis_client.delete(
+            RedisKeys.task_status(task_id),
+            RedisKeys.task_metadata(task_id),
+            RedisKeys.task_result(task_id),
+            RedisKeys.task_error(task_id),
+            RedisKeys.feedback_task(task_id),
+        )
+
+
+# --- AC-1 module exports ---------------------------------------------------
+
+
+def test_feedback_view_module_exports():
+    """AC-1: all 4 new models + the 2 public helpers are importable from
+    core.feedback; api.schemas re-exports point at the same classes."""
+    import redis_sre_agent.core.feedback as mod
+    from redis_sre_agent.api import schemas as api_schemas
+
+    assert issubclass(mod.FeedbackView, object)
+    assert issubclass(mod.TaskInfo, object)
+    assert issubclass(mod.ConversationMessage, object)
+    assert issubclass(mod.ToolCallSummary, object)
+    assert callable(mod.get_feedback_view)
+    assert callable(mod.list_feedback_views)
+
+    assert api_schemas.FeedbackView is mod.FeedbackView
+    assert api_schemas.TaskInfo is mod.TaskInfo
+    assert api_schemas.ConversationMessage is mod.ConversationMessage
+    assert api_schemas.ToolCallSummary is mod.ToolCallSummary
+
+
+# --- AC-2 trim policy ------------------------------------------------------
+
+
+def test_trim_policy_drops_tool_messages_and_raw_outputs():
+    """AC-2: tool/system messages dropped; raw tool_calls payload replaced
+    with a ToolCallSummary list (no raw outputs); args_summary <=256 chars."""
+    from redis_sre_agent.core.feedback import (
+        ConversationMessage,
+        ToolCallSummary,
+        _compact_tool_calls,
+        _trim_task_messages,
+    )
+
+    huge_args = {"query": "x" * 1000, "extra": list(range(100))}
+    raw_result = {
+        "messages": [
+            {"role": "user", "content": "Help me debug Redis"},
+            {
+                "role": "assistant",
+                "content": "Looking into it now.",
+                "tool_calls": [
+                    {"name": "redis_cli", "args": huge_args},
+                ],
+                "metadata": {
+                    "tool_calls": [
+                        {"name": "search_kb", "args": {"q": "memory"}},
+                    ],
+                },
+            },
+            {
+                "role": "tool",
+                "content": "RAW_TOOL_OUTPUT_BYTES_HERE",
+                "metadata": {"output_bytes": "x" * 5000},
+            },
+            {"role": "system", "content": "internal citation system prompt"},
+            {"role": "assistant", "content": "Memory looks healthy."},
+        ],
+        "tool_envelopes": [
+            {
+                "tool_name": "redis_info",
+                "tool_args": {"section": "memory"},
+                "output": "RAW_OUTPUT_HERE_should_be_dropped",
+            },
+        ],
+    }
+
+    trimmed = _trim_task_messages(raw_result)
+    assert all(isinstance(m, ConversationMessage) for m in trimmed)
+    assert [m.role for m in trimmed] == ["user", "assistant", "assistant"]
+    assert [m.content for m in trimmed] == [
+        "Help me debug Redis",
+        "Looking into it now.",
+        "Memory looks healthy.",
+    ]
+    # No raw tool/system entries leaked through.
+    assert not any("RAW_TOOL_OUTPUT_BYTES_HERE" in m.content for m in trimmed)
+    assert not any("citation system prompt" in m.content for m in trimmed)
+
+    summaries = _compact_tool_calls(raw_result)
+    assert all(isinstance(s, ToolCallSummary) for s in summaries)
+    # Three tool calls: inline `redis_cli`, metadata `search_kb`, envelope `redis_info`.
+    tool_names = sorted(s.tool for s in summaries)
+    assert tool_names == ["redis_cli", "redis_info", "search_kb"]
+    for s in summaries:
+        assert len(s.args_summary) <= 256
+        assert "RAW_OUTPUT_HERE_should_be_dropped" not in s.args_summary
+
+    # Empty / non-dict inputs are tolerated.
+    assert _trim_task_messages(None) == []
+    assert _trim_task_messages({}) == []
+    assert _compact_tool_calls(None) == []
+    assert _compact_tool_calls({}) == []
+
+
+# --- AC-3 task info field set ---------------------------------------------
+
+
+def test_task_info_field_set():
+    """AC-3: TaskInfo carries exactly the documented subset.
+
+    Specifically NO `updates`, NO raw `tool_calls`, NO `resume_supported`.
+    `tool_calls` IS present as the compact ToolCallSummary list (allowed by
+    spec) — but the field type must NOT be the raw List[Dict[str, Any]] shape.
+    """
+    from redis_sre_agent.core.feedback import TaskInfo, ToolCallSummary
+
+    expected = {
+        "task_id",
+        "thread_id",
+        "status",
+        "subject",
+        "created_at",
+        "updated_at",
+        "error_message",
+        "pending_approval",
+        "messages",
+        "tool_calls",
+    }
+    assert set(TaskInfo.model_fields) == expected
+    assert "updates" not in TaskInfo.model_fields
+    assert "resume_supported" not in TaskInfo.model_fields
+
+    # The `tool_calls` field is the compact summary list, not raw envelopes.
+    tc_field = TaskInfo.model_fields["tool_calls"]
+    annotation_repr = repr(tc_field.annotation)
+    assert "ToolCallSummary" in annotation_repr, (
+        f"tool_calls must be List[ToolCallSummary], got {annotation_repr}"
+    )
+    assert ToolCallSummary.model_fields["args_summary"].metadata, (
+        "args_summary must carry a max_length constraint"
+    )
+
+
+# --- AC: get_feedback_view returns joined view ----------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_feedback_view_returns_joined(redis_client, task_factory_with_result):
+    """get_feedback_view returns a FeedbackView with both feedback and task fields."""
+    from redis_sre_agent.core.feedback import get_feedback_view
+
+    result_payload = {
+        "response": "ok",
+        "messages": [
+            {"role": "user", "content": "Why is memory high?"},
+            {
+                "role": "assistant",
+                "content": "Checked INFO memory.",
+                "tool_calls": [{"name": "redis_info", "args": {"section": "memory"}}],
+            },
+        ],
+    }
+    task_id = await task_factory_with_result(result=result_payload, status="done")
+    await submit_feedback(task_id, "down", comment="bad explanation")
+
+    view = await get_feedback_view(task_id)
+
+    assert view is not None
+    assert view.feedback.task_id == task_id
+    assert view.feedback.verdict == "down"
+    assert view.feedback.comment == "bad explanation"
+
+    assert view.task.task_id == task_id
+    assert view.task.thread_id == "thr-test"
+    assert view.task.status == "done"
+    assert view.task.subject == "Test subject"
+    assert view.task.created_at == "2026-05-01T00:00:00+00:00"
+    assert [m.role for m in view.task.messages] == ["user", "assistant"]
+    assert [m.content for m in view.task.messages] == [
+        "Why is memory high?",
+        "Checked INFO memory.",
+    ]
+    assert len(view.task.tool_calls) == 1
+    assert view.task.tool_calls[0].tool == "redis_info"
+    assert "memory" in view.task.tool_calls[0].args_summary
+
+
+# --- AC: get_feedback_view returns None when known task lacks feedback ----
+
+
+@pytest.mark.asyncio
+async def test_get_feedback_view_returns_none_when_no_record(
+    redis_client, task_factory_with_result
+):
+    """get_feedback_view returns None for a known task with no feedback row."""
+    from redis_sre_agent.core.feedback import get_feedback_view
+
+    task_id = await task_factory_with_result()
+    view = await get_feedback_view(task_id)
+    assert view is None
+
+
+# --- AC: get_feedback_view raises on unknown task -------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_feedback_view_raises_on_unknown_task(redis_client):
+    """get_feedback_view raises TaskNotFoundError when the task doesn't exist."""
+    from redis_sre_agent.core.feedback import get_feedback_view
+
+    bogus = f"tsk-missing-{uuid.uuid4().hex[:8]}"
+    await redis_client.delete(RedisKeys.task_status(bogus))
+    with pytest.raises(TaskNotFoundError):
+        await get_feedback_view(bogus)
+
+
+# --- AC: list_feedback_views applies AND-semantics filters ----------------
+
+
+@pytest.mark.asyncio
+async def test_list_feedback_views_filters_apply_AND(  # noqa: N802 — verb-form name from spec
+    redis_client, task_factory_with_result
+):
+    """Filters (verdict, status) compose with AND-semantics."""
+    from redis_sre_agent.core.feedback import list_feedback_views
+
+    # Seed 4 tasks with all combinations of verdict x status.
+    task_down_done = await task_factory_with_result(status="done")
+    task_down_failed = await task_factory_with_result(status="failed")
+    task_up_done = await task_factory_with_result(status="done")
+    task_up_failed = await task_factory_with_result(status="failed")
+    await submit_feedback(task_down_done, "down", comment="A")
+    await submit_feedback(task_down_failed, "down", comment="B")
+    await submit_feedback(task_up_done, "up", comment="C")
+    await submit_feedback(task_up_failed, "up", comment="D")
+
+    targets = {task_down_done, task_down_failed, task_up_done, task_up_failed}
+
+    # verdict=down AND status=done → only task_down_done.
+    rows = await list_feedback_views(verdict="down", status="done", limit=500)
+    matching = [v for v in rows if v.feedback.task_id in targets]
+    assert {v.feedback.task_id for v in matching} == {task_down_done}
+
+    # verdict=up alone → both up rows.
+    rows = await list_feedback_views(verdict="up", limit=500)
+    matching = [v for v in rows if v.feedback.task_id in targets]
+    assert {v.feedback.task_id for v in matching} == {task_up_done, task_up_failed}
+
+    # status=failed alone → both failed rows.
+    rows = await list_feedback_views(status="failed", limit=500)
+    matching = [v for v in rows if v.feedback.task_id in targets]
+    assert {v.feedback.task_id for v in matching} == {task_down_failed, task_up_failed}
+
+
+# --- AC: list limit clamped to 500 ----------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_feedback_views_limit_clamped_to_500(redis_client, task_factory_with_result):
+    """Asking for limit=10000 returns at most 500 rows."""
+    from redis_sre_agent.core.feedback import list_feedback_views
+
+    # Seed one row so the path exercises the clamp.
+    task_id = await task_factory_with_result()
+    await submit_feedback(task_id, "up")
+
+    rows = await list_feedback_views(limit=10000)
+    assert len(rows) <= 500
+
+
+# --- AC: list uses SCAN not KEYS ------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_feedback_views_uses_scan_not_keys(
+    redis_client, task_factory_with_result, monkeypatch
+):
+    """Patch the client's `.keys` method to raise; list_feedback_views must
+    still succeed (proves the implementation walks via SCAN)."""
+    from redis_sre_agent.core import feedback as fb_mod
+    from redis_sre_agent.core.feedback import list_feedback_views
+
+    task_id = await task_factory_with_result()
+    await submit_feedback(task_id, "up")
+
+    real_client = fb_mod.get_redis_client()
+
+    async def _boom(*_a, **_kw):
+        raise AssertionError("list_feedback_views must NOT call KEYS")
+
+    monkeypatch.setattr(real_client, "keys", _boom, raising=False)
+
+    rows = await list_feedback_views(limit=500)
+    assert any(v.feedback.task_id == task_id for v in rows)
+
+
+# --- AC: OTel spans on reads ----------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_otel_read_spans(redis_client, task_factory_with_result):
+    """`feedback.get` + `feedback.list` spans exist with the expected attributes."""
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+    from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+    from redis_sre_agent.core.feedback import get_feedback_view, list_feedback_views
+
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    new_tracer = provider.get_tracer("test.feedback.read")
+
+    task_id = await task_factory_with_result()
+    await submit_feedback(task_id, "down", comment="for span test")
+
+    with patch("redis_sre_agent.core.feedback.tracer", new_tracer):
+        await get_feedback_view(task_id)
+        await list_feedback_views(verdict="down", status="done", since="1d", limit=10)
+
+    finished = exporter.get_finished_spans()
+    get_spans = [s for s in finished if s.name == "feedback.get"]
+    list_spans = [s for s in finished if s.name == "feedback.list"]
+
+    assert get_spans, "expected a `feedback.get` span"
+    get_attrs = dict(get_spans[0].attributes or {})
+    assert get_attrs.get("task_id") == task_id
+    assert get_attrs.get("sre_agent.category") == "feedback"
+
+    assert list_spans, "expected a `feedback.list` span"
+    list_attrs = dict(list_spans[0].attributes or {})
+    assert list_attrs.get("verdict_filter") == "down"
+    assert list_attrs.get("status_filter") == "done"
+    assert list_attrs.get("since_filter") == "1d"
+    assert "result_count" in list_attrs
+    assert isinstance(list_attrs.get("result_count"), int)
+    assert list_attrs.get("sre_agent.category") == "feedback"

--- a/tests/unit/core/test_keys.py
+++ b/tests/unit/core/test_keys.py
@@ -1,0 +1,15 @@
+"""Unit tests for RedisKeys key construction utilities."""
+
+from redis_sre_agent.core.keys import RedisKeys
+
+
+def test_feedback_task_key_shape():
+    """feedback_task returns the expected key string."""
+    task_id = "01HXYZK7A3PMQX5N9V8RWHTJDF"
+    assert RedisKeys.feedback_task(task_id) == "sre:feedback:task:01HXYZK7A3PMQX5N9V8RWHTJDF"
+
+
+def test_feedback_task_is_static():
+    """feedback_task is callable without instantiation."""
+    key = RedisKeys.feedback_task("abc")
+    assert key == "sre:feedback:task:abc"

--- a/tests/unit/mcp_server/test_feedback_tool.py
+++ b/tests/unit/mcp_server/test_feedback_tool.py
@@ -1,0 +1,227 @@
+"""Tests for the redis_sre_submit_feedback MCP tool (US-007).
+
+Tests use real Redis (skip when unavailable) following the pattern established
+in tests/unit/core/test_feedback.py. The tool is called directly rather than
+through the MCP transport layer, matching the style of TestSkillTools in
+test_mcp_server.py.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import AsyncIterator
+
+import pytest
+import pytest_asyncio
+
+from redis_sre_agent.core.feedback import TaskNotFoundError
+from redis_sre_agent.core.keys import RedisKeys
+from redis_sre_agent.core.redis import get_redis_client
+from redis_sre_agent.mcp_server.server import (
+    redis_sre_get_feedback,
+    redis_sre_list_feedback,
+    redis_sre_submit_feedback,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def redis_client() -> AsyncIterator:
+    """Provide a real Redis client; skip the test if Redis is unreachable."""
+    client = get_redis_client()
+    try:
+        await client.ping()
+    except Exception as exc:
+        pytest.skip(f"Redis unavailable: {exc}")
+    try:
+        yield client
+    finally:
+        await client.aclose()
+
+
+@pytest_asyncio.fixture
+async def task_factory(redis_client):
+    """Create real task-status keys so submit_feedback accepts the task_id.
+
+    Mirrors the fixture in tests/unit/core/test_feedback.py.
+    """
+    created: list[str] = []
+
+    async def _make(*, thread_id: str | None = "thr-test") -> str:
+        task_id = f"tsk-{uuid.uuid4().hex[:12]}"
+        await redis_client.set(RedisKeys.task_status(task_id), "done")
+        mapping: dict = {"created_at": "2026-01-01T00:00:00+00:00"}
+        if thread_id is not None:
+            mapping["thread_id"] = thread_id
+        await redis_client.hset(RedisKeys.task_metadata(task_id), mapping=mapping)
+        created.append(task_id)
+        return task_id
+
+    yield _make
+
+    for task_id in created:
+        await redis_client.delete(
+            RedisKeys.task_status(task_id),
+            RedisKeys.task_metadata(task_id),
+            RedisKeys.feedback_task(task_id),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestMCPSubmitFeedback:
+    """Tests for redis_sre_submit_feedback MCP tool."""
+
+    @pytest.mark.asyncio
+    async def test_mcp_submit_feedback(self, task_factory):
+        """Happy path: returns a FeedbackRecord-shaped dict with correct fields."""
+        task_id = await task_factory()
+
+        result = await redis_sre_submit_feedback(
+            task_id=task_id,
+            verdict="up",
+            comment="Excellent diagnosis",
+        )
+
+        assert isinstance(result, dict)
+        assert result["task_id"] == task_id
+        assert result["verdict"] == "up"
+        assert result["comment"] == "Excellent diagnosis"
+        assert "created_at" in result
+        assert "updated_at" in result
+        # Must not be an error-shaped dict.
+        assert "error" not in result
+        assert "status" not in result
+
+    @pytest.mark.asyncio
+    async def test_mcp_validation_raises(self, task_factory):
+        """Invalid verdict propagates as ValidationError — NOT a success-shaped dict.
+
+        Deliberately verifies the anti-pattern from redis_sre_general_chat
+        (swallowing errors into {"error": ..., "status": "failed"}) is absent.
+        """
+        task_id = await task_factory()
+
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            await redis_sre_submit_feedback(task_id=task_id, verdict="maybe")
+
+        # Confirm the tool has no try/except that would swallow the error: the
+        # exception must propagate, never become {"error": ..., "status": "failed"}.
+
+    @pytest.mark.asyncio
+    async def test_mcp_unknown_task_raises(self):
+        """Non-existent task_id propagates TaskNotFoundError — NOT a success-shaped dict."""
+        bogus_task_id = f"tsk-nonexistent-{uuid.uuid4().hex[:8]}"
+
+        with pytest.raises(TaskNotFoundError):
+            await redis_sre_submit_feedback(task_id=bogus_task_id, verdict="down")
+
+
+# ---------------------------------------------------------------------------
+# Phase-2: redis_sre_get_feedback tests (US-006)
+# ---------------------------------------------------------------------------
+
+
+class TestMCPGetFeedback:
+    """Tests for redis_sre_get_feedback MCP tool."""
+
+    @pytest.mark.asyncio
+    async def test_mcp_get_feedback_success(self, task_factory):
+        """Happy path: returns a FeedbackView-shaped dict with feedback + task keys."""
+        task_id = await task_factory()
+        await redis_sre_submit_feedback(task_id=task_id, verdict="up", comment="Great")
+
+        result = await redis_sre_get_feedback(task_id=task_id)
+
+        assert isinstance(result, dict)
+        assert "feedback" in result
+        assert "task" in result
+        assert result["feedback"]["task_id"] == task_id
+        assert result["feedback"]["verdict"] == "up"
+        assert result["feedback"]["comment"] == "Great"
+
+    @pytest.mark.asyncio
+    async def test_mcp_get_feedback_returns_none_when_no_feedback(self, task_factory):
+        """Known task with no feedback returns None — NOT a success-shaped error dict."""
+        task_id = await task_factory()
+
+        result = await redis_sre_get_feedback(task_id=task_id)
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_mcp_get_feedback_unknown_task_raises(self):
+        """Non-existent task_id propagates TaskNotFoundError — NOT a success-shaped dict."""
+        bogus_task_id = f"tsk-nonexistent-{uuid.uuid4().hex[:8]}"
+
+        with pytest.raises(TaskNotFoundError):
+            await redis_sre_get_feedback(task_id=bogus_task_id)
+
+
+# ---------------------------------------------------------------------------
+# Phase-2: redis_sre_list_feedback tests (US-006)
+# ---------------------------------------------------------------------------
+
+
+class TestMCPListFeedback:
+    """Tests for redis_sre_list_feedback MCP tool."""
+
+    @pytest.mark.asyncio
+    async def test_mcp_list_feedback_returns_items_and_count(self, task_factory):
+        """Two seeded tasks with feedback appear in the result with correct shape."""
+        task_id_1 = await task_factory()
+        task_id_2 = await task_factory()
+        await redis_sre_submit_feedback(task_id=task_id_1, verdict="up")
+        await redis_sre_submit_feedback(task_id=task_id_2, verdict="down")
+
+        result = await redis_sre_list_feedback()
+
+        assert isinstance(result, dict)
+        assert "items" in result
+        assert "count" in result
+        # At least our two seeded items are present (other tests may leave data).
+        assert result["count"] >= 2
+        assert len(result["items"]) == result["count"]
+        # Each item must have feedback + task keys.
+        for item in result["items"]:
+            assert "feedback" in item
+            assert "task" in item
+
+    @pytest.mark.asyncio
+    async def test_mcp_list_feedback_filters(self, task_factory):
+        """Verdict filter returns only matching items."""
+        task_up = await task_factory()
+        task_down_1 = await task_factory()
+        task_down_2 = await task_factory()
+        await redis_sre_submit_feedback(task_id=task_up, verdict="up")
+        await redis_sre_submit_feedback(task_id=task_down_1, verdict="down")
+        await redis_sre_submit_feedback(task_id=task_down_2, verdict="down")
+
+        result = await redis_sre_list_feedback(verdict="down")
+
+        assert isinstance(result, dict)
+        # All returned items must have verdict="down".
+        for item in result["items"]:
+            assert item["feedback"]["verdict"] == "down"
+        # Our two down items must appear.
+        returned_ids = {item["feedback"]["task_id"] for item in result["items"]}
+        assert task_down_1 in returned_ids
+        assert task_down_2 in returned_ids
+        assert task_up not in returned_ids
+
+    @pytest.mark.asyncio
+    async def test_mcp_list_feedback_limit_clamp(self, task_factory):
+        """limit=10000 is clamped to 500; result never exceeds 500 items."""
+        result = await redis_sre_list_feedback(limit=10000)
+
+        assert isinstance(result, dict)
+        assert result["count"] <= 500
+        assert len(result["items"]) <= 500

--- a/tests/unit/mcp_server/test_feedback_tool.py
+++ b/tests/unit/mcp_server/test_feedback_tool.py
@@ -117,8 +117,12 @@ class TestMCPSubmitFeedback:
         # exception must propagate, never become {"error": ..., "status": "failed"}.
 
     @pytest.mark.asyncio
-    async def test_mcp_unknown_task_raises(self):
-        """Non-existent task_id propagates TaskNotFoundError — NOT a success-shaped dict."""
+    async def test_mcp_unknown_task_raises(self, redis_client):
+        """Non-existent task_id propagates TaskNotFoundError — NOT a success-shaped dict.
+
+        Depends on `redis_client` so the test skips cleanly when Redis is unreachable
+        rather than surfacing a ConnectionError from the not-found probe.
+        """
         bogus_task_id = f"tsk-nonexistent-{uuid.uuid4().hex[:8]}"
 
         with pytest.raises(TaskNotFoundError):
@@ -158,8 +162,12 @@ class TestMCPGetFeedback:
         assert result is None
 
     @pytest.mark.asyncio
-    async def test_mcp_get_feedback_unknown_task_raises(self):
-        """Non-existent task_id propagates TaskNotFoundError — NOT a success-shaped dict."""
+    async def test_mcp_get_feedback_unknown_task_raises(self, redis_client):
+        """Non-existent task_id propagates TaskNotFoundError — NOT a success-shaped dict.
+
+        Depends on `redis_client` so the test skips cleanly when Redis is unreachable
+        rather than surfacing a ConnectionError from the not-found probe.
+        """
         bogus_task_id = f"tsk-nonexistent-{uuid.uuid4().hex[:8]}"
 
         with pytest.raises(TaskNotFoundError):

--- a/ui/e2e/feedback.spec.ts
+++ b/ui/e2e/feedback.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 
 // E2E tests for the feedback (thumbs up/down) UI flow.
 //
@@ -10,18 +10,19 @@ import { execSync } from 'child_process';
 const REDIS_PORT = process.env.REDIS_PORT || '7843';
 const BACKEND_URL = process.env.FEEDBACK_TEST_BACKEND_URL || 'http://127.0.0.1:8001';
 
+// execFileSync (argv) avoids spawning a shell, eliminating command-injection risk
+// even for internal test values flagged by CodeQL.
 function redisSet(key: string, value: string) {
-  execSync(`redis-cli -p ${REDIS_PORT} SET "${key}" "${value}"`, { stdio: 'pipe' });
+  execFileSync('redis-cli', ['-p', REDIS_PORT, 'SET', key, value], { stdio: 'pipe' });
 }
 
 function redisHSet(key: string, ...fieldValues: string[]) {
-  const pairs = fieldValues.join(' ');
-  execSync(`redis-cli -p ${REDIS_PORT} HSET "${key}" ${pairs}`, { stdio: 'pipe' });
+  execFileSync('redis-cli', ['-p', REDIS_PORT, 'HSET', key, ...fieldValues], { stdio: 'pipe' });
 }
 
 function redisDel(...keys: string[]) {
   try {
-    execSync(`redis-cli -p ${REDIS_PORT} DEL ${keys.map((k) => `"${k}"`).join(' ')}`, { stdio: 'pipe' });
+    execFileSync('redis-cli', ['-p', REDIS_PORT, 'DEL', ...keys], { stdio: 'pipe' });
   } catch {
     // best-effort cleanup
   }

--- a/ui/e2e/feedback.spec.ts
+++ b/ui/e2e/feedback.spec.ts
@@ -1,0 +1,171 @@
+import { test, expect } from '@playwright/test';
+import { execSync } from 'child_process';
+
+// E2E tests for the feedback (thumbs up/down) UI flow.
+//
+// Seeding strategy: create a thread + task via HTTP (direct to backend), then
+// force task status to "done" via redis-cli so the UI renders FeedbackButtons.
+// This avoids waiting for the agent worker and is deterministic.
+
+const REDIS_PORT = process.env.REDIS_PORT || '7843';
+const BACKEND_URL = process.env.FEEDBACK_TEST_BACKEND_URL || 'http://127.0.0.1:8001';
+
+function redisSet(key: string, value: string) {
+  execSync(`redis-cli -p ${REDIS_PORT} SET "${key}" "${value}"`, { stdio: 'pipe' });
+}
+
+function redisHSet(key: string, ...fieldValues: string[]) {
+  const pairs = fieldValues.join(' ');
+  execSync(`redis-cli -p ${REDIS_PORT} HSET "${key}" ${pairs}`, { stdio: 'pipe' });
+}
+
+function redisDel(...keys: string[]) {
+  try {
+    execSync(`redis-cli -p ${REDIS_PORT} DEL ${keys.map((k) => `"${k}"`).join(' ')}`, { stdio: 'pipe' });
+  } catch {
+    // best-effort cleanup
+  }
+}
+
+async function apiFetch(path: string, options: RequestInit = {}): Promise<any> {
+  const res = await fetch(`${BACKEND_URL}/api/v1${path}`, {
+    headers: { 'Content-Type': 'application/json', ...(options.headers || {}) },
+    ...options,
+  });
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`API ${options.method || 'GET'} ${path} failed: ${res.status} ${body}`);
+  }
+  return res.json();
+}
+
+interface SeedResult {
+  threadId: string;
+  taskId: string;
+}
+
+async function seedCompletedTask(): Promise<SeedResult> {
+  // 1. Create a thread with a user message and an assistant response already in place.
+  const thread = await apiFetch('/threads', {
+    method: 'POST',
+    body: JSON.stringify({
+      subject: 'E2E feedback test thread',
+      user_id: 'e2e-test',
+      messages: [
+        { role: 'user', content: 'E2E feedback: what is Redis memory usage?' },
+        { role: 'assistant', content: 'E2E feedback: Redis memory usage is 42 MB.' },
+      ],
+    }),
+  });
+  const threadId: string = thread.thread_id;
+
+  // 2. Create a task linked to the thread (this writes the status key as "queued").
+  const task = await apiFetch('/tasks', {
+    method: 'POST',
+    body: JSON.stringify({
+      message: 'E2E feedback: what is Redis memory usage?',
+      thread_id: threadId,
+      user_id: 'e2e-test',
+    }),
+  });
+  const taskId: string = task.task_id;
+
+  // 3. Force the task to "done" and write metadata so the feedback module can
+  //    resolve the thread_id (needed for stream publish — non-fatal if absent).
+  redisSet(`sre:task:${taskId}:status`, 'done');
+  redisHSet(`sre:task:${taskId}:metadata`, 'thread_id', threadId, 'user_id', 'e2e-test');
+
+  return { threadId, taskId };
+}
+
+async function cleanupTask(threadId: string, taskId: string) {
+  redisDel(
+    `sre:task:${taskId}:status`,
+    `sre:task:${taskId}:metadata`,
+    `sre:feedback:task:${taskId}`,
+  );
+  try {
+    await apiFetch(`/threads/${threadId}`, { method: 'DELETE' });
+  } catch {
+    // best-effort
+  }
+}
+
+test.describe('Feedback buttons — thumbs up / down flow', () => {
+  let threadId: string;
+  let taskId: string;
+
+  test.beforeAll(async () => {
+    ({ threadId, taskId } = await seedCompletedTask());
+  });
+
+  test.afterAll(async () => {
+    await cleanupTask(threadId, taskId);
+  });
+
+  test('full feedback lifecycle: up → down → withdraw → reload', async ({ page, request }) => {
+    // ── Navigate to Triage with the seeded thread ──────────────────────────
+    await page.goto(`/triage?thread=${encodeURIComponent(threadId)}`);
+
+    // Wait for the static transcript view (no live WebSocket monitor, no Stop button).
+    // The FeedbackButtons appear once the assistant message is rendered.
+    const upBtn = page.getByTestId('feedback-up');
+    const downBtn = page.getByTestId('feedback-down');
+    await expect(upBtn).toBeVisible({ timeout: 30_000 });
+    await expect(downBtn).toBeVisible({ timeout: 30_000 });
+
+    // Both buttons should be inactive initially (no prior feedback).
+    await expect(upBtn).toHaveAttribute('data-active', 'false');
+    await expect(downBtn).toHaveAttribute('data-active', 'false');
+
+    // ── AC-1: Click 👍 — button becomes active ─────────────────────────────
+    // Use waitForResponse to confirm the backend POST has settled before querying.
+    await Promise.all([
+      upBtn.click(),
+      page.waitForResponse((r) => r.url().includes(`/tasks/${taskId}/feedback`) && r.request().method() === 'POST'),
+    ]);
+    await expect(upBtn).toHaveAttribute('data-active', 'true', { timeout: 5_000 });
+    await expect(downBtn).toHaveAttribute('data-active', 'false');
+
+    // Verify backend: GET /api/v1/tasks/{taskId}/feedback → verdict "up"
+    const afterUp = await request.get(`/api/v1/tasks/${taskId}/feedback`);
+    expect(afterUp.ok()).toBe(true);
+    const upRecord = await afterUp.json();
+    expect(upRecord.verdict).toBe('up');
+
+    // ── AC-2: Click 👎 — switches active state to down ────────────────────
+    await Promise.all([
+      downBtn.click(),
+      page.waitForResponse((r) => r.url().includes(`/tasks/${taskId}/feedback`) && r.request().method() === 'POST'),
+    ]);
+    await expect(downBtn).toHaveAttribute('data-active', 'true', { timeout: 5_000 });
+    await expect(upBtn).toHaveAttribute('data-active', 'false');
+
+    // Verify backend: verdict now "down"
+    const afterDown = await request.get(`/api/v1/tasks/${taskId}/feedback`);
+    expect(afterDown.ok()).toBe(true);
+    const downRecord = await afterDown.json();
+    expect(downRecord.verdict).toBe('down');
+
+    // ── AC-3: Click 👎 again (same verdict) — withdraws ───────────────────
+    await Promise.all([
+      downBtn.click(),
+      page.waitForResponse((r) => r.url().includes(`/tasks/${taskId}/feedback`) && r.request().method() === 'POST'),
+    ]);
+    await expect(downBtn).toHaveAttribute('data-active', 'false', { timeout: 5_000 });
+    await expect(upBtn).toHaveAttribute('data-active', 'false');
+
+    // Verify backend: verdict now "withdrawn"
+    const afterWithdraw = await request.get(`/api/v1/tasks/${taskId}/feedback`);
+    expect(afterWithdraw.ok()).toBe(true);
+    const withdrawRecord = await afterWithdraw.json();
+    expect(withdrawRecord.verdict).toBe('withdrawn');
+
+    // ── AC-4: Reload — no button active (withdrawn state persists) ─────────
+    await page.goto(`/triage?thread=${encodeURIComponent(threadId)}`);
+    await expect(upBtn).toBeVisible({ timeout: 30_000 });
+    await expect(downBtn).toBeVisible({ timeout: 30_000 });
+    await expect(upBtn).toHaveAttribute('data-active', 'false');
+    await expect(downBtn).toHaveAttribute('data-active', 'false');
+  });
+});

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1728,9 +1728,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1748,9 +1745,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1768,9 +1762,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1788,9 +1779,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1808,9 +1796,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1828,9 +1813,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11582,9 +11564,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -11606,9 +11585,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -11630,9 +11606,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -11654,9 +11627,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/ui/src/pages/Triage.tsx
+++ b/ui/src/pages/Triage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, useCallback } from "react";
 import { useSearchParams } from "react-router-dom";
 import { Card, CardHeader, CardContent, Button } from "@radar/ui-kit";
 import { ConfirmDialog } from "../components/Modal";
@@ -7,6 +7,8 @@ import MemoryPanel from "../components/MemoryPanel";
 import TaskMonitor from "../components/TaskMonitor";
 import sreAgentApi, {
   ApprovalRecord,
+  FeedbackRecord,
+  FeedbackVerdict,
   PendingApprovalSummary,
   RedisCluster,
   RedisInstance,
@@ -26,6 +28,85 @@ const ErrorMessage = ({ message }: { message: string }) => (
     {message}
   </div>
 );
+
+interface FeedbackButtonsProps {
+  taskId: string;
+  initialVerdict?: FeedbackVerdict | null;
+  onError: (msg: string) => void;
+}
+
+const FeedbackButtons = ({
+  taskId,
+  initialVerdict,
+  onError,
+}: FeedbackButtonsProps) => {
+  const [verdict, setVerdict] = useState<FeedbackVerdict | null>(
+    initialVerdict ?? null,
+  );
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleClick = useCallback(
+    async (clicked: "up" | "down") => {
+      if (isSubmitting) return;
+      // Clicking the already-active verdict withdraws it
+      const nextVerdict: FeedbackVerdict =
+        verdict === clicked ? "withdrawn" : clicked;
+      const optimistic = nextVerdict === "withdrawn" ? null : nextVerdict;
+      const previous = verdict;
+      setVerdict(optimistic);
+      setIsSubmitting(true);
+      try {
+        const record = await sreAgentApi.submitFeedback(taskId, nextVerdict);
+        setVerdict(record.verdict === "withdrawn" ? null : record.verdict);
+      } catch (err) {
+        setVerdict(previous);
+        onError(
+          `Failed to submit feedback: ${err instanceof Error ? err.message : "Unknown error"}`,
+        );
+      } finally {
+        setIsSubmitting(false);
+      }
+    },
+    [taskId, verdict, isSubmitting, onError],
+  );
+
+  return (
+    <div className="flex items-center gap-2 mt-2">
+      <button
+        data-testid="feedback-up"
+        data-active={verdict === "up" ? "true" : "false"}
+        onClick={() => handleClick("up")}
+        disabled={isSubmitting}
+        title="Helpful"
+        className={`text-lg px-2 py-1 rounded transition-colors ${
+          isSubmitting ? "opacity-40 cursor-not-allowed" : "cursor-pointer"
+        } ${
+          verdict === "up"
+            ? "bg-green-100 text-green-700 border border-green-300"
+            : "hover:bg-redis-dusk-08 text-redis-dusk-04"
+        }`}
+      >
+        👍
+      </button>
+      <button
+        data-testid="feedback-down"
+        data-active={verdict === "down" ? "true" : "false"}
+        onClick={() => handleClick("down")}
+        disabled={isSubmitting}
+        title="Not helpful"
+        className={`text-lg px-2 py-1 rounded transition-colors ${
+          isSubmitting ? "opacity-40 cursor-not-allowed" : "cursor-pointer"
+        } ${
+          verdict === "down"
+            ? "bg-red-100 text-red-700 border border-red-300"
+            : "hover:bg-redis-dusk-08 text-redis-dusk-04"
+        }`}
+      >
+        👎
+      </button>
+    </div>
+  );
+};
 
 /**
  * Extract human-readable operation name from full tool name.
@@ -109,6 +190,9 @@ const Triage = () => {
     return window.localStorage.getItem("triage.showMemoryPanel") === "1";
   });
   const [memoryRefreshKey, setMemoryRefreshKey] = useState(0);
+  const [threadFeedback, setThreadFeedback] = useState<FeedbackRecord | null>(
+    null,
+  );
 
   useEffect(() => {
     if (typeof window === "undefined") return;
@@ -563,6 +647,7 @@ const Triage = () => {
     setShowNewConversation(false);
     setLiveModeLocked(sidebarActive);
     setShowWebSocketMonitor(sidebarActive);
+    setThreadFeedback(null);
     resetApprovalState();
 
     // On mobile only, switch to chat view
@@ -625,8 +710,15 @@ const Triage = () => {
       if (status.task_id) {
         const approvals = await sreAgentApi.getTaskApprovals(status.task_id);
         setApprovalHistory(approvals);
+        try {
+          const feedback = await sreAgentApi.getFeedback(status.task_id);
+          setThreadFeedback(feedback);
+        } catch {
+          setThreadFeedback(null);
+        }
       } else {
         setApprovalHistory([]);
+        setThreadFeedback(null);
       }
       if (!liveModeLocked) setShowWebSocketMonitor(active);
     } catch (err) {
@@ -1436,6 +1528,20 @@ const Triage = () => {
                           </div>
                         ))
                       )}
+                      {!isThreadBusy &&
+                        !showWebSocketMonitor &&
+                        activeTaskId &&
+                        messages.some((m) => m.role === "assistant") && (
+                          <div className="flex justify-start pl-0">
+                            <FeedbackButtons
+                              taskId={activeTaskId}
+                              initialVerdict={
+                                threadFeedback?.verdict ?? null
+                              }
+                              onError={(msg) => setError(msg)}
+                            />
+                          </div>
+                        )}
                       {isThreadBusy && (
                         <div className="text-redis-xs text-redis-dusk-04">
                           Task is running. Press Stop to cancel before sending a

--- a/ui/src/services/sreAgentApi.ts
+++ b/ui/src/services/sreAgentApi.ts
@@ -1,4 +1,15 @@
 // SRE Agent API service - Task-based implementation
+
+export type FeedbackVerdict = "up" | "down" | "withdrawn";
+
+export interface FeedbackRecord {
+  task_id: string;
+  verdict: FeedbackVerdict;
+  comment: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
 export interface ChatMessage {
   role: "user" | "assistant" | "tool" | "system";
   content: string;
@@ -72,6 +83,7 @@ export interface TaskStatusResponse {
   error_message?: string;
   pending_approval?: PendingApprovalSummary | null;
   resume_supported: boolean;
+  feedback?: FeedbackRecord | null;
   metadata: {
     created_at: string;
     updated_at: string;
@@ -1575,6 +1587,40 @@ class SREAgentAPI {
       throw new Error(
         `Failed to reset knowledge settings: ${response.statusText}`,
       );
+    }
+    return response.json();
+  }
+
+  async submitFeedback(
+    taskId: string,
+    verdict: FeedbackVerdict,
+    comment?: string,
+  ): Promise<FeedbackRecord> {
+    const response = await fetch(
+      `${this.tasksBaseUrl}/tasks/${taskId}/feedback`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ verdict, comment: comment ?? null }),
+      },
+    );
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`HTTP ${response.status}: ${errorText}`);
+    }
+    return response.json();
+  }
+
+  async getFeedback(taskId: string): Promise<FeedbackRecord | null> {
+    const response = await fetch(
+      `${this.tasksBaseUrl}/tasks/${taskId}/feedback`,
+    );
+    if (response.status === 404) {
+      return null;
+    }
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`HTTP ${response.status}: ${errorText}`);
     }
     return response.json();
   }


### PR DESCRIPTION
## Summary
- new `core/feedback` module with HSETNX-anchored writes captures 👍/👎/withdrawn verdicts on completed agent tasks (anonymous, last-write-wins, idempotent resubmit, withdrawal preserved as a verdict value)
- exposed on four surfaces: HTTP routes (single + list with verdict/status/since/limit filters), MCP tools (submit/get/list), CLI subgroup (`feedback up|down|withdraw|show|list` with jsonl + table output), and 👍/👎 buttons on the Triage UI
- every read path returns a joined `FeedbackView` (feedback + trimmed task info: messages and `tool_calls` with raw outputs stripped); a shared `_filter_feedback_views` helper is the single drift-protection source of truth, asserted by a cross-surface contract test
- new `feedback_submitted` event published on the existing per-thread Redis Streams after every successful write; OpenTelemetry spans under a new `SpanCategory.FEEDBACK`
- usage documented in `docs/how-to/feedback.md` with cross-references from `docs/how-to/api.md`, `docs/how-to/cli.md`, `AGENTS.md`, and `README.md`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New anonymous write API and Redis-backed persistence on task paths; list uses SCAN with pipelined reads—moderate surface area but well-tested and isolated from core agent execution.
> 
> **Overview**
> Adds **anonymous thumbs-up / thumbs-down / withdrawn feedback** on completed agent tasks, with a single write path in `core/feedback.py` (Redis hash `sre:feedback:task:{task_id}`, `HSETNX`-anchored `created_at`, last-write-wins, idempotent identical resubmits).
> 
> **Surfaces:** HTTP (`POST`/`GET` per task, `GET /api/v1/feedback` list with filters), MCP (`redis_sre_submit_feedback`, get, list), CLI `feedback` subgroup, and Triage **👍/👎** controls (toggle active verdict or withdraw). Reads return a joined **`FeedbackView`** (feedback + trimmed task context); list filtering is centralized in `_filter_feedback_views` with contract tests across HTTP/MCP/CLI.
> 
> **Integration:** Optional `feedback` on task GET (Redis errors fail open); `feedback_submitted` stream events after writes; `SpanCategory.FEEDBACK`; docs and broad unit/API/E2E coverage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c671d47b76d1ffb3d7ba6a812647a8076822403. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->