### PR TITLE
Fix dashboard URL construction when API base is relative

### DIFF
--- a/ui/src/services/sreAgentApi.ts
+++ b/ui/src/services/sreAgentApi.ts
@@ -1037,7 +1037,7 @@ class SREAgentAPI {
 
   // Cluster Management Methods
   async listClusters(params?: ListClustersParams): Promise<ClusterListResponse> {
-    const url = new URL(`${this.tasksBaseUrl}/clusters`);
+    const url = this.createURL(`${this.tasksBaseUrl}/clusters`);
 
     if (params) {
       if (params.environment)
@@ -1128,7 +1128,7 @@ class SREAgentAPI {
   async listInstances(
     params?: ListInstancesParams,
   ): Promise<InstanceListResponse> {
-    const url = new URL(`${this.tasksBaseUrl}/instances`);
+    const url = this.createURL(`${this.tasksBaseUrl}/instances`);
 
     if (params) {
       if (params.environment)


### PR DESCRIPTION
## Summary

- Route `listInstances` and `listClusters` through `createURL`, which supplies `window.location.origin` as the base.
- Fixes `TypeError: Failed to construct URL: Invalid URL` on the dashboard when the bundles `VITE_API_BASE_URL` resolves to the relative `/api/v1` fallback (e.g., production deployments where the env var was set at Pod runtime instead of image build time).

Closes #184

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted client fix aligned with existing URL helper; no auth or server changes.
> 
> **Overview**
> **Fixes dashboard crashes** when listing clusters or instances if the API base is a relative path like `/api/v1` (e.g. production with runtime env instead of build-time `VITE_API_BASE_URL`).
> 
> `listClusters` and `listInstances` now build URLs via `createURL` instead of `new URL(...)`, so the browser uses `window.location.origin` as the base—matching `listTasks` and `listThreads` and avoiding `TypeError: Failed to construct 'URL': Invalid URL`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e5e578d62a8c6715cdcb2376cfdaca96261a298. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->