### PR TITLE
Route explicit zero-scope deep triage requests to triage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,6 +32,42 @@ jobs:
     - name: Run deterministic eval subset
       run: make test-eval-pr
 
+  live-evals-pr:
+    name: Live evals (PR)
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    needs:
+      - deterministic-evals
+      - test
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v4
+      with:
+        version: "0.5.7"
+        enable-cache: true
+
+    - name: Set up Python 3.12
+      run: uv python install 3.12
+
+    - name: Install dependencies
+      run: uv sync --dev
+
+    - name: Run PR live eval suite
+      env:
+        OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        OPENAI_MODEL: ${{ vars.OPENAI_MODEL }}
+      run: make test-eval-pr-live EVAL_PR_LIVE_TRIGGER="${{ github.event_name }}"
+
+    - name: Upload PR live eval artifacts
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: pr-live-evals
+        path: artifacts/pr-live-evals
+
   test:
     runs-on: ubuntu-latest
     strategy:

--- a/Makefile
+++ b/Makefile
@@ -133,6 +133,7 @@ EVAL_PR_LIVE_CONFIG ?= evals/suites/pr-target-discovery-live.yaml
 EVAL_PR_LIVE_BASELINE_PROFILE ?= pull_request
 EVAL_PR_LIVE_OUTPUT_DIR ?= artifacts/pr-live-evals
 EVAL_PR_LIVE_TRIGGER ?= pull_request
+EVAL_PR_LIVE_REDIS_TESTCONTAINER ?= true
 
 test-eval-live: sync ## Run the scheduled/manual live-model eval suite
 	$(UV) run python scripts/run_live_eval_suite.py \
@@ -149,7 +150,8 @@ test-eval-pr-live: sync ## Run the LLM-backed eval suite used in PR CI
 		--baseline-profile $(EVAL_PR_LIVE_BASELINE_PROFILE) \
 		--report-dir $(EVAL_PR_LIVE_OUTPUT_DIR) \
 		--trigger $(EVAL_PR_LIVE_TRIGGER) \
-		--session-id-prefix pr-live-eval
+		--session-id-prefix pr-live-eval \
+		$(if $(filter true,$(EVAL_PR_LIVE_REDIS_TESTCONTAINER)),--redis-testcontainer,)
 
 test-integration: sync ## Run integration tests only
 	$(UV) run pytest -m integration

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ UI_DIST ?= $(UI_DIR)/dist
 REDIS_DOCS_REPO_URL ?= https://github.com/redis/docs.git
 REDIS_DOCS_BRANCH ?= main
 
-.PHONY: help venv sync hooks-install lint docs-build docs-serve local-services local-services-down local-services-logs quick-demo test test-eval-pr test-eval-live test-integration test-all ui-kit-install ui-kit-build ui-kit-dev ui-install ui-dev ui-build redis-docs-sync redis-docs-index
+.PHONY: help venv sync hooks-install lint docs-build docs-serve local-services local-services-down local-services-logs quick-demo test test-eval-pr test-eval-pr-live test-eval-live test-integration test-all ui-kit-install ui-kit-build ui-kit-dev ui-install ui-dev ui-build redis-docs-sync redis-docs-index
 
 help: ## Show this help and available targets
 	@awk 'BEGIN {FS = ":.*##"; printf "Usage: make <target>\n\nTargets:\n"} /^[a-zA-Z0-9][^:]*:.*##/ { printf "  %-20s %s\n", $$1, $$2 }' $(MAKEFILE_LIST)
@@ -129,9 +129,12 @@ EVAL_LIVE_BASELINE_PROFILE ?= scheduled_live
 EVAL_LIVE_OUTPUT_DIR ?= artifacts/live-evals
 EVAL_LIVE_TRIGGER ?= manual
 EVAL_LIVE_UPDATE_BASELINE ?= false
+EVAL_PR_LIVE_CONFIG ?= evals/suites/pr-target-discovery-live.yaml
+EVAL_PR_LIVE_BASELINE_PROFILE ?= pull_request
+EVAL_PR_LIVE_OUTPUT_DIR ?= artifacts/pr-live-evals
+EVAL_PR_LIVE_TRIGGER ?= pull_request
 
 test-eval-live: sync ## Run the scheduled/manual live-model eval suite
-	@test -n "$$OPENAI_API_KEY" || (echo "OPENAI_API_KEY is required for live evals" && exit 1)
 	$(UV) run python scripts/run_live_eval_suite.py \
 		--suite $(EVAL_LIVE_CONFIG) \
 		--baseline-profile $(EVAL_LIVE_BASELINE_PROFILE) \
@@ -139,6 +142,14 @@ test-eval-live: sync ## Run the scheduled/manual live-model eval suite
 		--trigger $(EVAL_LIVE_TRIGGER) \
 		$(if $(filter true,$(EVAL_LIVE_UPDATE_BASELINE)),--update-baseline,) \
 		--session-id-prefix live-eval
+
+test-eval-pr-live: sync ## Run the LLM-backed eval suite used in PR CI
+	$(UV) run python scripts/run_live_eval_suite.py \
+		--suite $(EVAL_PR_LIVE_CONFIG) \
+		--baseline-profile $(EVAL_PR_LIVE_BASELINE_PROFILE) \
+		--report-dir $(EVAL_PR_LIVE_OUTPUT_DIR) \
+		--trigger $(EVAL_PR_LIVE_TRIGGER) \
+		--session-id-prefix pr-live-eval
 
 test-integration: sync ## Run integration tests only
 	$(UV) run pytest -m integration

--- a/evals/baseline_policy.yaml
+++ b/evals/baseline_policy.yaml
@@ -18,6 +18,24 @@ profiles:
       missing_required_findings_max_delta: 1
       missing_required_sources_max_delta: 1
       hard_assertion_failures_allowed: 0
+  pull_request:
+    baseline_id: pr-target-discovery-live-v1
+    update_allowed: false
+    max_failed_scenarios: 0
+    update_rule: no_auto_update
+    judge_score_variance_band: 0.0
+    notes:
+      - Pull request live evals are gating checks for changed routing and target-discovery behavior.
+      - Keep this suite small and deterministic in fixtures; investigate failures before merging.
+    allowed_triggers:
+      - pull_request
+      - workflow_dispatch
+    review_required: true
+    acceptable_variance:
+      overall_score_max_drop: 0.0
+      missing_required_findings_max_delta: 0
+      missing_required_sources_max_delta: 0
+      hard_assertion_failures_allowed: 0
   manual_update:
     baseline_id: live-agent-only-smoke-v1
     update_allowed: true

--- a/evals/goldens/prompt/deep-triage-over-limit-targets/assertions.json
+++ b/evals/goldens/prompt/deep-triage-over-limit-targets/assertions.json
@@ -1,0 +1,21 @@
+{
+  "required_tool_calls": [],
+  "forbidden_tool_calls": [
+    {
+      "provider_family": "redis_command",
+      "operation": "info"
+    }
+  ],
+  "required_response_patterns": [],
+  "required_findings": [
+    "too many Redis targets",
+    "5 or fewer targets",
+    "narrow the request"
+  ],
+  "forbidden_claims": [
+    "ran deep triage on the first 5 targets",
+    "completed fan-out for 5 targets"
+  ],
+  "required_sources": [],
+  "expected_routing_decision": "triage"
+}

--- a/evals/goldens/prompt/deep-triage-over-limit-targets/expected.md
+++ b/evals/goldens/prompt/deep-triage-over-limit-targets/expected.md
@@ -1,0 +1,5 @@
+Classify the request as deep triage, resolve the named Redis targets, and detect that the target
+set exceeds the supported fan-out limit.
+
+The answer should ask the user to narrow the request to `5` or fewer Redis targets. It should not
+start child deep-triage tasks for a partial target set.

--- a/evals/goldens/prompt/deep-triage-over-limit-targets/metadata.yaml
+++ b/evals/goldens/prompt/deep-triage-over-limit-targets/metadata.yaml
@@ -1,0 +1,12 @@
+scenario_id: prompt/deep-triage-over-limit-targets
+review_status: reviewed
+reviewed_by: sre-evals
+expectation_basis: human_authored
+source_pack: prompt-core
+source_pack_version: "2026-04-14"
+baseline_policy:
+  mode: deterministic
+  update_allowed: false
+notes:
+  - The intended path is triage intent classification followed by target-limit handling.
+  - The answer should ask the user to narrow the request and must not run partial child triage tasks.

--- a/evals/goldens/prompt/target-discovery-multi-target-comparison/assertions.json
+++ b/evals/goldens/prompt/target-discovery-multi-target-comparison/assertions.json
@@ -13,11 +13,17 @@
       "provider_family": "redis_command",
       "operation": "info",
       "target_handle": "tgt_session_cache_prod"
+    },
+    {
+      "provider_family": "redis_command",
+      "operation": "info",
+      "target_handle": "tgt_cart_cache_prod"
     }
   ],
   "required_findings": [
     "prod checkout cache",
     "prod session cache",
+    "prod cart cache",
     "prod session cache is closer to maxmemory"
   ],
   "required_sources": [

--- a/evals/goldens/prompt/target-discovery-multi-target-comparison/assertions.json
+++ b/evals/goldens/prompt/target-discovery-multi-target-comparison/assertions.json
@@ -6,18 +6,15 @@
     },
     {
       "provider_family": "redis_command",
-      "operation": "info",
-      "target_handle": "tgt_checkout_cache_prod"
+      "operation": "info"
     },
     {
       "provider_family": "redis_command",
-      "operation": "info",
-      "target_handle": "tgt_session_cache_prod"
+      "operation": "info"
     },
     {
       "provider_family": "redis_command",
-      "operation": "info",
-      "target_handle": "tgt_cart_cache_prod"
+      "operation": "info"
     }
   ],
   "required_findings": [

--- a/evals/goldens/prompt/target-discovery-multi-target-comparison/expected.md
+++ b/evals/goldens/prompt/target-discovery-multi-target-comparison/expected.md
@@ -1,5 +1,5 @@
-Resolve both cache targets from the natural-language names, keep the attached target set, and
+Resolve all three cache targets from the natural-language names, keep the attached target set, and
 compare live memory evidence per cache instead of collapsing to one target.
 
-The answer should mention both `prod checkout cache` and `prod session cache`, and it should
-conclude that `prod session cache` is closer to `maxmemory`.
+The answer should mention `prod checkout cache`, `prod session cache`, and `prod cart cache`, and
+it should conclude that `prod session cache` is closer to `maxmemory`.

--- a/evals/goldens/prompt/target-discovery-over-limit-comparison/assertions.json
+++ b/evals/goldens/prompt/target-discovery-over-limit-comparison/assertions.json
@@ -1,0 +1,26 @@
+{
+  "required_tool_calls": [
+    {
+      "provider_family": "target_discovery",
+      "operation": "resolve_redis_targets"
+    }
+  ],
+  "forbidden_tool_calls": [
+    {
+      "provider_family": "redis_command",
+      "operation": "info"
+    }
+  ],
+  "required_response_patterns": [],
+  "required_findings": [
+    "too many Redis targets",
+    "5 or fewer targets",
+    "narrow the request"
+  ],
+  "forbidden_claims": [
+    "compared all 10 targets",
+    "ran diagnostics on the first 5 targets"
+  ],
+  "required_sources": [],
+  "expected_routing_decision": "chat"
+}

--- a/evals/goldens/prompt/target-discovery-over-limit-comparison/expected.md
+++ b/evals/goldens/prompt/target-discovery-over-limit-comparison/expected.md
@@ -1,0 +1,4 @@
+Resolve the named target set and detect that the request exceeds the supported multi-target limit.
+
+The answer should ask the user to narrow the request to `5` or fewer Redis targets. It should not
+attach a partial set or run diagnostics for the first five targets.

--- a/evals/goldens/prompt/target-discovery-over-limit-comparison/metadata.yaml
+++ b/evals/goldens/prompt/target-discovery-over-limit-comparison/metadata.yaml
@@ -1,0 +1,12 @@
+scenario_id: prompt/target-discovery-over-limit-comparison
+review_status: reviewed
+reviewed_by: sre-evals
+expectation_basis: human_authored
+source_pack: prompt-core
+source_pack_version: "2026-04-14"
+baseline_policy:
+  mode: deterministic
+  update_allowed: false
+notes:
+  - The intended path is target discovery followed by a narrowing request, not partial attachment.
+  - The answer should not run live diagnostics for any subset of the ten targets.

--- a/evals/scenarios/prompt/deep-triage-over-limit-targets/scenario.yaml
+++ b/evals/scenarios/prompt/deep-triage-over-limit-targets/scenario.yaml
@@ -1,0 +1,123 @@
+id: prompt/deep-triage-over-limit-targets
+name: Deep triage over limit targets
+description: Evaluate whether a deep-triage request that names too many Redis targets asks the user to narrow the target set instead of running a partial fan-out.
+provenance:
+  source_kind: synthetic
+  source_pack: prompt-core
+  source_pack_version: 2026-04-14
+  derived_from:
+    - redis_sre_agent.agent.router.route_to_appropriate_agent
+    - redis_sre_agent.core.docket_tasks.process_agent_turn
+    - redis_sre_agent.targets.redis_catalog.RedisCatalogDiscoveryBackend
+  synthetic:
+    is_synthetic: true
+    method: hand-authored deep-triage fan-out limit case
+  golden:
+    expectation_basis: human_authored
+    exemplar_sources:
+      - evals/goldens/prompt/deep-triage-over-limit-targets/expected.md
+    review_status: reviewed
+    reviewed_by: sre-evals
+
+execution:
+  lane: full_turn
+  agent: redis_triage
+  route_via_router: true
+  query: >
+    Do a deep triage on prod cache 0, prod cache 1, prod cache 2, prod cache 3,
+    prod cache 4, prod cache 5, prod cache 6, prod cache 7, prod cache 8, and
+    prod cache 9.
+  max_tool_steps: 4
+  llm_mode: replay
+
+scope:
+  turn_scope:
+    resolution_policy: allow_zero_scope
+    automation_mode: interactive
+  target_catalog:
+    - handle: tgt_prod_cache_0
+      kind: instance
+      display_name: prod cache 0
+      resource_id: redis-prod-cache-0
+      capabilities: [diagnostics]
+      public_metadata: {environment: production, usage: cache, aliases: [prod cache 0]}
+    - handle: tgt_prod_cache_1
+      kind: instance
+      display_name: prod cache 1
+      resource_id: redis-prod-cache-1
+      capabilities: [diagnostics]
+      public_metadata: {environment: production, usage: cache, aliases: [prod cache 1]}
+    - handle: tgt_prod_cache_2
+      kind: instance
+      display_name: prod cache 2
+      resource_id: redis-prod-cache-2
+      capabilities: [diagnostics]
+      public_metadata: {environment: production, usage: cache, aliases: [prod cache 2]}
+    - handle: tgt_prod_cache_3
+      kind: instance
+      display_name: prod cache 3
+      resource_id: redis-prod-cache-3
+      capabilities: [diagnostics]
+      public_metadata: {environment: production, usage: cache, aliases: [prod cache 3]}
+    - handle: tgt_prod_cache_4
+      kind: instance
+      display_name: prod cache 4
+      resource_id: redis-prod-cache-4
+      capabilities: [diagnostics]
+      public_metadata: {environment: production, usage: cache, aliases: [prod cache 4]}
+    - handle: tgt_prod_cache_5
+      kind: instance
+      display_name: prod cache 5
+      resource_id: redis-prod-cache-5
+      capabilities: [diagnostics]
+      public_metadata: {environment: production, usage: cache, aliases: [prod cache 5]}
+    - handle: tgt_prod_cache_6
+      kind: instance
+      display_name: prod cache 6
+      resource_id: redis-prod-cache-6
+      capabilities: [diagnostics]
+      public_metadata: {environment: production, usage: cache, aliases: [prod cache 6]}
+    - handle: tgt_prod_cache_7
+      kind: instance
+      display_name: prod cache 7
+      resource_id: redis-prod-cache-7
+      capabilities: [diagnostics]
+      public_metadata: {environment: production, usage: cache, aliases: [prod cache 7]}
+    - handle: tgt_prod_cache_8
+      kind: instance
+      display_name: prod cache 8
+      resource_id: redis-prod-cache-8
+      capabilities: [diagnostics]
+      public_metadata: {environment: production, usage: cache, aliases: [prod cache 8]}
+    - handle: tgt_prod_cache_9
+      kind: instance
+      display_name: prod cache 9
+      resource_id: redis-prod-cache-9
+      capabilities: [diagnostics]
+      public_metadata: {environment: production, usage: cache, aliases: [prod cache 9]}
+
+knowledge:
+  mode: full
+  version: latest
+  pinned_documents:
+    - ../../_shared/startup/live-system-boundary.md
+    - ../../_shared/startup/policies/target-discovery-before-live-access.md
+  corpus:
+    - ../../../corpora/prompt-core/2026-04-14
+
+tools: {}
+
+expectations:
+  required_tool_calls: []
+  forbidden_tool_calls:
+    - provider_family: redis_command
+      operation: info
+  required_findings:
+    - too many Redis targets
+    - 5 or fewer targets
+    - narrow the request
+  forbidden_claims:
+    - ran deep triage on the first 5 targets
+    - completed fan-out for 5 targets
+  required_sources: []
+  expected_routing_decision: triage

--- a/evals/scenarios/prompt/target-discovery-multi-target-comparison/fixtures/tools/info-cart-memory.json
+++ b/evals/scenarios/prompt/target-discovery-multi-target-comparison/fixtures/tools/info-cart-memory.json
@@ -1,0 +1,10 @@
+{
+  "section": "memory",
+  "data": {
+    "used_memory_human": "6.2G",
+    "maxmemory_human": "8.0G",
+    "maxmemory_policy": "allkeys-lru",
+    "evicted_keys": 640,
+    "mem_fragmentation_ratio": 1.04
+  }
+}

--- a/evals/scenarios/prompt/target-discovery-multi-target-comparison/scenario.yaml
+++ b/evals/scenarios/prompt/target-discovery-multi-target-comparison/scenario.yaml
@@ -22,10 +22,10 @@ execution:
   agent: redis_chat
   route_via_router: false
   query: >
-    Compare the prod checkout cache and prod session cache for memory pressure
-    right now. Resolve both targets from the natural-language names if needed,
-    inspect live Redis state for each one, and tell me which cache is closer to
-    maxmemory.
+    Compare the prod checkout cache, prod session cache, and prod cart cache
+    for memory pressure right now. Resolve all three targets from the
+    natural-language names if needed, inspect live Redis state for each one,
+    and tell me which cache is closest to maxmemory.
   max_tool_steps: 7
   llm_mode: replay
 
@@ -62,6 +62,20 @@ scope:
         aliases:
           - session cache
           - prod session cache
+    - handle: tgt_cart_cache_prod
+      kind: instance
+      display_name: prod cart cache
+      resource_id: redis-prod-cart-cache
+      capabilities:
+        - diagnostics
+      public_metadata:
+        environment: production
+        usage: cache
+        status: healthy
+        target_type: oss_single
+        aliases:
+          - cart cache
+          - prod cart cache
 
 knowledge:
   mode: full
@@ -94,6 +108,12 @@ tools:
                 args_contains:
                   section: memory
               result: fixtures/tools/info-session-memory.json
+        tgt_cart_cache_prod:
+          responders:
+            - when:
+                args_contains:
+                  section: memory
+              result: fixtures/tools/info-cart-memory.json
 
 expectations:
   required_tool_calls:
@@ -105,9 +125,13 @@ expectations:
     - provider_family: redis_command
       operation: info
       target_handle: tgt_session_cache_prod
+    - provider_family: redis_command
+      operation: info
+      target_handle: tgt_cart_cache_prod
   required_findings:
     - prod checkout cache
     - prod session cache
+    - prod cart cache
     - prod session cache is closer to maxmemory
   required_sources:
     - live-system-boundary

--- a/evals/scenarios/prompt/target-discovery-multi-target-comparison/scenario.yaml
+++ b/evals/scenarios/prompt/target-discovery-multi-target-comparison/scenario.yaml
@@ -95,6 +95,28 @@ tools:
         properties:
           section:
             type: string
+      responders:
+        - when:
+            call_count: 1
+            args_contains:
+              section: memory
+          result: fixtures/tools/info-checkout-memory.json
+        - when:
+            call_count: 2
+            args_contains:
+              section: memory
+          result: fixtures/tools/info-session-memory.json
+        - when:
+            call_count: 3
+            args_contains:
+              section: memory
+          result: fixtures/tools/info-cart-memory.json
+        - when:
+            call_count: 4
+            args_contains:
+              section: memory
+          result: fixtures/tools/info-checkout-memory.json
+      result: fixtures/tools/info-checkout-memory.json
       target_overrides:
         tgt_checkout_cache_prod:
           responders:
@@ -121,13 +143,10 @@ expectations:
       operation: resolve_redis_targets
     - provider_family: redis_command
       operation: info
-      target_handle: tgt_checkout_cache_prod
     - provider_family: redis_command
       operation: info
-      target_handle: tgt_session_cache_prod
     - provider_family: redis_command
       operation: info
-      target_handle: tgt_cart_cache_prod
   required_findings:
     - prod checkout cache
     - prod session cache

--- a/evals/scenarios/prompt/target-discovery-over-limit-comparison/scenario.yaml
+++ b/evals/scenarios/prompt/target-discovery-over-limit-comparison/scenario.yaml
@@ -1,0 +1,124 @@
+id: prompt/target-discovery-over-limit-comparison
+name: Target discovery over limit comparison
+description: Evaluate whether a chat comparison request that names too many Redis targets asks the user to narrow the target set instead of attaching a partial set.
+provenance:
+  source_kind: synthetic
+  source_pack: prompt-core
+  source_pack_version: 2026-04-14
+  derived_from:
+    - redis_sre_agent.agent.chat_agent.CHAT_SYSTEM_PROMPT
+    - redis_sre_agent.targets.redis_catalog.RedisCatalogDiscoveryBackend
+  synthetic:
+    is_synthetic: true
+    method: hand-authored multi-target limit case
+  golden:
+    expectation_basis: human_authored
+    exemplar_sources:
+      - evals/goldens/prompt/target-discovery-over-limit-comparison/expected.md
+    review_status: reviewed
+    reviewed_by: sre-evals
+
+execution:
+  lane: full_turn
+  agent: redis_chat
+  route_via_router: false
+  query: >
+    Compare prod cache 0, prod cache 1, prod cache 2, prod cache 3, prod cache 4,
+    prod cache 5, prod cache 6, prod cache 7, prod cache 8, and prod cache 9 for
+    memory pressure right now.
+  max_tool_steps: 4
+  llm_mode: replay
+
+scope:
+  turn_scope:
+    resolution_policy: allow_zero_scope
+    automation_mode: interactive
+  target_catalog:
+    - handle: tgt_prod_cache_0
+      kind: instance
+      display_name: prod cache 0
+      resource_id: redis-prod-cache-0
+      capabilities: [diagnostics]
+      public_metadata: {environment: production, usage: cache, aliases: [prod cache 0]}
+    - handle: tgt_prod_cache_1
+      kind: instance
+      display_name: prod cache 1
+      resource_id: redis-prod-cache-1
+      capabilities: [diagnostics]
+      public_metadata: {environment: production, usage: cache, aliases: [prod cache 1]}
+    - handle: tgt_prod_cache_2
+      kind: instance
+      display_name: prod cache 2
+      resource_id: redis-prod-cache-2
+      capabilities: [diagnostics]
+      public_metadata: {environment: production, usage: cache, aliases: [prod cache 2]}
+    - handle: tgt_prod_cache_3
+      kind: instance
+      display_name: prod cache 3
+      resource_id: redis-prod-cache-3
+      capabilities: [diagnostics]
+      public_metadata: {environment: production, usage: cache, aliases: [prod cache 3]}
+    - handle: tgt_prod_cache_4
+      kind: instance
+      display_name: prod cache 4
+      resource_id: redis-prod-cache-4
+      capabilities: [diagnostics]
+      public_metadata: {environment: production, usage: cache, aliases: [prod cache 4]}
+    - handle: tgt_prod_cache_5
+      kind: instance
+      display_name: prod cache 5
+      resource_id: redis-prod-cache-5
+      capabilities: [diagnostics]
+      public_metadata: {environment: production, usage: cache, aliases: [prod cache 5]}
+    - handle: tgt_prod_cache_6
+      kind: instance
+      display_name: prod cache 6
+      resource_id: redis-prod-cache-6
+      capabilities: [diagnostics]
+      public_metadata: {environment: production, usage: cache, aliases: [prod cache 6]}
+    - handle: tgt_prod_cache_7
+      kind: instance
+      display_name: prod cache 7
+      resource_id: redis-prod-cache-7
+      capabilities: [diagnostics]
+      public_metadata: {environment: production, usage: cache, aliases: [prod cache 7]}
+    - handle: tgt_prod_cache_8
+      kind: instance
+      display_name: prod cache 8
+      resource_id: redis-prod-cache-8
+      capabilities: [diagnostics]
+      public_metadata: {environment: production, usage: cache, aliases: [prod cache 8]}
+    - handle: tgt_prod_cache_9
+      kind: instance
+      display_name: prod cache 9
+      resource_id: redis-prod-cache-9
+      capabilities: [diagnostics]
+      public_metadata: {environment: production, usage: cache, aliases: [prod cache 9]}
+
+knowledge:
+  mode: full
+  version: latest
+  pinned_documents:
+    - ../../_shared/startup/live-system-boundary.md
+    - ../../_shared/startup/policies/target-discovery-before-live-access.md
+  corpus:
+    - ../../../corpora/prompt-core/2026-04-14
+
+tools: {}
+
+expectations:
+  required_tool_calls:
+    - provider_family: target_discovery
+      operation: resolve_redis_targets
+  forbidden_tool_calls:
+    - provider_family: redis_command
+      operation: info
+  required_findings:
+    - too many Redis targets
+    - 5 or fewer targets
+    - narrow the request
+  forbidden_claims:
+    - compared all 10 targets
+    - ran diagnostics on the first 5 targets
+  required_sources: []
+  expected_routing_decision: chat

--- a/evals/suites/pr-target-discovery-live.yaml
+++ b/evals/suites/pr-target-discovery-live.yaml
@@ -1,0 +1,9 @@
+suites:
+  pr-target-discovery-live:
+    description: LLM-backed PR eval suite for natural-language Redis target discovery and deep-triage routing.
+    policy_file: ../baseline_policy.yaml
+    judge_pass_threshold: 75.0
+    scenarios:
+      - ../scenarios/prompt/target-discovery-multi-target-comparison/scenario.yaml
+      - ../scenarios/prompt/target-discovery-over-limit-comparison/scenario.yaml
+      - ../scenarios/prompt/deep-triage-over-limit-targets/scenario.yaml

--- a/redis_sre_agent/agent/chat_agent.py
+++ b/redis_sre_agent/agent/chat_agent.py
@@ -330,7 +330,7 @@ For target discovery:
 - If the user describes a target but has not given `instance_id` or `cluster_id`, call `resolve_redis_targets` before making live-state claims
 - Only treat target discovery as confirmed when it returns an exact live match. If the match is fuzzy, partial, or ambiguous, ask the user to confirm the target before you attach tools or describe live state
 - If the user asks to compare or investigate multiple targets, call `resolve_redis_targets` with `allow_multiple=true`, keep the attached target set, and gather evidence per target before comparing
-- If target discovery returns `status="too_many_matches"`, do not attach or inspect a partial target set. Ask the user to narrow the request to the reported `max_selectable` target count
+- If target discovery returns `status="too_many_matches"`, do not attach or inspect a partial target set. Say there are too many Redis targets, ask the user to narrow the request to the reported `max_selectable` target count, and include "5 or fewer targets" when `max_selectable` is 5
 - If the user asks both "what do you know about?" and asks to drill into one target in the same turn, list first, then resolve the chosen target and continue with the attached live tools
 - A hostname or hostname fragment is not enough to assume a live Redis target. If target discovery does not return an exact live match, do not attach or describe a different Redis deployment as if it were that hostname
 

--- a/redis_sre_agent/agent/chat_agent.py
+++ b/redis_sre_agent/agent/chat_agent.py
@@ -330,6 +330,7 @@ For target discovery:
 - If the user describes a target but has not given `instance_id` or `cluster_id`, call `resolve_redis_targets` before making live-state claims
 - Only treat target discovery as confirmed when it returns an exact live match. If the match is fuzzy, partial, or ambiguous, ask the user to confirm the target before you attach tools or describe live state
 - If the user asks to compare or investigate multiple targets, call `resolve_redis_targets` with `allow_multiple=true`, keep the attached target set, and gather evidence per target before comparing
+- If target discovery returns `status="too_many_matches"`, do not attach or inspect a partial target set. Ask the user to narrow the request to the reported `max_selectable` target count
 - If the user asks both "what do you know about?" and asks to drill into one target in the same turn, list first, then resolve the chosen target and continue with the attached live tools
 - A hostname or hostname fragment is not enough to assume a live Redis target. If target discovery does not return an exact live match, do not attach or describe a different Redis deployment as if it were that hostname
 

--- a/redis_sre_agent/agent/router.py
+++ b/redis_sre_agent/agent/router.py
@@ -6,6 +6,7 @@ which agent should handle them based on context and query content.
 """
 
 import logging
+import re
 from enum import Enum
 from typing import Any, Dict, List, Optional
 
@@ -18,6 +19,20 @@ from redis_sre_agent.core.targets import get_attached_target_handles_from_contex
 from .cluster_diagnostics import cluster_query_requests_db_diagnostics
 
 logger = logging.getLogger(__name__)
+
+_EXPLICIT_DEEP_TRIAGE_PATTERNS = (
+    re.compile(r"\bdeep[\s-]+triage\b"),
+    re.compile(r"\bdeep[\s-]+research\b"),
+    re.compile(r"\bdeep[\s-]+analysis\b"),
+    re.compile(r"\bdeep[\s-]+dive\b"),
+    re.compile(r"\bgo[\s-]+deep\b"),
+    re.compile(r"\bdig[\s-]+deep\b"),
+    re.compile(r"\binvestigate[\s-]+deeply\b"),
+    re.compile(r"\bcomprehensive[\s-]+triage\b"),
+    re.compile(r"\bfull[\s-]+triage\b"),
+    re.compile(r"\bexhaustive[\s-]+analysis\b"),
+    re.compile(r"\bthorough[\s-]+investigation\b"),
+)
 
 
 class AgentType(Enum):
@@ -51,6 +66,12 @@ def format_conversation_context(
         lines.append(f"{role}: {content}")
 
     return "\n".join(lines)
+
+
+def _query_explicitly_requests_deep_triage(query: str) -> bool:
+    """Return True when the user directly requests the heavy triage path."""
+    query_text = (query or "").lower()
+    return any(pattern.search(query_text) for pattern in _EXPLICIT_DEEP_TRIAGE_PATTERNS)
 
 
 async def route_to_appropriate_agent(
@@ -90,7 +111,12 @@ async def route_to_appropriate_agent(
         logger.info("Support package provided - routing to REDIS_TRIAGE for diagnostic tools")
         return AgentType.REDIS_TRIAGE
 
-    # 2. No diagnostic scope (instance/cluster) - default to chat.
+    # 2. Explicit deep triage requests need triage before target discovery resolves scope.
+    if not has_diagnostic_scope and _query_explicitly_requests_deep_triage(query):
+        logger.info("Zero-scope query explicitly requested deep triage - routing to REDIS_TRIAGE")
+        return AgentType.REDIS_TRIAGE
+
+    # 3. No diagnostic scope (instance/cluster) - default to chat.
     # Chat now serves as the zero-scope knowledge/default agent.
     if not has_diagnostic_scope:
         logger.info(
@@ -98,7 +124,7 @@ async def route_to_appropriate_agent(
         )
         return AgentType.REDIS_CHAT
 
-    # 3. Has instance or cluster scope - decide between triage (full) and chat (quick)
+    # 4. Has instance or cluster scope - decide between triage (full) and chat (quick)
     # Check user preferences first
     if user_preferences and user_preferences.get("preferred_agent"):
         preferred = user_preferences["preferred_agent"]
@@ -106,7 +132,7 @@ async def route_to_appropriate_agent(
             logger.info(f"Using user preference: {preferred}")
             return AgentType(preferred)
 
-    # 4. Use LLM to categorize triage vs chat
+    # 5. Use LLM to categorize triage vs chat
     context_str = format_conversation_context(conversation_history)
 
     try:

--- a/redis_sre_agent/agent/router.py
+++ b/redis_sre_agent/agent/router.py
@@ -6,7 +6,6 @@ which agent should handle them based on context and query content.
 """
 
 import logging
-import re
 from enum import Enum
 from typing import Any, Dict, List, Optional
 
@@ -19,20 +18,6 @@ from redis_sre_agent.core.targets import get_attached_target_handles_from_contex
 from .cluster_diagnostics import cluster_query_requests_db_diagnostics
 
 logger = logging.getLogger(__name__)
-
-_EXPLICIT_DEEP_TRIAGE_PATTERNS = (
-    re.compile(r"\bdeep[\s-]+triage\b"),
-    re.compile(r"\bdeep[\s-]+research\b"),
-    re.compile(r"\bdeep[\s-]+analysis\b"),
-    re.compile(r"\bdeep[\s-]+dive\b"),
-    re.compile(r"\bgo[\s-]+deep\b"),
-    re.compile(r"\bdig[\s-]+deep\b"),
-    re.compile(r"\binvestigate[\s-]+deeply\b"),
-    re.compile(r"\bcomprehensive[\s-]+triage\b"),
-    re.compile(r"\bfull[\s-]+triage\b"),
-    re.compile(r"\bexhaustive[\s-]+analysis\b"),
-    re.compile(r"\bthorough[\s-]+investigation\b"),
-)
 
 
 class AgentType(Enum):
@@ -66,12 +51,6 @@ def format_conversation_context(
         lines.append(f"{role}: {content}")
 
     return "\n".join(lines)
-
-
-def _query_explicitly_requests_deep_triage(query: str) -> bool:
-    """Return True when the user directly requests the heavy triage path."""
-    query_text = (query or "").lower()
-    return any(pattern.search(query_text) for pattern in _EXPLICIT_DEEP_TRIAGE_PATTERNS)
 
 
 async def route_to_appropriate_agent(
@@ -111,28 +90,17 @@ async def route_to_appropriate_agent(
         logger.info("Support package provided - routing to REDIS_TRIAGE for diagnostic tools")
         return AgentType.REDIS_TRIAGE
 
-    # 2. Explicit deep triage requests need triage before target discovery resolves scope.
-    if not has_diagnostic_scope and _query_explicitly_requests_deep_triage(query):
-        logger.info("Zero-scope query explicitly requested deep triage - routing to REDIS_TRIAGE")
-        return AgentType.REDIS_TRIAGE
-
-    # 3. No diagnostic scope (instance/cluster) - default to chat.
-    # Chat now serves as the zero-scope knowledge/default agent.
-    if not has_diagnostic_scope:
-        logger.info(
-            "No diagnostic scope - routing to REDIS_CHAT as the default general-purpose agent"
-        )
-        return AgentType.REDIS_CHAT
-
-    # 4. Has instance or cluster scope - decide between triage (full) and chat (quick)
-    # Check user preferences first
+    # 2. Has user preference and diagnostic scope - use it.
+    # Zero-scope requests still go through intent routing before target discovery.
     if user_preferences and user_preferences.get("preferred_agent"):
         preferred = user_preferences["preferred_agent"]
-        if preferred in [agent.value for agent in AgentType]:
+        if has_diagnostic_scope and preferred in [agent.value for agent in AgentType]:
             logger.info(f"Using user preference: {preferred}")
             return AgentType(preferred)
 
-    # 5. Use LLM to categorize triage vs chat
+    # 3. Use LLM to categorize triage vs chat.
+    # This must run before the zero-scope fallback so explicit deep-triage
+    # requests can enter target discovery.
     context_str = format_conversation_context(conversation_history)
 
     try:
@@ -140,8 +108,9 @@ async def route_to_appropriate_agent(
 
         system_prompt = """You are a query categorization system for a Redis SRE agent.
 
-The user has Redis diagnostic scope available (instance and/or cluster). Determine what kind of agent should handle their query.
+Determine what kind of agent should handle the user's query.
 Consider the conversation context if provided - a follow-up like "yes", "sure", or "check that" refers to the previous discussion.
+Redis diagnostic scope may or may not already be attached. If no scope is attached, a DEEP_TRIAGE result can still be used to discover a target from the user's natural language.
 
 1. DEEP_TRIAGE: ONLY use this for explicit requests for deep, comprehensive, or multi-topic analysis.
    Trigger phrases (must explicitly appear):
@@ -172,7 +141,7 @@ DEFAULT TO CHAT unless you see explicit deep/exhaustive keywords.
 
 Respond with ONLY one word: either "DEEP_TRIAGE" or "CHAT"."""
 
-        scope_hint = ""
+        scope_hint = " [Scope: none attached]"
         if has_cluster and not has_instance:
             scope_hint = " [Scope: cluster]"
         elif has_instance:

--- a/redis_sre_agent/core/docket_tasks.py
+++ b/redis_sre_agent/core/docket_tasks.py
@@ -57,6 +57,10 @@ from redis_sre_agent.core.targets import (
 from redis_sre_agent.core.tasks import TaskManager, TaskStatus
 from redis_sre_agent.core.threads import Message, ThreadManager
 from redis_sre_agent.core.turn_scope import TurnScope
+from redis_sre_agent.targets.contracts import (
+    DISCOVERY_STATUS_TOO_MANY_MATCHES,
+    MULTI_TARGET_SELECTION_LIMIT,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -725,6 +729,119 @@ def _format_single_target_triage_response(*, binding: Any, response_text: str) -
     metadata = _target_binding_metadata(binding)
     target_label = metadata["display_name"] or metadata["target_handle"] or "Redis target"
     return f"## Deep triage: {target_label}\n\n{response_text}".strip()
+
+
+def _format_target_limit_response(
+    *,
+    resolution: Any = None,
+    bindings: Optional[List[Any]] = None,
+) -> str:
+    binding_list = list(bindings or [])
+    max_selectable = int(
+        getattr(resolution, "max_selectable", None) or MULTI_TARGET_SELECTION_LIMIT
+    )
+    match_count = int(
+        getattr(resolution, "match_count", None)
+        or len(getattr(resolution, "matches", []) or [])
+        or len(binding_list)
+    )
+    matches = list(getattr(resolution, "matches", None) or [])
+    labels: List[str] = []
+    for match in matches[:max_selectable]:
+        label = str(getattr(match, "display_name", "") or "").strip()
+        kind = str(getattr(match, "target_kind", "") or "").strip()
+        labels.append(f"- {label} ({kind})" if kind else f"- {label}")
+    for binding in binding_list[:max_selectable]:
+        metadata = _target_binding_metadata(binding)
+        label = metadata["display_name"] or metadata["target_handle"]
+        kind = metadata["target_kind"]
+        labels.append(f"- {label} ({kind})" if kind else f"- {label}")
+
+    lines = [
+        f"I found {match_count} Redis targets, which is more than I can deep triage in one request.",
+        f"Please narrow the request to {max_selectable} or fewer targets, then I can run one deep triage session per target and return each report as it completes.",
+    ]
+    if labels:
+        lines.extend(["", "Some matching targets:", *labels])
+    return "\n".join(lines)
+
+
+async def _complete_deep_triage_target_limit_response(
+    *,
+    task_manager: TaskManager,
+    thread_manager: ThreadManager,
+    thread_id: str,
+    task_id: str,
+    user_message: str,
+    resolution: Any = None,
+    bindings: Optional[List[Any]] = None,
+    append_user_message: bool = True,
+) -> Dict[str, Any]:
+    """Complete a deep-triage turn that matched more targets than fan-out should run."""
+    binding_list = list(bindings or [])
+    response_text = _format_target_limit_response(
+        resolution=resolution,
+        bindings=binding_list,
+    )
+    user_timestamp = datetime.now(timezone.utc).isoformat()
+    assistant_message_id = str(ULID())
+    match_count = (
+        getattr(resolution, "match_count", None)
+        or len(getattr(resolution, "matches", []) or [])
+        or len(binding_list)
+    )
+    assistant_metadata = {
+        "agent_type": "redis_triage",
+        "task_id": task_id,
+        "message_id": assistant_message_id,
+        "target_resolution_status": DISCOVERY_STATUS_TOO_MANY_MATCHES,
+        "max_selectable": getattr(resolution, "max_selectable", None)
+        or MULTI_TARGET_SELECTION_LIMIT,
+        "match_count": match_count,
+    }
+    await task_manager.add_task_update(
+        task_id,
+        "Target discovery matched too many Redis targets for one deep triage request",
+        "target_limit_exceeded",
+        metadata=assistant_metadata,
+    )
+    messages_to_append = []
+    if append_user_message:
+        messages_to_append.append(
+            {
+                "role": "user",
+                "content": user_message,
+                "metadata": {"timestamp": user_timestamp},
+            }
+        )
+    messages_to_append.append(
+        {
+            "message_id": assistant_message_id,
+            "role": "assistant",
+            "content": response_text,
+            "metadata": assistant_metadata,
+        },
+    )
+    await thread_manager.append_messages(thread_id, messages_to_append)
+    result = {
+        "response": response_text,
+        "metadata": assistant_metadata,
+        "thread_id": thread_id,
+        "task_id": task_id,
+        "message_id": assistant_message_id,
+        "target_resolution": (
+            resolution.public_dump() if hasattr(resolution, "public_dump") else None
+        ),
+        "turn_completed_at": datetime.now(timezone.utc).isoformat(),
+    }
+    await task_manager.set_task_result(task_id, result)
+    await task_manager.update_task_status(task_id, TaskStatus.DONE)
+    await task_manager._publish_stream_update(
+        thread_id,
+        "turn_complete",
+        {"task_id": task_id, "message": "Task completed successfully"},
+    )
+    return result
 
 
 async def _run_single_target_triage_child(
@@ -2132,6 +2249,21 @@ async def _process_agent_turn_impl(
                     max_results=5,
                     preferred_capabilities=["diagnostics", "admin", "cloud"],
                 )
+                if resolution.status == DISCOVERY_STATUS_TOO_MANY_MATCHES:
+                    result = await _complete_deep_triage_target_limit_response(
+                        task_manager=task_manager,
+                        thread_manager=thread_manager,
+                        thread_id=thread_id,
+                        task_id=task_id,
+                        user_message=message,
+                        resolution=resolution,
+                    )
+                    try:
+                        if _root_span is not None:
+                            _root_span.end()
+                    except Exception:
+                        pass
+                    return result
                 if resolution.selected_matches:
                     bound_scope = await materialize_bound_target_scope(
                         matches=resolution.selected_matches,
@@ -2252,6 +2384,25 @@ async def _process_agent_turn_impl(
         fanout_bindings = current_scope.bindings or get_target_bindings_from_context(
             routing_context
         )
+        if (
+            agent_type == AgentType.REDIS_TRIAGE
+            and len(fanout_bindings) > MULTI_TARGET_SELECTION_LIMIT
+        ):
+            result = await _complete_deep_triage_target_limit_response(
+                task_manager=task_manager,
+                thread_manager=thread_manager,
+                thread_id=thread_id,
+                task_id=task_id,
+                user_message=message,
+                bindings=fanout_bindings,
+                append_user_message=False,
+            )
+            try:
+                if _root_span is not None:
+                    _root_span.end()
+            except Exception:
+                pass
+            return result
         if agent_type == AgentType.REDIS_TRIAGE and len(fanout_bindings) > 1:
             await task_manager.add_task_update(
                 task_id,

--- a/redis_sre_agent/core/docket_tasks.py
+++ b/redis_sre_agent/core/docket_tasks.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List, Optional
@@ -48,7 +49,11 @@ from redis_sre_agent.core.qa import QAManager
 from redis_sre_agent.core.redis import (
     get_redis_client,
 )
-from redis_sre_agent.core.targets import get_attached_target_handles_from_context
+from redis_sre_agent.core.targets import (
+    build_bound_target_scope_context,
+    get_attached_target_handles_from_context,
+    get_target_bindings_from_context,
+)
 from redis_sre_agent.core.tasks import TaskManager, TaskStatus
 from redis_sre_agent.core.threads import Message, ThreadManager
 from redis_sre_agent.core.turn_scope import TurnScope
@@ -643,6 +648,388 @@ async def _ensure_handle_backed_turn_scope(
             if routing_context.get(key)
         },
     )
+
+
+def _target_binding_metadata(binding: Any) -> Dict[str, Any]:
+    """Return stable, public metadata for a target binding."""
+    return {
+        "target_handle": getattr(binding, "target_handle", ""),
+        "target_kind": getattr(binding, "target_kind", ""),
+        "display_name": getattr(binding, "display_name", ""),
+        "capabilities": list(getattr(binding, "capabilities", None) or []),
+    }
+
+
+def _build_single_target_triage_query(*, original_query: str, binding: Any) -> str:
+    """Scope a fan-out child run to one target while preserving the user's request."""
+    metadata = _target_binding_metadata(binding)
+    return "\n".join(
+        [
+            "Run the requested deep triage for this one Redis target only.",
+            (
+                "Target: "
+                f"{metadata['display_name']} "
+                f"[handle={metadata['target_handle']}, kind={metadata['target_kind']}]"
+            ),
+            "",
+            f"Original user request: {original_query}",
+        ]
+    )
+
+
+def _build_single_target_context(
+    *,
+    base_context: Dict[str, Any],
+    binding: Any,
+    child_task_id: str,
+    parent_task_id: str,
+    thread_id: str,
+    child_session_id: str,
+    generation: int,
+) -> Dict[str, Any]:
+    """Build an agent context that exposes exactly one attached target."""
+    child_context = dict(base_context)
+    target_handle = str(getattr(binding, "target_handle", "") or "")
+    child_context.update(
+        build_bound_target_scope_context(
+            [binding],
+            generation=generation,
+            active_handle=target_handle,
+        )
+    )
+    child_context.pop("instance_id", None)
+    child_context.pop("cluster_id", None)
+    child_context.pop("turn_scope", None)
+    child_context.update(
+        {
+            "task_id": child_task_id,
+            "parent_task_id": parent_task_id,
+            "thread_id": thread_id,
+            "session_id": child_session_id,
+        }
+    )
+    child_scope = TurnScope.from_context(
+        child_context,
+        thread_id=thread_id,
+        session_id=child_session_id,
+    )
+    child_context.update(child_scope.to_thread_context())
+    child_context["turn_scope"] = child_scope.model_dump(mode="json")
+    child_context.pop("instance_id", None)
+    child_context.pop("cluster_id", None)
+    return child_context
+
+
+def _format_single_target_triage_response(*, binding: Any, response_text: str) -> str:
+    """Label a child triage result with its target identity for thread display."""
+    metadata = _target_binding_metadata(binding)
+    target_label = metadata["display_name"] or metadata["target_handle"] or "Redis target"
+    return f"## Deep triage: {target_label}\n\n{response_text}".strip()
+
+
+async def _run_single_target_triage_child(
+    *,
+    agent: Any,
+    binding: Any,
+    child_task_id: str,
+    parent_task_id: str,
+    thread_id: str,
+    thread: Any,
+    task_manager: TaskManager,
+    thread_manager: ThreadManager,
+    base_conversation_state: Dict[str, Any],
+    base_context: Dict[str, Any],
+    original_query: str,
+    generation: int,
+) -> Dict[str, Any]:
+    """Run one deep-triage child task for one target binding."""
+    target_metadata = _target_binding_metadata(binding)
+    target_label = target_metadata["display_name"] or target_metadata["target_handle"]
+    child_session_id = f"{thread_id}:{child_task_id}"
+    child_context = _build_single_target_context(
+        base_context=base_context,
+        binding=binding,
+        child_task_id=child_task_id,
+        parent_task_id=parent_task_id,
+        thread_id=thread_id,
+        child_session_id=child_session_id,
+        generation=generation,
+    )
+    child_messages = [
+        dict(message)
+        for message in list(base_conversation_state.get("messages") or [])[:-1]
+        if isinstance(message, dict)
+    ]
+    child_messages.append(
+        {
+            "role": "user",
+            "content": _build_single_target_triage_query(
+                original_query=original_query,
+                binding=binding,
+            ),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        }
+    )
+    child_conversation_state = {
+        "messages": child_messages,
+        "thread_id": child_session_id,
+    }
+    child_emitter = TaskEmitter(task_manager=task_manager, task_id=child_task_id)
+
+    await task_manager.update_task_status(child_task_id, TaskStatus.IN_PROGRESS)
+    await task_manager.add_task_update(
+        child_task_id,
+        f"Starting deep triage for {target_label}",
+        "agent_start",
+        metadata={
+            "parent_task_id": parent_task_id,
+            **target_metadata,
+        },
+    )
+
+    try:
+        agent_response = await run_agent_with_progress(
+            agent,
+            child_conversation_state,
+            child_emitter,
+            thread,
+            agent_context=child_context,
+        )
+    except GraphInterrupt as exc:
+        approval_result = await _transition_task_to_awaiting_approval_from_interrupt(
+            task_manager=task_manager,
+            task_id=child_task_id,
+            thread_id=thread_id,
+            error=exc,
+        )
+        approval_result["parent_task_id"] = parent_task_id
+        approval_result["target"] = target_metadata
+        return approval_result
+    except ApprovalRequiredError as exc:
+        approval_result = await _transition_task_to_awaiting_approval(
+            task_manager=task_manager,
+            task_id=child_task_id,
+            thread_id=thread_id,
+            error=exc,
+        )
+        approval_result["parent_task_id"] = parent_task_id
+        approval_result["target"] = target_metadata
+        return approval_result
+    except Exception as exc:
+        error_message = f"Deep triage failed for {target_label}: {exc}"
+        result = {
+            "status": TaskStatus.FAILED.value,
+            "response": error_message,
+            "thread_id": thread_id,
+            "task_id": child_task_id,
+            "parent_task_id": parent_task_id,
+            "target": target_metadata,
+            "turn_completed_at": datetime.now(timezone.utc).isoformat(),
+        }
+        await task_manager.set_task_result(child_task_id, result)
+        await task_manager.set_task_error(child_task_id, error_message)
+        await task_manager.add_task_update(
+            child_task_id,
+            error_message,
+            "error",
+            metadata={"parent_task_id": parent_task_id, **target_metadata},
+        )
+        return result
+
+    response_text = str(agent_response.get("response") or "")
+    child_message_id = str(ULID())
+    metadata = {
+        "agent_type": "redis_triage",
+        "parent_task_id": parent_task_id,
+        "task_id": child_task_id,
+        "message_id": child_message_id,
+        "target": target_metadata,
+    }
+    result = {
+        "status": TaskStatus.DONE.value,
+        "response": response_text,
+        "metadata": metadata,
+        "thread_id": thread_id,
+        "task_id": child_task_id,
+        "parent_task_id": parent_task_id,
+        "message_id": child_message_id,
+        "target": target_metadata,
+        "turn_completed_at": datetime.now(timezone.utc).isoformat(),
+    }
+
+    await thread_manager.append_messages(
+        thread_id,
+        [
+            {
+                "message_id": child_message_id,
+                "role": "assistant",
+                "content": _format_single_target_triage_response(
+                    binding=binding,
+                    response_text=response_text,
+                ),
+                "metadata": metadata,
+            }
+        ],
+    )
+    await task_manager.set_task_result(child_task_id, result)
+    await task_manager.update_task_status(child_task_id, TaskStatus.DONE)
+
+    tool_envelopes = agent_response.get("tool_envelopes", [])
+    if tool_envelopes:
+        await thread_manager.set_message_trace(
+            message_id=child_message_id,
+            tool_envelopes=tool_envelopes,
+            otel_trace_id=None,
+        )
+
+    await task_manager._publish_stream_update(
+        thread_id,
+        "turn_complete",
+        {
+            "task_id": child_task_id,
+            "parent_task_id": parent_task_id,
+            "message": f"Deep triage completed for {target_label}",
+            "target": target_metadata,
+        },
+    )
+    return result
+
+
+async def _run_multi_target_deep_triage_fanout(
+    *,
+    agent: Any,
+    bindings: List[Any],
+    task_id: str,
+    thread_id: str,
+    thread: Any,
+    task_manager: TaskManager,
+    thread_manager: ThreadManager,
+    conversation_state: Dict[str, Any],
+    routing_context: Dict[str, Any],
+    original_query: str,
+    generation: int,
+) -> Dict[str, Any]:
+    """Fan out a multi-target deep-triage turn into one child task per target."""
+    child_specs: List[Dict[str, Any]] = []
+    for binding in bindings:
+        target_metadata = _target_binding_metadata(binding)
+        target_label = target_metadata["display_name"] or target_metadata["target_handle"]
+        child_task_id = await task_manager.create_task(
+            thread_id=thread_id,
+            user_id=thread.metadata.user_id,
+            subject=f"Deep triage: {target_label}",
+        )
+        child_specs.append(
+            {
+                "task_id": child_task_id,
+                "binding": binding,
+                "target": target_metadata,
+            }
+        )
+
+    await task_manager.add_task_update(
+        task_id,
+        f"Starting deep triage fan-out for {len(child_specs)} targets",
+        "triage_fanout_start",
+        metadata={
+            "child_task_ids": [spec["task_id"] for spec in child_specs],
+            "target_count": len(child_specs),
+            "targets": [spec["target"] for spec in child_specs],
+        },
+    )
+
+    child_tasks = [
+        asyncio.create_task(
+            _run_single_target_triage_child(
+                agent=agent,
+                binding=spec["binding"],
+                child_task_id=spec["task_id"],
+                parent_task_id=task_id,
+                thread_id=thread_id,
+                thread=thread,
+                task_manager=task_manager,
+                thread_manager=thread_manager,
+                base_conversation_state=conversation_state,
+                base_context=routing_context,
+                original_query=original_query,
+                generation=generation,
+            )
+        )
+        for spec in child_specs
+    ]
+
+    child_results: List[Dict[str, Any]] = []
+    for child_task in asyncio.as_completed(child_tasks):
+        child_result = await child_task
+        child_results.append(child_result)
+        target = child_result.get("target") or {}
+        target_label = target.get("display_name") or target.get("target_handle") or "target"
+        status = str(child_result.get("status") or TaskStatus.DONE.value)
+        update_type = (
+            "triage_fanout_child_failed"
+            if status == TaskStatus.FAILED.value
+            else "triage_fanout_child_complete"
+        )
+        await task_manager.add_task_update(
+            task_id,
+            f"Deep triage {status} for {target_label}",
+            update_type,
+            metadata={
+                "child_task_id": child_result.get("task_id"),
+                "message_id": child_result.get("message_id"),
+                "status": status,
+                "target": target,
+            },
+        )
+
+    failed_count = sum(
+        1 for child_result in child_results if child_result.get("status") == TaskStatus.FAILED.value
+    )
+    awaiting_approval_count = sum(
+        1
+        for child_result in child_results
+        if child_result.get("status") == TaskStatus.AWAITING_APPROVAL.value
+    )
+    response = (
+        f"Deep triage fan-out completed for {len(child_results)} targets. "
+        "Individual target reports were emitted as child task results."
+    )
+    if failed_count or awaiting_approval_count:
+        response += (
+            f" Failed targets: {failed_count}. Awaiting approval: {awaiting_approval_count}."
+        )
+
+    result = {
+        "response": response,
+        "metadata": {
+            "agent_type": "redis_triage",
+            "fanout": True,
+            "target_count": len(bindings),
+            "failed_count": failed_count,
+            "awaiting_approval_count": awaiting_approval_count,
+        },
+        "thread_id": thread_id,
+        "task_id": task_id,
+        "child_task_ids": [spec["task_id"] for spec in child_specs],
+        "target_results": [
+            {
+                "task_id": child_result.get("task_id"),
+                "message_id": child_result.get("message_id"),
+                "status": child_result.get("status"),
+                "target": child_result.get("target"),
+            }
+            for child_result in child_results
+        ],
+        "turn_completed_at": datetime.now(timezone.utc).isoformat(),
+    }
+    await task_manager.set_task_result(task_id, result)
+    await task_manager.update_task_status(task_id, TaskStatus.DONE)
+    await task_manager._publish_stream_update(
+        thread_id,
+        "turn_complete",
+        {"task_id": task_id, "message": "Multi-target deep triage fan-out completed"},
+    )
+    return result
 
 
 # NOTE: analyze_system_metrics was removed as it was never actually provided
@@ -1861,6 +2248,40 @@ async def _process_agent_turn_impl(
             task_manager=task_manager,
             task_id=task_id,
         )
+
+        fanout_bindings = current_scope.bindings or get_target_bindings_from_context(
+            routing_context
+        )
+        if agent_type == AgentType.REDIS_TRIAGE and len(fanout_bindings) > 1:
+            await task_manager.add_task_update(
+                task_id,
+                "Processing query with per-target deep triage fan-out",
+                "agent_processing",
+                metadata={"target_count": len(fanout_bindings)},
+            )
+            result = await _run_multi_target_deep_triage_fanout(
+                agent=agent,
+                bindings=fanout_bindings,
+                task_id=task_id,
+                thread_id=thread_id,
+                thread=thread,
+                task_manager=task_manager,
+                thread_manager=thread_manager,
+                conversation_state=conversation_state,
+                routing_context=routing_context,
+                original_query=message,
+                generation=int(
+                    routing_context.get("target_toolset_generation")
+                    or current_scope.toolset_generation
+                    or 0
+                ),
+            )
+            try:
+                if _root_span is not None:
+                    _root_span.end()
+            except Exception:
+                pass
+            return result
 
         # Run the appropriate agent
         if agent_type != AgentType.REDIS_TRIAGE:

--- a/redis_sre_agent/evaluation/live_suite/__init__.py
+++ b/redis_sre_agent/evaluation/live_suite/__init__.py
@@ -349,7 +349,14 @@ def _infer_live_trace_logical_identity(
         }
 
     candidate_operations: list[tuple[int, str, str, str | None]] = []
-    for provider_family, operation_map in scenario.tools.providers.items():
+    provider_operations = {
+        provider_family: set(operation_map)
+        for provider_family, operation_map in scenario.tools.providers.items()
+    }
+    provider_operations.setdefault("target_discovery", set()).update(
+        {"list_known_redis_targets", "resolve_redis_targets"}
+    )
+    for provider_family, operations in provider_operations.items():
         raw_provider = normalize_tool_name_token(provider_family)
         normalized_provider = normalize_provider_family(raw_provider)
         provider_prefixes = {
@@ -358,7 +365,7 @@ def _infer_live_trace_logical_identity(
         }
         if not any(normalized_name.startswith(prefix) for prefix in provider_prefixes):
             continue
-        for operation in operation_map:
+        for operation in operations:
             normalized_operation = normalize_tool_name_token(operation)
             if normalized_name.endswith(f"_{normalized_operation}"):
                 candidate_operations.append(

--- a/redis_sre_agent/evaluation/runtime.py
+++ b/redis_sre_agent/evaluation/runtime.py
@@ -32,6 +32,8 @@ from redis_sre_agent.evaluation.scenarios import EvalScenario, ExecutionLane
 from redis_sre_agent.evaluation.tool_runtime import FixtureBehaviorState, build_fixture_tool_runtime
 from redis_sre_agent.targets import TargetBindingService
 from redis_sre_agent.targets.contracts import (
+    DISCOVERY_STATUS_TOO_MANY_MATCHES,
+    MULTI_TARGET_SELECTION_LIMIT,
     DiscoveryCandidate,
     DiscoveryRequest,
     DiscoveryResponse,
@@ -325,20 +327,38 @@ class _EvalTargetCatalogDiscoveryBackend:
             )
 
         ranked.sort(key=lambda candidate: (candidate.score, candidate.confidence), reverse=True)
-        limited = ranked[: max(1, min(request.max_results, 10))]
+        response_limit = max(1, min(request.max_results, 10))
+        selection_limit = max(1, min(request.max_results, MULTI_TARGET_SELECTION_LIMIT))
+        limited = ranked[:response_limit]
         if not limited:
             return DiscoveryResponse(status="no_match")
 
         top = limited[0]
         if request.allow_multiple:
-            selected = [
-                candidate for candidate in limited if candidate.score >= max(3.0, top.score - 1.5)
-            ][: min(3, request.max_results)]
+            selectable = [
+                candidate for candidate in ranked if candidate.score >= max(3.0, top.score - 1.5)
+            ]
+            if len(selectable) > selection_limit:
+                return DiscoveryResponse(
+                    status=DISCOVERY_STATUS_TOO_MANY_MATCHES,
+                    clarification_required=True,
+                    matches=[candidate.public_match for candidate in selectable[:response_limit]],
+                    selected_matches=[],
+                    message=(
+                        f"Matched {len(selectable)} Redis targets, but at most {selection_limit} "
+                        "can be selected for one multi-target request. Ask the user to narrow the target set."
+                    ),
+                    max_selectable=selection_limit,
+                    match_count=len(selectable),
+                    truncated=len(selectable) > response_limit,
+                )
+            selected = selectable[:selection_limit]
             return DiscoveryResponse(
                 status="resolved",
                 clarification_required=False,
                 matches=[candidate.public_match for candidate in limited],
                 selected_matches=selected,
+                match_count=len(selectable),
             )
 
         clarification_required = len(limited) > 1 and limited[1].score >= top.score - 0.75

--- a/redis_sre_agent/evaluation/runtime.py
+++ b/redis_sre_agent/evaluation/runtime.py
@@ -377,6 +377,19 @@ def _build_eval_target_catalog_docs(scenario: EvalScenario) -> list[TargetCatalo
     return [_build_eval_target_catalog_doc(entry) for entry in scenario.scope.target_catalog]
 
 
+def _build_eval_target_handle_lookup(scenario: EvalScenario) -> dict[tuple[str, str], str]:
+    """Map eval target catalog subjects to stable scenario handles."""
+
+    lookup: dict[tuple[str, str], str] = {}
+    for entry in scenario.scope.target_catalog:
+        subjects = {entry.handle}
+        if entry.resource_id:
+            subjects.add(entry.resource_id)
+        for subject in subjects:
+            lookup[(entry.kind, subject)] = entry.handle
+    return lookup
+
+
 def _build_eval_target_registry(scenario: EvalScenario) -> TargetIntegrationRegistry | None:
     """Install a scenario-backed discovery backend while reusing production binders."""
 
@@ -410,11 +423,43 @@ def _target_registry_override_scope(
         return nullcontext()
 
     catalog_docs = _build_eval_target_catalog_docs(scenario)
+    target_handle_lookup = _build_eval_target_handle_lookup(scenario)
 
     async def _get_eval_target_catalog(*, user_id: str | None = None) -> list[TargetCatalogDoc]:
         if not user_id:
             return list(catalog_docs)
         return [doc for doc in catalog_docs if doc.user_id in {None, "", user_id}]
+
+    original_build_public_binding = TargetBindingService.build_public_binding
+
+    def _build_eval_public_binding(
+        cls,
+        candidate,
+        *,
+        thread_id: str | None,
+        task_id: str | None,
+        existing_handle: str | None = None,
+    ) -> PublicTargetBinding:
+        if existing_handle is None:
+            normalized_candidate = cls._normalize_candidate(candidate)
+            public_match = normalized_candidate.public_match
+            candidate_subjects = [
+                normalized_candidate.binding_subject,
+                public_match.resource_id,
+            ]
+            for subject in candidate_subjects:
+                if not subject:
+                    continue
+                existing_handle = target_handle_lookup.get((public_match.target_kind, subject))
+                if existing_handle:
+                    break
+
+        return original_build_public_binding(
+            candidate,
+            thread_id=thread_id,
+            task_id=task_id,
+            existing_handle=existing_handle,
+        )
 
     stack = ExitStack()
     for target in (
@@ -425,6 +470,13 @@ def _target_registry_override_scope(
         stack.enter_context(patch(target, return_value=registry))
     stack.enter_context(
         patch("redis_sre_agent.core.targets.get_target_catalog", new=_get_eval_target_catalog)
+    )
+    stack.enter_context(
+        patch.object(
+            TargetBindingService,
+            "build_public_binding",
+            classmethod(_build_eval_public_binding),
+        )
     )
     return stack
 

--- a/redis_sre_agent/targets/contracts.py
+++ b/redis_sre_agent/targets/contracts.py
@@ -7,6 +7,9 @@ from typing import Any, Dict, List, Optional, Protocol
 
 from pydantic import BaseModel, Field, field_validator
 
+MULTI_TARGET_SELECTION_LIMIT = 5
+DISCOVERY_STATUS_TOO_MANY_MATCHES = "too_many_matches"
+
 
 class PublicTargetMatch(BaseModel):
     """Secret-safe target match shown to the model."""
@@ -163,11 +166,15 @@ class DiscoveryResponse(BaseModel):
     matches: List[PublicTargetMatch] = Field(default_factory=list)
     attached_target_handles: List[str] = Field(default_factory=list)
     toolset_generation: int = 0
+    message: Optional[str] = None
+    max_selectable: Optional[int] = None
+    match_count: int = 0
+    truncated: bool = False
     selected_matches: List[DiscoveryCandidate] = Field(default_factory=list, exclude=True)
 
     def public_dump(self) -> Dict[str, Any]:
         """Return the model-facing discovery payload."""
-        payload = self.model_dump(mode="json")
+        payload = self.model_dump(mode="json", exclude_none=True)
         payload["matches"] = [match.public_dump() for match in self.matches]
         return payload
 

--- a/redis_sre_agent/targets/redis_catalog.py
+++ b/redis_sre_agent/targets/redis_catalog.py
@@ -15,7 +15,7 @@ def _select_catalog_candidates(
     allow_multiple: bool,
     max_results: int,
 ) -> tuple[List[DiscoveryCandidate], bool]:
-    selection_limit = min(3, max_results)
+    selection_limit = max(1, min(max_results, 10))
 
     if exact_ranked:
         if allow_multiple:

--- a/redis_sre_agent/targets/redis_catalog.py
+++ b/redis_sre_agent/targets/redis_catalog.py
@@ -4,7 +4,13 @@ from __future__ import annotations
 
 from typing import List
 
-from .contracts import DiscoveryCandidate, DiscoveryRequest, DiscoveryResponse
+from .contracts import (
+    DISCOVERY_STATUS_TOO_MANY_MATCHES,
+    MULTI_TARGET_SELECTION_LIMIT,
+    DiscoveryCandidate,
+    DiscoveryRequest,
+    DiscoveryResponse,
+)
 from .registry import get_target_integration_registry
 
 
@@ -14,19 +20,21 @@ def _select_catalog_candidates(
     *,
     allow_multiple: bool,
     max_results: int,
-) -> tuple[List[DiscoveryCandidate], bool]:
-    selection_limit = max(1, min(max_results, 10))
+) -> tuple[List[DiscoveryCandidate], bool, bool]:
+    selection_limit = max(1, min(max_results, MULTI_TARGET_SELECTION_LIMIT))
 
     if exact_ranked:
         if allow_multiple:
-            return exact_ranked[:selection_limit], False
+            if len(exact_ranked) > selection_limit:
+                return [], False, True
+            return exact_ranked[:selection_limit], False, False
 
         top_exact = exact_ranked[0]
         if len(exact_ranked) > 1 and exact_ranked[1].score >= top_exact.score - 0.75:
-            return exact_ranked[:selection_limit], True
-        return [top_exact], False
+            return exact_ranked[:selection_limit], True, False
+        return [top_exact], False, False
 
-    return limited[:selection_limit], True
+    return limited[:selection_limit], True, False
 
 
 class RedisCatalogDiscoveryBackend:
@@ -90,24 +98,44 @@ class RedisCatalogDiscoveryBackend:
         exact_ranked.sort(
             key=lambda candidate: (candidate.score, candidate.confidence), reverse=True
         )
-        limited = ranked[: max(1, min(request.max_results, 10))]
+        response_limit = max(1, min(request.max_results, 10))
+        limited = ranked[:response_limit]
         if not limited:
             return DiscoveryResponse(status="no_match")
 
-        selected, clarification_required = _select_catalog_candidates(
+        selected, clarification_required, too_many_matches = _select_catalog_candidates(
             limited,
             exact_ranked,
             allow_multiple=request.allow_multiple,
             max_results=request.max_results,
         )
+        selection_limit = max(1, min(request.max_results, MULTI_TARGET_SELECTION_LIMIT))
+        response_matches = (
+            exact_ranked[:response_limit] if too_many_matches and exact_ranked else limited
+        )
+        match_count = len(exact_ranked) if exact_ranked else len(ranked)
+        status = (
+            DISCOVERY_STATUS_TOO_MANY_MATCHES
+            if too_many_matches
+            else "clarification_required"
+            if clarification_required
+            else "resolved"
+            if selected
+            else "no_match"
+        )
 
         return DiscoveryResponse(
-            status=(
-                "clarification_required"
-                if clarification_required
-                else ("resolved" if selected else "no_match")
-            ),
-            clarification_required=clarification_required,
-            matches=[candidate.public_match for candidate in limited],
+            status=status,
+            clarification_required=clarification_required or too_many_matches,
+            matches=[candidate.public_match for candidate in response_matches],
             selected_matches=selected,
+            message=(
+                f"Matched {match_count} Redis targets, but at most {selection_limit} "
+                "can be selected for one multi-target request. Ask the user to narrow the target set."
+                if too_many_matches
+                else None
+            ),
+            max_selectable=selection_limit if too_many_matches else None,
+            match_count=match_count,
+            truncated=len(response_matches) < match_count,
         )

--- a/redis_sre_agent/tools/target_discovery/provider.py
+++ b/redis_sre_agent/tools/target_discovery/provider.py
@@ -104,7 +104,10 @@ class TargetDiscoveryToolProvider(ToolProvider):
                         },
                         "max_results": {
                             "type": "integer",
-                            "description": "Maximum number of candidate matches to return.",
+                            "description": (
+                                "Maximum number of candidate matches to return. Multi-target "
+                                "selection is capped at 5 targets even when more candidates are returned."
+                            ),
                             "default": 5,
                             "minimum": 1,
                             "maximum": 10,

--- a/scripts/run_live_eval_suite.py
+++ b/scripts/run_live_eval_suite.py
@@ -6,8 +6,13 @@ from __future__ import annotations
 import argparse
 import asyncio
 import os
+from pathlib import Path
+
+from dotenv import load_dotenv
 
 from redis_sre_agent.evaluation.live_suite import load_live_eval_suite_config, run_live_eval_suite
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
 
 
 def _parse_args() -> argparse.Namespace:
@@ -51,6 +56,8 @@ def _parse_args() -> argparse.Namespace:
 
 
 def _require_live_model_credentials() -> None:
+    load_dotenv(dotenv_path=_REPO_ROOT / ".env")
+    load_dotenv()
     if os.getenv("OPENAI_API_KEY"):
         return
     raise SystemExit("OPENAI_API_KEY is required for live eval runs")

--- a/scripts/run_live_eval_suite.py
+++ b/scripts/run_live_eval_suite.py
@@ -6,10 +6,15 @@ from __future__ import annotations
 import argparse
 import asyncio
 import os
+from contextlib import contextmanager
 from pathlib import Path
+from typing import Iterator
 
 from dotenv import load_dotenv
+from pydantic import SecretStr
+from testcontainers.redis import RedisContainer
 
+import redis_sre_agent.core.config as config_module
 from redis_sre_agent.evaluation.live_suite import load_live_eval_suite_config, run_live_eval_suite
 
 _REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -52,6 +57,11 @@ def _parse_args() -> argparse.Namespace:
         default="live-eval",
         help="Prefix used for generated live-eval session ids.",
     )
+    parser.add_argument(
+        "--redis-testcontainer",
+        action="store_true",
+        help="Run the suite against an isolated Redis testcontainer.",
+    )
     return parser.parse_args()
 
 
@@ -61,6 +71,31 @@ def _require_live_model_credentials() -> None:
     if os.getenv("OPENAI_API_KEY"):
         return
     raise SystemExit("OPENAI_API_KEY is required for live eval runs")
+
+
+@contextmanager
+def _redis_testcontainer_scope(enabled: bool) -> Iterator[str | None]:
+    if not enabled:
+        yield None
+        return
+
+    old_env_redis_url = os.environ.get("REDIS_URL")
+    old_settings_redis_url = config_module.settings.redis_url
+
+    with RedisContainer("redis:8") as redis_container:
+        host = redis_container.get_container_host_ip()
+        port = redis_container.get_exposed_port(redis_container.port)
+        redis_url = f"redis://{host}:{port}/0"
+        os.environ["REDIS_URL"] = redis_url
+        config_module.settings.redis_url = SecretStr(redis_url)
+        try:
+            yield redis_url
+        finally:
+            config_module.settings.redis_url = old_settings_redis_url
+            if old_env_redis_url is None:
+                os.environ.pop("REDIS_URL", None)
+            else:
+                os.environ["REDIS_URL"] = old_env_redis_url
 
 
 async def _run(args: argparse.Namespace) -> int:
@@ -80,16 +115,17 @@ async def _run(args: argparse.Namespace) -> int:
             )
         suite_name = suite_names[0]
 
-    summary = await run_live_eval_suite(
-        suite_name,
-        config_path=args.suite,
-        output_dir=args.report_dir,
-        user_id="github-actions-live-eval",
-        session_id_prefix=args.session_id_prefix,
-        baseline_profile=args.baseline_profile,
-        event_name=args.trigger,
-        update_baseline=args.update_baseline or args.baseline_profile == "manual_update",
-    )
+    with _redis_testcontainer_scope(args.redis_testcontainer):
+        summary = await run_live_eval_suite(
+            suite_name,
+            config_path=args.suite,
+            output_dir=args.report_dir,
+            user_id="github-actions-live-eval",
+            session_id_prefix=args.session_id_prefix,
+            baseline_profile=args.baseline_profile,
+            event_name=args.trigger,
+            update_baseline=args.update_baseline or args.baseline_profile == "manual_update",
+        )
     print(summary.model_dump_json(indent=2))
     return 0 if summary.overall_pass else 1
 

--- a/tests/integration/test_target_discovery_flow.py
+++ b/tests/integration/test_target_discovery_flow.py
@@ -9,7 +9,6 @@ import pytest
 from redisvl.index import AsyncSearchIndex
 from redisvl.schema import IndexSchema
 
-from redis_sre_agent.agent.router import AgentType
 from redis_sre_agent.core.docket_tasks import process_agent_turn
 from redis_sre_agent.core.instances import RedisInstance, save_instances
 from redis_sre_agent.core.redis import (
@@ -546,10 +545,6 @@ async def test_process_agent_turn_pre_resolves_target_scope_for_deep_triage(
     }
 
     with (
-        patch(
-            "redis_sre_agent.core.docket_tasks.route_to_appropriate_agent",
-            new=AsyncMock(return_value=AgentType.REDIS_TRIAGE),
-        ),
         patch(
             "redis_sre_agent.core.docket_tasks.run_agent_with_progress",
             new=AsyncMock(return_value=fake_agent_result),

--- a/tests/integration/test_target_discovery_flow.py
+++ b/tests/integration/test_target_discovery_flow.py
@@ -546,6 +546,14 @@ async def test_process_agent_turn_pre_resolves_target_scope_for_deep_triage(
 
     with (
         patch(
+            "redis_sre_agent.agent.router.create_nano_llm",
+            return_value=MagicMock(),
+        ),
+        patch(
+            "redis_sre_agent.agent.router.guarded_ainvoke",
+            new=AsyncMock(return_value=MagicMock(content="DEEP_TRIAGE")),
+        ),
+        patch(
             "redis_sre_agent.core.docket_tasks.run_agent_with_progress",
             new=AsyncMock(return_value=fake_agent_result),
         ),

--- a/tests/unit/agent/test_chat_agent.py
+++ b/tests/unit/agent/test_chat_agent.py
@@ -251,6 +251,7 @@ class TestChatAgentSystemPrompt:
         assert "list_known_redis_targets" in CHAT_SYSTEM_PROMPT
         assert "resolve_redis_targets" in CHAT_SYSTEM_PROMPT
         assert "allow_multiple=true" in CHAT_SYSTEM_PROMPT
+        assert "too_many_matches" in CHAT_SYSTEM_PROMPT
         assert "what redis targets you know about" in prompt_lower
 
     def test_system_prompt_requires_skill_fetch_and_hostname_caution(self):

--- a/tests/unit/agent/test_router.py
+++ b/tests/unit/agent/test_router.py
@@ -89,14 +89,24 @@ class TestRouteToAppropriateAgent:
 
             assert result == AgentType.REDIS_CHAT
 
-    async def test_zero_scope_deep_language_still_defaults_to_chat(self):
-        """Until target discovery lands, zero-scope requests stay on chat even if phrased broadly."""
-        result = await route_to_appropriate_agent(
-            query="Do a deep triage on Redis best practices",
-            context=None,
-        )
+    @pytest.mark.parametrize(
+        "query",
+        [
+            "Do a deep triage on database 12345",
+            "Do a deep triage on orders-cache-prod",
+            "Run a comprehensive triage for the prod orders cache",
+        ],
+    )
+    async def test_zero_scope_deep_language_routes_to_triage_without_llm(self, query):
+        """Zero-scope deep-triage requests should enter target discovery."""
+        with patch("redis_sre_agent.agent.router.create_nano_llm") as mock_create:
+            result = await route_to_appropriate_agent(
+                query=query,
+                context=None,
+            )
 
-        assert result == AgentType.REDIS_CHAT
+        assert result == AgentType.REDIS_TRIAGE
+        mock_create.assert_not_called()
 
     async def test_user_preference_respected(self):
         """Test that user preferences are respected when instance exists."""

--- a/tests/unit/agent/test_router.py
+++ b/tests/unit/agent/test_router.py
@@ -33,15 +33,21 @@ class TestRouteToAppropriateAgent:
     """Test the route_to_appropriate_agent function."""
 
     async def test_no_instance_routes_to_chat(self):
-        """Zero-scope queries should use chat as the default general-purpose agent."""
+        """Zero-scope queries should use nano routing before defaulting to chat."""
         with patch("redis_sre_agent.agent.router.create_nano_llm") as mock_create:
+            mock_llm = MagicMock()
+            mock_response = MagicMock()
+            mock_response.content = "CHAT"
+            mock_llm.ainvoke = AsyncMock(return_value=mock_response)
+            mock_create.return_value = mock_llm
+
             result = await route_to_appropriate_agent(
                 query="What are Redis best practices?",
                 context=None,
             )
 
             assert result == AgentType.REDIS_CHAT
-            mock_create.assert_not_called()
+            mock_create.assert_called_once()
 
     async def test_instance_with_deep_triage_request_routes_to_triage(self):
         """Test that deep triage requests with instance route to triage agent."""
@@ -97,16 +103,34 @@ class TestRouteToAppropriateAgent:
             "Run a comprehensive triage for the prod orders cache",
         ],
     )
-    async def test_zero_scope_deep_language_routes_to_triage_without_llm(self, query):
+    async def test_zero_scope_deep_language_routes_to_triage_with_llm(self, query):
         """Zero-scope deep-triage requests should enter target discovery."""
         with patch("redis_sre_agent.agent.router.create_nano_llm") as mock_create:
+            mock_llm = MagicMock()
+            mock_response = MagicMock()
+            mock_response.content = "DEEP_TRIAGE"
+            mock_llm.ainvoke = AsyncMock(return_value=mock_response)
+            mock_create.return_value = mock_llm
+
             result = await route_to_appropriate_agent(
                 query=query,
                 context=None,
             )
 
         assert result == AgentType.REDIS_TRIAGE
-        mock_create.assert_not_called()
+        mock_create.assert_called_once()
+
+    async def test_zero_scope_llm_error_defaults_to_chat(self):
+        """Zero-scope LLM routing failures should still default to chat."""
+        with patch("redis_sre_agent.agent.router.create_nano_llm") as mock_create:
+            mock_create.side_effect = Exception("LLM unavailable")
+
+            result = await route_to_appropriate_agent(
+                query="What are Redis best practices?",
+                context=None,
+            )
+
+            assert result == AgentType.REDIS_CHAT
 
     async def test_user_preference_respected(self):
         """Test that user preferences are respected when instance exists."""

--- a/tests/unit/cli/test_cli_eval.py
+++ b/tests/unit/cli/test_cli_eval.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import os
 
 from click.testing import CliRunner
 
@@ -563,6 +564,18 @@ def test_eval_live_suite_command_defaults_missing_overall_pass_to_failure(tmp_pa
 
     assert result.exit_code == 1
     assert "Overall pass: no" in result.output
+
+
+def test_live_eval_script_loads_repo_dotenv_before_requiring_credentials(tmp_path, monkeypatch):
+    import scripts.run_live_eval_suite as live_eval_script
+
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.setattr(live_eval_script, "_REPO_ROOT", tmp_path)
+    (tmp_path / ".env").write_text("OPENAI_API_KEY=dotenv-test-key\n", encoding="utf-8")
+
+    live_eval_script._require_live_model_credentials()
+
+    assert os.environ["OPENAI_API_KEY"] == "dotenv-test-key"
 
 
 def test_eval_list_json_includes_known_scenario():

--- a/tests/unit/cli/test_cli_eval.py
+++ b/tests/unit/cli/test_cli_eval.py
@@ -578,6 +578,47 @@ def test_live_eval_script_loads_repo_dotenv_before_requiring_credentials(tmp_pat
     assert os.environ["OPENAI_API_KEY"] == "dotenv-test-key"
 
 
+def test_live_eval_script_uses_redis_testcontainer_scope(monkeypatch):
+    import scripts.run_live_eval_suite as live_eval_script
+
+    created_images = []
+    exited = False
+    original_settings_redis_url = live_eval_script.config_module.settings.redis_url
+
+    class FakeRedisContainer:
+        port = 6379
+
+        def __init__(self, image: str):
+            created_images.append(image)
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            nonlocal exited
+            exited = True
+
+        def get_container_host_ip(self):
+            return "127.0.0.1"
+
+        def get_exposed_port(self, port):
+            assert port == 6379
+            return "49153"
+
+    monkeypatch.delenv("REDIS_URL", raising=False)
+    monkeypatch.setattr(live_eval_script, "RedisContainer", FakeRedisContainer)
+
+    with live_eval_script._redis_testcontainer_scope(True) as redis_url:
+        assert redis_url == "redis://127.0.0.1:49153/0"
+        assert os.environ["REDIS_URL"] == redis_url
+        assert live_eval_script.config_module.settings.redis_url.get_secret_value() == redis_url
+
+    assert created_images == ["redis:8"]
+    assert exited is True
+    assert "REDIS_URL" not in os.environ
+    assert live_eval_script.config_module.settings.redis_url is original_settings_redis_url
+
+
 def test_eval_list_json_includes_known_scenario():
     runner = CliRunner()
 

--- a/tests/unit/core/test_targets.py
+++ b/tests/unit/core/test_targets.py
@@ -363,6 +363,42 @@ async def test_resolve_target_query_allow_multiple_uses_exact_mentions_inside_co
 
 
 @pytest.mark.asyncio
+async def test_resolve_target_query_allow_multiple_honors_max_results_for_exact_mentions():
+    targets = [
+        TargetCatalogDoc(
+            target_id=f"instance:redis-prod-cache-{index}",
+            target_kind="instance",
+            resource_id=f"redis-prod-cache-{index}",
+            display_name=f"cache-{index}-prod",
+            name=f"cache-{index}-prod",
+            environment="production",
+            usage="cache",
+            target_type="oss_single",
+            capabilities=["redis", "diagnostics"],
+            search_text=f"cache {index} prod production cache",
+            search_aliases=[f"cache {index} prod"],
+        )
+        for index in range(5)
+    ]
+
+    with patch(
+        "redis_sre_agent.core.targets.get_target_catalog",
+        new=AsyncMock(return_value=targets),
+    ):
+        resolved = await resolve_target_query(
+            query="deep triage cache-0-prod cache-1-prod cache-2-prod cache-3-prod cache-4-prod",
+            allow_multiple=True,
+            max_results=5,
+        )
+
+    assert resolved.status == "resolved"
+    assert resolved.clarification_required is False
+    assert [match.resource_id for match in resolved.selected_matches] == [
+        f"redis-prod-cache-{index}" for index in range(5)
+    ]
+
+
+@pytest.mark.asyncio
 async def test_resolve_target_query_allow_multiple_requires_confirmation_for_descriptive_query():
     prod = TargetCatalogDoc(
         target_id="instance:redis-prod-checkout-cache",

--- a/tests/unit/core/test_targets.py
+++ b/tests/unit/core/test_targets.py
@@ -26,6 +26,10 @@ from redis_sre_agent.core.targets import (
     sync_target_catalog,
 )
 from redis_sre_agent.core.threads import Thread, ThreadMetadata
+from redis_sre_agent.targets.contracts import (
+    DISCOVERY_STATUS_TOO_MANY_MATCHES,
+    MULTI_TARGET_SELECTION_LIMIT,
+)
 from redis_sre_agent.targets.services import TargetBindingService
 
 
@@ -396,6 +400,43 @@ async def test_resolve_target_query_allow_multiple_honors_max_results_for_exact_
     assert [match.resource_id for match in resolved.selected_matches] == [
         f"redis-prod-cache-{index}" for index in range(5)
     ]
+
+
+@pytest.mark.asyncio
+async def test_resolve_target_query_allow_multiple_rejects_over_limit_exact_mentions():
+    targets = [
+        TargetCatalogDoc(
+            target_id=f"instance:redis-prod-cache-{index}",
+            target_kind="instance",
+            resource_id=f"redis-prod-cache-{index}",
+            display_name=f"cache-{index}-prod",
+            name=f"cache-{index}-prod",
+            environment="production",
+            usage="cache",
+            target_type="oss_single",
+            capabilities=["redis", "diagnostics"],
+            search_text=f"cache {index} prod production cache",
+            search_aliases=[f"cache {index} prod"],
+        )
+        for index in range(10)
+    ]
+
+    with patch(
+        "redis_sre_agent.core.targets.get_target_catalog",
+        new=AsyncMock(return_value=targets),
+    ):
+        resolved = await resolve_target_query(
+            query="deep triage " + " ".join(f"cache-{index}-prod" for index in range(10)),
+            allow_multiple=True,
+            max_results=10,
+        )
+
+    assert resolved.status == DISCOVERY_STATUS_TOO_MANY_MATCHES
+    assert resolved.clarification_required is True
+    assert resolved.selected_matches == []
+    assert resolved.match_count == 10
+    assert resolved.max_selectable == MULTI_TARGET_SELECTION_LIMIT
+    assert "narrow" in (resolved.message or "")
 
 
 @pytest.mark.asyncio

--- a/tests/unit/core/test_tasks.py
+++ b/tests/unit/core/test_tasks.py
@@ -52,6 +52,11 @@ from redis_sre_agent.core.targets import (
 from redis_sre_agent.core.tasks import TaskState, TaskStatus
 from redis_sre_agent.core.threads import Message, Thread, ThreadMetadata
 from redis_sre_agent.core.turn_scope import TurnScope
+from redis_sre_agent.targets.contracts import (
+    DISCOVERY_STATUS_TOO_MANY_MATCHES,
+    DiscoveryResponse,
+    PublicTargetMatch,
+)
 
 
 def _build_approval_required_error(
@@ -2187,6 +2192,97 @@ class TestProcessAgentTurn:
             "child-task-1",
             "child-task-2",
         ]
+
+    @pytest.mark.asyncio
+    async def test_pre_resolved_over_limit_multi_target_deep_triage_asks_to_narrow(self):
+        mock_redis = AsyncMock()
+        mock_thread = MagicMock()
+        mock_thread.context = {}
+        mock_thread.messages = []
+        mock_thread.metadata.user_id = "test-user"
+        mock_thread.metadata.session_id = "session-123"
+
+        mock_thread_manager = AsyncMock()
+        mock_thread_manager.get_thread = AsyncMock(return_value=mock_thread)
+        mock_thread_manager.update_thread_context = AsyncMock()
+        mock_thread_manager.append_messages = AsyncMock()
+        mock_thread_manager.update_thread = AsyncMock()
+
+        mock_task_manager = AsyncMock()
+        mock_task_manager.create_task = AsyncMock(return_value="provided-task-123")
+        mock_task_manager.add_task_update = AsyncMock()
+        mock_task_manager.set_task_result = AsyncMock()
+        mock_task_manager.update_task_status = AsyncMock()
+        mock_task_manager._publish_stream_update = AsyncMock()
+        mock_task_manager.get_task_state = AsyncMock(return_value=MagicMock(updates=[]))
+
+        resolution = DiscoveryResponse(
+            status=DISCOVERY_STATUS_TOO_MANY_MATCHES,
+            clarification_required=True,
+            matches=[
+                PublicTargetMatch(
+                    target_kind="instance",
+                    display_name=f"cache-{index}-prod",
+                    confidence=1.0,
+                    capabilities=["diagnostics"],
+                )
+                for index in range(5)
+            ],
+            selected_matches=[],
+            max_selectable=5,
+            match_count=10,
+            message="Matched 10 Redis targets; ask the user to narrow the target set.",
+            truncated=True,
+        )
+        mock_run_agent = AsyncMock()
+
+        with (
+            patch("redis_sre_agent.core.docket_tasks.get_redis_client", return_value=mock_redis),
+            patch(
+                "redis_sre_agent.core.docket_tasks.ThreadManager", return_value=mock_thread_manager
+            ),
+            patch("redis_sre_agent.core.docket_tasks.TaskManager", return_value=mock_task_manager),
+            patch(
+                "redis_sre_agent.core.docket_tasks._extract_instance_details_from_message",
+                return_value=None,
+            ),
+            patch(
+                "redis_sre_agent.core.docket_tasks.route_to_appropriate_agent",
+                new=AsyncMock(return_value=AgentType.REDIS_TRIAGE),
+            ),
+            patch(
+                "redis_sre_agent.core.targets.resolve_target_query",
+                new=AsyncMock(return_value=resolution),
+            ),
+            patch("redis_sre_agent.core.docket_tasks.get_sre_agent") as mock_get_sre_agent,
+            patch(
+                "redis_sre_agent.core.docket_tasks.run_agent_with_progress",
+                new=mock_run_agent,
+            ),
+            patch(
+                "redis_sre_agent.core.docket_tasks.ULID", return_value="01HXTESTMESSAGEID1234567890"
+            ),
+            patch("opentelemetry.trace.get_tracer") as mock_tracer,
+        ):
+            mock_span = MagicMock()
+            mock_span.end = MagicMock()
+            mock_span.set_attribute = MagicMock()
+            mock_tracer.return_value.start_span.return_value = mock_span
+
+            result = await process_agent_turn(
+                thread_id="thread-123",
+                message="Deep triage cache-0-prod cache-1-prod cache-2-prod cache-3-prod cache-4-prod cache-5-prod cache-6-prod cache-7-prod cache-8-prod cache-9-prod",
+                task_id="provided-task-123",
+            )
+
+        mock_get_sre_agent.assert_not_called()
+        mock_run_agent.assert_not_awaited()
+        assert result["metadata"]["target_resolution_status"] == DISCOVERY_STATUS_TOO_MANY_MATCHES
+        assert result["metadata"]["match_count"] == 10
+        assert "narrow" in result["response"]
+        appended_messages = mock_thread_manager.append_messages.await_args.args[1]
+        assert [message["role"] for message in appended_messages] == ["user", "assistant"]
+        mock_task_manager.update_task_status.assert_any_await("provided-task-123", TaskStatus.DONE)
 
     @pytest.mark.asyncio
     async def test_process_agent_turn_chat_path_does_not_bind_single_target_for_multi_scope(self):

--- a/tests/unit/core/test_tasks.py
+++ b/tests/unit/core/test_tasks.py
@@ -2012,7 +2012,7 @@ class TestProcessAgentTurn:
         assert "cluster_id" not in kwargs["agent_context"]
 
     @pytest.mark.asyncio
-    async def test_pre_resolved_multi_target_scope_reaches_agent_without_singular_target_ids(self):
+    async def test_pre_resolved_multi_target_scope_fans_out_to_child_triage_tasks(self):
         mock_redis = AsyncMock()
         mock_thread = MagicMock()
         mock_thread.context = {}
@@ -2022,11 +2022,12 @@ class TestProcessAgentTurn:
         mock_thread_manager = AsyncMock()
         mock_thread_manager.get_thread = AsyncMock(return_value=mock_thread)
         mock_thread_manager.update_thread_context = AsyncMock()
-        mock_thread_manager.append_message = AsyncMock()
-        mock_thread_manager.update_thread = AsyncMock()
+        mock_thread_manager.append_messages = AsyncMock()
+        mock_thread_manager.set_message_trace = AsyncMock()
 
         mock_task_manager = AsyncMock()
-        mock_task_manager.create_task = AsyncMock(return_value="provided-task-123")
+        mock_task_manager.create_task = AsyncMock(side_effect=["child-task-1", "child-task-2"])
+        mock_task_manager.update_task_status = AsyncMock()
         mock_task_manager.add_task_update = AsyncMock()
         mock_task_manager.set_task_result = AsyncMock()
         mock_task_manager.set_task_error = AsyncMock()
@@ -2080,14 +2081,18 @@ class TestProcessAgentTurn:
                 task_id="provided-task-123",
             ),
         ]
-        mock_run_agent = AsyncMock(
-            return_value={
-                "response": "Comparison response",
+
+        async def _run_child(*args, **kwargs):
+            context = kwargs["agent_context"]
+            handle = context["attached_target_handles"][0]
+            return {
+                "response": f"Triage response for {handle}",
                 "search_results": [],
                 "tool_envelopes": [],
                 "metadata": {"agent_type": "redis_triage"},
             }
-        )
+
+        mock_run_agent = AsyncMock(side_effect=_run_child)
 
         with (
             patch("redis_sre_agent.core.docket_tasks.get_redis_client", return_value=mock_redis),
@@ -2142,18 +2147,46 @@ class TestProcessAgentTurn:
             mock_span.set_attribute = MagicMock()
             mock_tracer.return_value.start_span.return_value = mock_span
 
-            await process_agent_turn(
+            result = await process_agent_turn(
                 thread_id="thread-123",
                 message="Compare checkout and session cache",
                 task_id="provided-task-123",
             )
 
-        _, kwargs = mock_run_agent.await_args
-        assert kwargs["agent_context"]["attached_target_handles"] == ["tgt_01", "tgt_02"]
-        assert kwargs["agent_context"]["active_target_handle"] == "tgt_01"
-        assert kwargs["agent_context"]["target_toolset_generation"] == 4
-        assert "instance_id" not in kwargs["agent_context"]
-        assert "cluster_id" not in kwargs["agent_context"]
+        assert result["metadata"]["fanout"] is True
+        assert result["child_task_ids"] == ["child-task-1", "child-task-2"]
+        assert mock_run_agent.await_count == 2
+        child_contexts = [call.kwargs["agent_context"] for call in mock_run_agent.await_args_list]
+        assert sorted(context["attached_target_handles"][0] for context in child_contexts) == [
+            "tgt_01",
+            "tgt_02",
+        ]
+        for context in child_contexts:
+            assert len(context["attached_target_handles"]) == 1
+            assert len(context["target_bindings"]) == 1
+            assert context["parent_task_id"] == "provided-task-123"
+            assert context["task_id"] in {"child-task-1", "child-task-2"}
+            assert "instance_id" not in context
+            assert "cluster_id" not in context
+
+        result_payloads = [
+            call.args[1] for call in mock_task_manager.set_task_result.await_args_list
+        ]
+        assert {payload["task_id"] for payload in result_payloads} == {
+            "child-task-1",
+            "child-task-2",
+            "provided-task-123",
+        }
+        child_messages = [
+            message
+            for call in mock_thread_manager.append_messages.await_args_list
+            for message in call.args[1]
+            if message["role"] == "assistant"
+        ]
+        assert sorted(message["metadata"]["task_id"] for message in child_messages) == [
+            "child-task-1",
+            "child-task-2",
+        ]
 
     @pytest.mark.asyncio
     async def test_process_agent_turn_chat_path_does_not_bind_single_target_for_multi_scope(self):

--- a/tests/unit/evaluation/test_live_suite.py
+++ b/tests/unit/evaluation/test_live_suite.py
@@ -231,6 +231,29 @@ def test_normalize_tool_trace_infers_re_admin_alias_for_single_bound_target():
     }
 
 
+def test_normalize_tool_trace_infers_target_discovery_without_mocked_provider():
+    scenario = load_eval_scenario(
+        "evals/scenarios/prompt/target-discovery-over-limit-comparison/scenario.yaml"
+    )
+
+    trace = live_suite_module._normalize_tool_trace(
+        [
+            {
+                "tool_key": "target_discovery_a043f5_resolve_redis_targets",
+                "status": "success",
+                "args": {},
+                "data": {"status": "too_many_matches"},
+            }
+        ],
+        scenario=scenario,
+    )
+
+    assert trace[0]["logical"] == {
+        "provider_family": "target_discovery",
+        "operation": "resolve_redis_targets",
+    }
+
+
 def test_normalize_tool_trace_infers_mcp_server_logical_identity():
     scenario = EvalScenario.model_validate(
         {

--- a/tests/unit/evaluation/test_prompt_scenarios.py
+++ b/tests/unit/evaluation/test_prompt_scenarios.py
@@ -133,6 +133,18 @@ def _normalize_assertion_payload(payload: dict) -> dict:
             "prompt-core",
         ),
         (
+            "target-discovery-over-limit-comparison",
+            "redis_chat",
+            KnowledgeMode.FULL,
+            "prompt-core",
+        ),
+        (
+            "deep-triage-over-limit-targets",
+            "redis_triage",
+            KnowledgeMode.FULL,
+            "prompt-core",
+        ),
+        (
             "target-discovery-known-targets-then-connect",
             "redis_chat",
             KnowledgeMode.FULL,
@@ -165,6 +177,8 @@ def test_prompt_scenarios_load_from_authoritative_fixture_layout(
             "target-discovery-ambiguous-cache",
             "target-discovery-known-targets-inventory",
             "target-discovery-multi-target-comparison",
+            "target-discovery-over-limit-comparison",
+            "deep-triage-over-limit-targets",
             "target-discovery-known-targets-then-connect",
         }
         else ExecutionLane.AGENT_ONLY
@@ -360,6 +374,12 @@ def test_prompt_scenarios_ship_goldens_and_policy_expectations():
     target_multi = load_eval_scenario(
         scenario_manifest_path("prompt", "target-discovery-multi-target-comparison")
     )
+    target_over_limit = load_eval_scenario(
+        scenario_manifest_path("prompt", "target-discovery-over-limit-comparison")
+    )
+    deep_triage_over_limit = load_eval_scenario(
+        scenario_manifest_path("prompt", "deep-triage-over-limit-targets")
+    )
     target_inventory_connect = load_eval_scenario(
         scenario_manifest_path("prompt", "target-discovery-known-targets-then-connect")
     )
@@ -398,6 +418,22 @@ def test_prompt_scenarios_ship_goldens_and_policy_expectations():
     assert (
         target_multi.expectations.required_tool_calls[2].target_handle == "tgt_session_cache_prod"
     )
+    assert target_multi.expectations.required_tool_calls[3].target_handle == "tgt_cart_cache_prod"
+    assert target_over_limit.expectations.required_tool_calls[0].operation == (
+        "resolve_redis_targets"
+    )
+    assert target_over_limit.expectations.forbidden_tool_calls[0].operation == "info"
+    assert target_over_limit.expectations.required_findings == [
+        "too many Redis targets",
+        "5 or fewer targets",
+        "narrow the request",
+    ]
+    assert deep_triage_over_limit.expectations.expected_routing_decision == "triage"
+    assert deep_triage_over_limit.expectations.required_tool_calls == []
+    assert deep_triage_over_limit.expectations.forbidden_claims == [
+        "ran deep triage on the first 5 targets",
+        "completed fan-out for 5 targets",
+    ]
     assert (
         target_inventory_connect.expectations.required_tool_calls[0].operation
         == "list_known_redis_targets"
@@ -416,6 +452,8 @@ def test_prompt_scenarios_ship_goldens_and_policy_expectations():
         "target-discovery-ambiguous-cache": "prompt-core",
         "target-discovery-known-targets-inventory": "prompt-core",
         "target-discovery-multi-target-comparison": "prompt-core",
+        "target-discovery-over-limit-comparison": "prompt-core",
+        "deep-triage-over-limit-targets": "prompt-core",
         "target-discovery-known-targets-then-connect": "prompt-core",
         "sev1-escalation-policy": "prompt-policy-curated",
         "memory-user-preference-honored": "prompt-core",

--- a/tests/unit/evaluation/test_prompt_scenarios.py
+++ b/tests/unit/evaluation/test_prompt_scenarios.py
@@ -412,13 +412,9 @@ def test_prompt_scenarios_ship_goldens_and_policy_expectations():
         "do not have an auto-enumerable list",
         "ask me for a search term first",
     ]
-    assert (
-        target_multi.expectations.required_tool_calls[1].target_handle == "tgt_checkout_cache_prod"
-    )
-    assert (
-        target_multi.expectations.required_tool_calls[2].target_handle == "tgt_session_cache_prod"
-    )
-    assert target_multi.expectations.required_tool_calls[3].target_handle == "tgt_cart_cache_prod"
+    assert target_multi.expectations.required_tool_calls[1].target_handle is None
+    assert target_multi.expectations.required_tool_calls[2].target_handle is None
+    assert target_multi.expectations.required_tool_calls[3].target_handle is None
     assert target_over_limit.expectations.required_tool_calls[0].operation == (
         "resolve_redis_targets"
     )

--- a/tests/unit/evaluation/test_runtime.py
+++ b/tests/unit/evaluation/test_runtime.py
@@ -2024,7 +2024,8 @@ async def test_run_full_turn_scenario_supports_discovery_first_target_attachment
     resolution = result.turn_result["resolution"]
     assert result.turn_context["turn_scope"]["scope_kind"] == "zero_scope"
     assert resolution["status"] == "resolved"
-    assert resolution["attached_target_handles"]
+    assert resolution["attached_target_handles"] == ["tgt_cluster_payments_east"]
+    assert list(handle_store.records) == ["tgt_cluster_payments_east"]
     assert resolution["toolset_generation"] >= 2
     assert any(name.startswith("re_admin_") for name in result.turn_result["tool_names"])
     assert result.turn_result["databases"]["databases"] == [

--- a/tests/unit/tools/test_target_discovery_provider.py
+++ b/tests/unit/tools/test_target_discovery_provider.py
@@ -6,6 +6,7 @@ import pytest
 
 from redis_sre_agent.core.targets import BoundTargetScope, ResolvedTargetMatch, TargetBinding
 from redis_sre_agent.targets.contracts import (
+    DISCOVERY_STATUS_TOO_MANY_MATCHES,
     DiscoveryCandidate,
     DiscoveryRequest,
     DiscoveryResponse,
@@ -222,6 +223,51 @@ async def test_resolve_redis_targets_does_not_attach_when_confirmation_is_requir
     assert payload["status"] == "clarification_required"
     assert payload["attached_target_handles"] == []
     assert payload["toolset_generation"] == 6
+
+
+@pytest.mark.asyncio
+async def test_resolve_redis_targets_does_not_attach_over_limit_target_sets():
+    provider = TargetDiscoveryToolProvider()
+    manager = MagicMock()
+    manager.thread_id = "thread-1"
+    manager.task_id = "task-1"
+    manager.user_id = "user-1"
+    manager.get_toolset_generation.return_value = 6
+    provider._manager = manager
+
+    resolution = DiscoveryResponse(
+        status=DISCOVERY_STATUS_TOO_MANY_MATCHES,
+        clarification_required=True,
+        matches=[],
+        selected_matches=[],
+        max_selectable=5,
+        match_count=10,
+        message="Matched 10 Redis targets; ask the user to narrow the target set.",
+    )
+
+    with (
+        patch(
+            "redis_sre_agent.tools.target_discovery.provider.resolve_target_query",
+            new=AsyncMock(return_value=resolution),
+        ) as mock_resolve,
+        patch(
+            "redis_sre_agent.tools.target_discovery.provider.bind_target_matches",
+            new=AsyncMock(),
+        ) as mock_bind,
+    ):
+        payload = await provider.resolve_redis_targets(
+            query="compare ten caches",
+            allow_multiple=True,
+            max_results=10,
+            attach_tools=True,
+        )
+
+    mock_resolve.assert_awaited_once()
+    mock_bind.assert_not_awaited()
+    assert payload["status"] == DISCOVERY_STATUS_TOO_MANY_MATCHES
+    assert payload["attached_target_handles"] == []
+    assert payload["max_selectable"] == 5
+    assert payload["match_count"] == 10
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- route explicit zero-scope deep-triage language to `redis_triage` before the chat fallback
- add router regression coverage for database ID/name-style deep-triage requests
- remove the mocked router from the deep-triage target-discovery integration test so it covers the real classifier path

Fixes #186.

## Validation

- `uv run pytest tests/unit/agent/test_router.py tests/integration/test_target_discovery_flow.py -q` -> `29 passed, 6 skipped`
- `make lint` -> passed
- `make test` -> `2945 passed, 90 skipped, 66 deselected`
- `npx gitnexus detect-changes --scope all --repo /Users/andrew.brookins/src/redis-sre-agent-deep-triage-routing` -> risk `low`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core agent routing, target discovery selection limits, and deep-triage task fan-out/orchestration—behavior regressions would affect most user turns that name multiple Redis targets.
> 
> **Overview**
> This PR extends **zero-scope routing** so explicit deep-triage language can reach `redis_triage` (and target discovery) via the nano classifier instead of always defaulting to chat, and adds a **hard cap of five Redis targets** per multi-target request with `too_many_matches` handling—no partial attach, no diagnostics on a subset, and user-facing “narrow to 5 or fewer” responses in chat and deep triage.
> 
> **Deep triage** now **fans out** one child task per target when 2–5 bindings are in scope, and stops with a limit response when discovery or bindings exceed five. Discovery backends, contracts, the target-discovery tool provider, eval runtime, and **chat system prompt** are aligned on that behavior.
> 
> **CI** gains a PR **live eval** job (`test-eval-pr-live`), a small **pr-target-discovery-live** suite (multi-target compare, over-limit chat, over-limit deep triage), stricter **pull_request** baseline policy, and optional **Redis testcontainer** support in `run_live_eval_suite.py`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41b711bb10370ceb1babea6972dcadfa7ba58930. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->