### PR TITLE
Complete chat turns after max iterations

### DIFF
--- a/evals/goldens/prompt/chat-max-iteration-terminal-response/assertions.json
+++ b/evals/goldens/prompt/chat-max-iteration-terminal-response/assertions.json
@@ -1,0 +1,23 @@
+{
+  "required_tool_calls": [
+    {
+      "provider_family": "mcp",
+      "server_name": "max_iteration_fixture",
+      "operation": "get_cluster_health"
+    }
+  ],
+  "forbidden_tool_calls": [],
+  "required_response_patterns": [
+    "(?i)degraded",
+    "(?i)memory"
+  ],
+  "required_findings": [
+    "cluster health is degraded",
+    "memory check failed"
+  ],
+  "forbidden_claims": [
+    "I couldn't process that query. Please try rephrasing."
+  ],
+  "required_sources": [],
+  "expected_routing_decision": "chat"
+}

--- a/evals/goldens/prompt/chat-max-iteration-terminal-response/expected.md
+++ b/evals/goldens/prompt/chat-max-iteration-terminal-response/expected.md
@@ -1,0 +1,3 @@
+The turn should still end with a useful answer.
+
+The gathered health evidence shows `checkout-cache-prod` is degraded. The failing check is memory-related: fragmentation is elevated and eviction pressure is active. Because the iteration budget was exhausted before a normal final response was emitted, the answer should clearly identify the evidence gathered and note that further diagnosis remains incomplete.

--- a/evals/goldens/prompt/chat-max-iteration-terminal-response/metadata.yaml
+++ b/evals/goldens/prompt/chat-max-iteration-terminal-response/metadata.yaml
@@ -1,0 +1,12 @@
+scenario_id: prompt/chat-max-iteration-terminal-response
+review_status: reviewed
+reviewed_by: sre-evals
+expectation_basis: human_authored
+source_pack: prompt-core
+source_pack_version: "2026-04-14"
+baseline_policy:
+  mode: deterministic
+  update_allowed: false
+notes:
+  - Regression for issue 165: exhausting the chat iteration budget must not return the generic fallback.
+  - The final answer should be synthesized from gathered tool evidence when no terminal assistant text exists.

--- a/evals/scenarios/prompt/chat-max-iteration-terminal-response/fixtures/tools/cluster-health.json
+++ b/evals/scenarios/prompt/chat-max-iteration-terminal-response/fixtures/tools/cluster-health.json
@@ -1,0 +1,11 @@
+{
+  "cluster": "checkout-cache-prod",
+  "failed_checks": [
+    {
+      "check": "memory",
+      "detail": "memory fragmentation is elevated and eviction pressure is active",
+      "severity": "warning"
+    }
+  ],
+  "status": "degraded"
+}

--- a/evals/scenarios/prompt/chat-max-iteration-terminal-response/scenario.yaml
+++ b/evals/scenarios/prompt/chat-max-iteration-terminal-response/scenario.yaml
@@ -1,0 +1,58 @@
+id: prompt/chat-max-iteration-terminal-response
+name: Chat max iteration terminal response
+description: Exercise the chat agent path where the iteration budget is exhausted after tool evidence is gathered but before terminal assistant text is emitted.
+provenance:
+  source_kind: synthetic
+  source_pack: prompt-core
+  source_pack_version: 2026-04-14
+  derived_from:
+    - redis_sre_agent.agent.chat_agent.ChatAgent.process_query
+    - https://github.com/redis-applied-ai/redis-sre-agent/issues/165
+  synthetic:
+    is_synthetic: true
+    method: issue-regression-fixture
+  golden:
+    expectation_basis: human_authored
+    exemplar_sources:
+      - evals/goldens/prompt/chat-max-iteration-terminal-response/expected.md
+    review_status: reviewed
+    reviewed_by: sre-evals
+execution:
+  lane: agent_only
+  agent: redis_chat
+  query: >
+    The checkout cache health check keeps looping through tools. If you hit the
+    turn budget after getting health evidence, still give me the best answer
+    you can from what you gathered.
+  max_tool_steps: 1
+  llm_mode: replay
+knowledge:
+  mode: disabled
+  version: latest
+tools:
+  mcp_servers:
+    max_iteration_fixture:
+      capability: diagnostics
+      tools:
+        get_cluster_health:
+          description: Return synthetic checkout cache health evidence.
+          input_schema:
+            type: object
+            properties:
+              cluster:
+                type: string
+          result: fixtures/tools/cluster-health.json
+expectations:
+  required_tool_calls:
+    - provider_family: mcp
+      server_name: max_iteration_fixture
+      operation: get_cluster_health
+  required_response_patterns:
+    - (?i)degraded
+    - (?i)memory
+  required_findings:
+    - cluster health is degraded
+    - memory check failed
+  forbidden_claims:
+    - I couldn't process that query. Please try rephrasing.
+  expected_routing_decision: chat

--- a/redis_sre_agent/agent/chat_agent.py
+++ b/redis_sre_agent/agent/chat_agent.py
@@ -403,6 +403,8 @@ class ChatAgent:
 
     # Threshold for summarizing tool outputs (chars)
     ENVELOPE_SUMMARY_THRESHOLD = 500
+    ITERATION_LIMIT_SYNTHESIS_MESSAGE_LIMIT = 14
+    ITERATION_LIMIT_SYNTHESIS_CONTEXT_LIMIT = 16000
     SKILL_CONTRACT_REPAIR_ATTEMPT_LIMIT = 1
 
     def _can_attempt_skill_contract_repair(self, state: Dict[str, Any]) -> bool:
@@ -756,6 +758,175 @@ class ChatAgent:
             response_text=response_text,
             tool_envelopes=tool_envelopes,
             messages=messages,
+        )
+
+    @staticmethod
+    def _reached_iteration_limit(
+        final_state: Dict[str, Any], requested_max_iterations: int
+    ) -> bool:
+        iteration_count = final_state.get("iteration_count")
+        max_iterations = final_state.get("max_iterations", requested_max_iterations)
+        if not isinstance(iteration_count, int) or not isinstance(max_iterations, int):
+            return False
+        return iteration_count >= max_iterations
+
+    @staticmethod
+    def _truncate_iteration_limit_text(text: str, max_chars: int) -> str:
+        if len(text) <= max_chars:
+            return text
+        omitted = len(text) - max_chars
+        return f"{text[:max_chars].rstrip()}\n... [truncated {omitted} chars]"
+
+    def _format_iteration_limit_messages(self, messages: List[BaseMessage]) -> str:
+        visible_messages = [
+            message for message in messages if not isinstance(message, SystemMessage)
+        ]
+        if not visible_messages:
+            return "No non-system conversation messages were captured."
+
+        selected_messages = visible_messages[-self.ITERATION_LIMIT_SYNTHESIS_MESSAGE_LIMIT :]
+        omitted_count = len(visible_messages) - len(selected_messages)
+        lines: List[str] = []
+        if omitted_count > 0:
+            lines.append(f"... [{omitted_count} earlier conversation messages omitted]")
+
+        for message in selected_messages:
+            role = getattr(message, "type", None) or message.__class__.__name__
+            header = str(role)
+
+            tool_calls = getattr(message, "tool_calls", None) or []
+            tool_names: List[str] = []
+            for tool_call in tool_calls:
+                if isinstance(tool_call, dict):
+                    name = tool_call.get("name")
+                else:
+                    name = getattr(tool_call, "name", None)
+                if name:
+                    tool_names.append(str(name))
+            if tool_names:
+                header = f"{header} requested tools: {', '.join(tool_names)}"
+
+            tool_name = getattr(message, "name", None)
+            if isinstance(message, ToolMessage) and tool_name:
+                header = f"{header} ({tool_name})"
+
+            content = coerce_response_text(getattr(message, "content", None))
+            if not content:
+                content = "(no text content)"
+            content = self._truncate_iteration_limit_text(content, 2000)
+            lines.append(f"{header}:\n{content}")
+
+        transcript = "\n\n".join(lines)
+        return self._truncate_iteration_limit_text(
+            transcript,
+            self.ITERATION_LIMIT_SYNTHESIS_CONTEXT_LIMIT,
+        )
+
+    def _format_iteration_limit_tool_evidence(
+        self,
+        tool_envelopes: List[Dict[str, Any]],
+    ) -> str:
+        if not tool_envelopes:
+            return "No structured tool result envelopes were captured."
+
+        lines: List[str] = []
+        selected_envelopes = tool_envelopes[-8:]
+        omitted_count = len(tool_envelopes) - len(selected_envelopes)
+        if omitted_count > 0:
+            lines.append(f"... [{omitted_count} earlier tool result envelopes omitted]")
+
+        for envelope in selected_envelopes:
+            tool_key = envelope.get("tool_key") or envelope.get("name") or "unknown_tool"
+            summary = envelope.get("summary")
+            if summary:
+                payload = str(summary)
+            else:
+                payload = json.dumps(envelope.get("data", {}), default=str, sort_keys=True)
+            payload = self._truncate_iteration_limit_text(payload, 2000)
+            lines.append(f"{tool_key}:\n{payload}")
+
+        evidence = "\n\n".join(lines)
+        return self._truncate_iteration_limit_text(
+            evidence,
+            self.ITERATION_LIMIT_SYNTHESIS_CONTEXT_LIMIT,
+        )
+
+    @staticmethod
+    def _iteration_limit_failure_response(
+        *,
+        iteration_count: int,
+        max_iterations: int,
+        messages: List[BaseMessage],
+        tool_envelopes: List[Dict[str, Any]],
+    ) -> str:
+        gathered: List[str] = []
+        if messages:
+            gathered.append(f"{len(messages)} conversation message(s)")
+        if tool_envelopes:
+            gathered.append(f"{len(tool_envelopes)} tool result envelope(s)")
+        gathered_text = ", ".join(gathered) if gathered else "no usable intermediate state"
+        return (
+            f"I reached the chat iteration limit ({iteration_count}/{max_iterations}) "
+            "before producing a final answer. I was trying to answer the current request "
+            f"and had gathered {gathered_text}. The final synthesis step did not return "
+            "usable text, so I cannot complete the turn cleanly from the captured state."
+        )
+
+    async def _synthesize_iteration_limit_response(
+        self,
+        *,
+        messages: List[BaseMessage],
+        tool_envelopes: List[Dict[str, Any]],
+        iteration_count: int,
+        max_iterations: int,
+    ) -> str:
+        """Produce a terminal answer after the graph loop exhausts its turn budget."""
+        synthesis_messages: List[BaseMessage] = [
+            SystemMessage(
+                content=(
+                    "The chat workflow stopped because it reached its iteration budget "
+                    "before emitting terminal assistant text. Write the best possible final "
+                    "answer from the gathered conversation and tool evidence. Do not call "
+                    "tools. Do not claim evidence that is not present. If the evidence is "
+                    "incomplete, say what was gathered and what remains uncertain."
+                )
+            ),
+            HumanMessage(
+                content=(
+                    f"Iteration budget: {iteration_count}/{max_iterations}\n\n"
+                    "Conversation tail:\n"
+                    f"{self._format_iteration_limit_messages(messages)}\n\n"
+                    "Structured tool evidence:\n"
+                    f"{self._format_iteration_limit_tool_evidence(tool_envelopes)}"
+                )
+            ),
+        ]
+
+        try:
+            synthesized = await self.llm.ainvoke(synthesis_messages)
+        except Exception as exc:
+            logger.warning(
+                "Chat agent max-iteration synthesis failed: %s",
+                _format_exception_message(exc),
+                exc_info=True,
+            )
+            return self._iteration_limit_failure_response(
+                iteration_count=iteration_count,
+                max_iterations=max_iterations,
+                messages=messages,
+                tool_envelopes=tool_envelopes,
+            )
+
+        response_text = coerce_response_text(getattr(synthesized, "content", ""))
+        if response_text:
+            return response_text
+
+        logger.warning("Chat agent max-iteration synthesis returned no text")
+        return self._iteration_limit_failure_response(
+            iteration_count=iteration_count,
+            max_iterations=max_iterations,
+            messages=messages,
+            tool_envelopes=tool_envelopes,
         )
 
     def _build_workflow(
@@ -1286,6 +1457,26 @@ User Query: {query}"""
                             tool_envelopes=tool_envelopes,
                             messages=messages,
                             final_state=final_state,
+                        )
+                        response = AgentResponse(
+                            response=response_text,
+                            tool_envelopes=tool_envelopes,
+                        )
+                        await prepared_memory.persist_response_fail_open(response.response)
+                        return response
+
+                    if self._reached_iteration_limit(final_state, max_iterations):
+                        iteration_count = final_state.get("iteration_count", max_iterations)
+                        state_max_iterations = final_state.get("max_iterations", max_iterations)
+                        if not isinstance(iteration_count, int):
+                            iteration_count = max_iterations
+                        if not isinstance(state_max_iterations, int):
+                            state_max_iterations = max_iterations
+                        response_text = await self._synthesize_iteration_limit_response(
+                            messages=messages,
+                            tool_envelopes=tool_envelopes,
+                            iteration_count=iteration_count,
+                            max_iterations=state_max_iterations,
                         )
                         response = AgentResponse(
                             response=response_text,

--- a/tests/unit/agent/test_chat_agent.py
+++ b/tests/unit/agent/test_chat_agent.py
@@ -1773,6 +1773,108 @@ class TestChatAgentStartupContext:
     @pytest.mark.asyncio
     @patch("redis_sre_agent.agent.chat_agent.create_llm")
     @patch("redis_sre_agent.agent.chat_agent.create_mini_llm")
+    async def test_process_query_synthesizes_response_after_iteration_limit(
+        self, mock_create_mini_llm, mock_create_llm
+    ):
+        mock_llm = MagicMock()
+        mock_llm.bind_tools.return_value = mock_llm
+        mock_llm.ainvoke = AsyncMock(
+            return_value=AIMessage(content="Best-effort answer from gathered evidence.")
+        )
+        mock_create_llm.return_value = mock_llm
+        mock_create_mini_llm.return_value = mock_llm
+
+        agent = ChatAgent()
+
+        prepared_memory = PreparedAgentTurnMemory(
+            memory_service=MagicMock(),
+            memory_context=TurnMemoryContext(
+                system_prompt=None,
+                user_working_memory=None,
+                asset_working_memory=None,
+            ),
+            session_id="test-session",
+            user_id=None,
+            query="Is the cluster healthy?",
+            instance_id=None,
+            cluster_id=None,
+            emitter=None,
+        )
+        prepared_memory.persist_response_fail_open = AsyncMock()
+
+        mock_tool_manager = MagicMock()
+        mock_tool_manager.__aenter__.return_value = mock_tool_manager
+        mock_tool_manager.__aexit__.return_value = None
+        mock_tool_manager.get_tools.return_value = []
+        mock_tool_manager.get_toolset_generation.return_value = 1
+
+        tool_envelopes = [
+            {
+                "tool_key": "get_cluster_health",
+                "name": "get_cluster_health",
+                "data": {"status": "degraded", "failed_checks": ["memory"]},
+            }
+        ]
+        fake_app = AsyncMock()
+        fake_app.ainvoke.return_value = {
+            "messages": [
+                HumanMessage(content="Is the cluster healthy?"),
+                AIMessage(
+                    content="",
+                    tool_calls=[
+                        {
+                            "id": "call-1",
+                            "name": "get_cluster_health",
+                            "args": {},
+                        }
+                    ],
+                ),
+                ToolMessage(
+                    content='{"status": "degraded", "failed_checks": ["memory"]}',
+                    tool_call_id="call-1",
+                    name="get_cluster_health",
+                ),
+            ],
+            "signals_envelopes": tool_envelopes,
+            "iteration_count": 2,
+            "max_iterations": 2,
+        }
+        fake_workflow = MagicMock()
+        fake_workflow.compile.return_value = fake_app
+
+        with (
+            patch(
+                "redis_sre_agent.agent.chat_agent.prepare_agent_turn_memory",
+                AsyncMock(return_value=prepared_memory),
+            ),
+            patch(
+                "redis_sre_agent.agent.chat_agent.ToolManager",
+                return_value=mock_tool_manager,
+            ),
+            patch(
+                "redis_sre_agent.agent.chat_agent.build_startup_knowledge_context",
+                new=AsyncMock(return_value=""),
+            ),
+            patch.object(agent, "_build_workflow", return_value=fake_workflow),
+        ):
+            response = await agent.process_query(
+                query="Is the cluster healthy?",
+                session_id="test-session",
+                user_id=None,
+                max_iterations=2,
+            )
+
+        assert response.response == "Best-effort answer from gathered evidence."
+        assert response.tool_envelopes == tool_envelopes
+        prepared_memory.persist_response_fail_open.assert_awaited_once_with(response.response)
+        mock_llm.ainvoke.assert_awaited_once()
+        synthesis_messages = mock_llm.ainvoke.await_args.args[0]
+        assert "Iteration budget: 2/2" in str(synthesis_messages[-1].content)
+        assert "get_cluster_health" in str(synthesis_messages[-1].content)
+
+    @pytest.mark.asyncio
+    @patch("redis_sre_agent.agent.chat_agent.create_llm")
+    @patch("redis_sre_agent.agent.chat_agent.create_mini_llm")
     async def test_process_query_rejects_blank_terminal_ai_message(
         self, mock_create_mini_llm, mock_create_llm
     ):

--- a/tests/unit/evaluation/test_prompt_scenarios.py
+++ b/tests/unit/evaluation/test_prompt_scenarios.py
@@ -3,13 +3,17 @@ from __future__ import annotations
 import json
 from datetime import date, datetime
 from types import SimpleNamespace
+from unittest.mock import patch
 
 import pytest
 import yaml
+from langchain_core.messages import AIMessage
 
 from redis_sre_agent.agent.knowledge_context import build_startup_knowledge_context
 from redis_sre_agent.core.instances import RedisInstance
 from redis_sre_agent.evaluation.agent_only import run_agent_only_scenario
+from redis_sre_agent.evaluation.assertions import score_structured_assertions
+from redis_sre_agent.evaluation.fake_mcp import build_fixture_mcp_runtime
 from redis_sre_agent.evaluation.fixture_layout import (
     CORPORA_ROOT,
     golden_assertions_path,
@@ -18,10 +22,14 @@ from redis_sre_agent.evaluation.fixture_layout import (
     scenario_manifest_path,
     shared_fixtures_dir,
 )
+from redis_sre_agent.evaluation.injection import eval_injection_scope
 from redis_sre_agent.evaluation.knowledge_backend import build_fixture_knowledge_backend
 from redis_sre_agent.evaluation.runtime import load_eval_scenario
 from redis_sre_agent.evaluation.scenarios import ExecutionLane, KnowledgeMode
-from redis_sre_agent.evaluation.tool_runtime import build_fixture_tool_runtime
+from redis_sre_agent.evaluation.tool_runtime import (
+    FixtureBehaviorState,
+    build_fixture_tool_runtime,
+)
 from redis_sre_agent.tools.models import Tool, ToolCapability, ToolDefinition, ToolMetadata
 from redis_sre_agent.tools.protocols import ToolProvider
 
@@ -76,6 +84,46 @@ class _FakeKnowledgeAgent:
             }
         )
         return SimpleNamespace(response="boundary stated", tool_envelopes=[])
+
+
+class _LoopingToolLLM:
+    def __init__(self) -> None:
+        self.bound_tool_names: list[str] = []
+        self.invocations: list[list] = []
+
+    def bind_tools(self, tools):
+        self.bound_tool_names = [
+            str(getattr(tool, "name", "")) for tool in tools if getattr(tool, "name", "")
+        ]
+        return self
+
+    def _health_tool_name(self) -> str:
+        for name in self.bound_tool_names:
+            if name.endswith("_get_cluster_health"):
+                return name
+        raise AssertionError(f"health tool was not bound: {self.bound_tool_names}")
+
+    async def ainvoke(self, messages):
+        self.invocations.append(list(messages))
+        call_number = len(self.invocations)
+        if call_number <= 2:
+            return AIMessage(
+                content="",
+                tool_calls=[
+                    {
+                        "id": f"health-call-{call_number}",
+                        "name": self._health_tool_name(),
+                        "args": {"cluster": "checkout-cache-prod"},
+                    }
+                ],
+            )
+
+        return AIMessage(
+            content=(
+                "Cluster health is degraded. Memory check failed: memory fragmentation "
+                "is elevated and eviction pressure is active."
+            )
+        )
 
 
 def _normalize_loaded_date(value):
@@ -467,3 +515,61 @@ def test_prompt_scenario_corpora_ship_authoritative_manifests_and_core_fixtures(
     assert (
         shared_fixtures_dir("startup/policies") / "target-discovery-before-live-access.md"
     ).exists()
+
+
+@pytest.mark.asyncio
+async def test_chat_max_iteration_terminal_response_eval_regression():
+    scenario_id = "chat-max-iteration-terminal-response"
+    scenario = load_eval_scenario(scenario_manifest_path("prompt", scenario_id))
+    metadata = yaml.safe_load(
+        golden_metadata_path("prompt", scenario_id).read_text(encoding="utf-8")
+    )
+    assertions = json.loads(golden_assertions_path("prompt", scenario_id).read_text("utf-8"))
+    assert metadata["scenario_id"] == scenario.id
+    assert metadata["source_pack"] == scenario.provenance.source_pack
+    assert _normalize_loaded_date(metadata["source_pack_version"]) == "2026-04-14"
+    assert _normalize_assertion_payload(assertions) == _normalized_expectations(scenario)
+    assert golden_expected_response_path("prompt", scenario_id).read_text("utf-8").strip()
+
+    behavior_state = FixtureBehaviorState()
+    mcp_runtime = build_fixture_mcp_runtime(scenario, state=behavior_state)
+    assert mcp_runtime is not None
+
+    fake_llm = _LoopingToolLLM()
+    with (
+        eval_injection_scope(
+            knowledge_backend=build_fixture_knowledge_backend(scenario),
+            mcp_servers=mcp_runtime.get_server_configs(),
+            mcp_runtime=mcp_runtime,
+        ),
+        patch("redis_sre_agent.agent.chat_agent.create_llm", return_value=fake_llm),
+        patch("redis_sre_agent.agent.chat_agent.create_mini_llm", return_value=fake_llm),
+    ):
+        result = await run_agent_only_scenario(
+            scenario,
+            session_id="eval::prompt::chat-max-iteration-terminal-response",
+            user_id="eval-regression",
+        )
+
+    response = result.response
+    assert response.response != "I couldn't process that query. Please try rephrasing."
+    assert len(fake_llm.invocations) == 3
+    synthesis_prompt = str(fake_llm.invocations[-1][-1].content)
+    assert "Iteration budget: 2/2" in synthesis_prompt
+    assert "get_cluster_health" in synthesis_prompt
+    assert "checkout-cache-prod" in synthesis_prompt
+
+    assertion_results = score_structured_assertions(
+        scenario,
+        tool_trace=response.tool_envelopes,
+        final_answer=response.response,
+        actual_routing_decision=result.agent_name,
+    )
+    grouped_assertions = [
+        *assertion_results.required_tool_calls,
+        *assertion_results.required_response_patterns,
+        *assertion_results.forbidden_claims,
+        *assertion_results.required_findings,
+    ]
+    failures = [assertion.message for assertion in grouped_assertions if not assertion.passed]
+    assert assertion_results.all_passed, failures


### PR DESCRIPTION
## Summary
- synthesize a terminal chat response when the graph exhausts the iteration budget without final assistant text
- preserve gathered tool envelopes and persist the synthesized response like normal terminal answers
- add unit coverage plus a deterministic eval regression scenario for issue #165

## Validation
- `uv run ruff check redis_sre_agent/agent/chat_agent.py tests/unit/agent/test_chat_agent.py tests/unit/evaluation/test_prompt_scenarios.py`
- `uv run ruff format --check redis_sre_agent/agent/chat_agent.py tests/unit/agent/test_chat_agent.py tests/unit/evaluation/test_prompt_scenarios.py`
- `uv run pytest tests/unit/agent/test_chat_agent.py tests/unit/evaluation/test_prompt_scenarios.py -q`
- `make test-eval-pr`
- `make test`

Closes #165

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes end-user chat behavior on an edge path and adds an extra LLM call with truncated context; mitigated by fallbacks, persistence parity with normal answers, and unit/eval regression tests.
> 
> **Overview**
> When the **chat** graph hits its **iteration budget** without emitting terminal assistant text, **`ChatAgent.process_query`** now runs a **one-shot LLM synthesis** over a truncated conversation tail and structured **tool envelopes**, instead of returning the generic *"I couldn't process that query..."* fallback.
> 
> Synthesized answers are **persisted** like normal terminal responses and still return **`tool_envelopes`**. If synthesis fails or returns empty text, users get an explicit **iteration-limit** message describing what was gathered.
> 
> Adds a **deterministic eval** scenario (`chat-max-iteration-terminal-response`) for issue **#165**, plus **unit** coverage for the synthesis path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e05bf8064d509ea582265c627ca25fcf66d9d67. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->