### PR TITLE
Harden RediSearch query escaping for symbol-heavy input

### DIFF
--- a/redis_sre_agent/core/clusters.py
+++ b/redis_sre_agent/core/clusters.py
@@ -15,10 +15,11 @@ from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel, Field, SecretStr, field_serializer, field_validator, model_validator
 from redisvl.query import CountQuery, FilterQuery
-from redisvl.query.filter import FilterExpression, Tag
+from redisvl.query.filter import Tag
 
 from .encryption import encrypt_secret, get_secret_value
 from .redis import SRE_CLUSTERS_INDEX, get_clusters_index, get_redis_client
+from .redisearch import tag_contains_expression
 
 logger = logging.getLogger(__name__)
 
@@ -239,8 +240,8 @@ async def query_clusters(
             user_filter = Tag("user_id") == user_id
             filter_expr = user_filter if filter_expr is None else (filter_expr & user_filter)
 
-        if search:
-            name_filter = FilterExpression(f"@name:{{*{search}*}}")
+        if search and search.strip():
+            name_filter = tag_contains_expression("name", search.strip())
             filter_expr = name_filter if filter_expr is None else (filter_expr & name_filter)
 
         count_expr = filter_expr if filter_expr is not None else "*"

--- a/redis_sre_agent/core/instances.py
+++ b/redis_sre_agent/core/instances.py
@@ -16,7 +16,7 @@ from typing import Annotated, Any, Dict, List, Optional
 
 from pydantic import BaseModel, Field, SecretStr, field_serializer, field_validator, model_validator
 from redisvl.query import CountQuery, FilterQuery
-from redisvl.query.filter import FilterExpression, Tag
+from redisvl.query.filter import Tag
 from ulid import ULID
 
 from .encryption import encrypt_secret, get_secret_value
@@ -26,6 +26,7 @@ from .redis import (
     get_instances_index,
     get_redis_client,  # noqa: F401  # Expose for tests that patch via this module path
 )
+from .redisearch import tag_contains_expression
 
 logger = logging.getLogger(__name__)
 
@@ -473,9 +474,8 @@ async def query_instances(
             user_filter = Tag("user_id") == user_id
             filter_expr = user_filter if filter_expr is None else (filter_expr & user_filter)
 
-        if search:
-            # Use raw FilterExpression for wildcard matching (Tag escapes wildcards)
-            name_filter = FilterExpression(f"@name:{{*{search}*}}")
+        if search and search.strip():
+            name_filter = tag_contains_expression("name", search.strip())
             filter_expr = name_filter if filter_expr is None else (filter_expr & name_filter)
 
         # Get total count with filter

--- a/redis_sre_agent/core/knowledge_helpers.py
+++ b/redis_sre_agent/core/knowledge_helpers.py
@@ -15,7 +15,6 @@ from typing import Any, Dict, List, Optional
 from opentelemetry import trace
 from redisvl.query import BaseQuery, FilterQuery, HybridQuery, VectorQuery, VectorRangeQuery
 from redisvl.query.filter import FilterExpression, Tag
-from redisvl.query.query import TokenEscaper
 from ulid import ULID
 
 from redis_sre_agent.core.config import Settings
@@ -25,6 +24,7 @@ from redis_sre_agent.core.redis import (
     get_support_tickets_index,
     get_vectorizer,
 )
+from redis_sre_agent.core.redisearch import escape_redisearch_query_value, tag_equals_expression
 from redis_sre_agent.core.runtime_overrides import dispatch_knowledge_backend_override
 from redis_sre_agent.skills.backend import get_skill_backend
 
@@ -71,7 +71,6 @@ _HYBRID_QUERY_UNSUPPORTED_MARKERS = (
     "not supported",
 )
 _HYBRID_MISSING_COMMAND_MARKERS = ("unknown command", "no such command")
-_TAG_EXACT_MATCH_ESCAPER = TokenEscaper(re.compile(r"[,.<>{}\[\]\\\"\':;!@#$%^&*()\-+=~\/ \?\|]"))
 
 
 async def _maybe_call_knowledge_backend(
@@ -315,8 +314,7 @@ def _normalize_exact_match_value(value: str, index_type: str) -> str:
 
 def _tag_equals_expression(field_name: str, value: str) -> FilterExpression:
     """Build a canonical TAG equality expression with explicit escaping."""
-    escaped_value = _TAG_EXACT_MATCH_ESCAPER.escape(str(value or ""))
-    return FilterExpression(f"@{field_name}:{{{escaped_value}}}")
+    return tag_equals_expression(field_name, value)
 
 
 def _exact_match_filter_expression(
@@ -461,9 +459,10 @@ def _quoted_text_phrase_query(phrase: str) -> str:
 
 def _hybrid_text_query(query: str) -> str:
     """Build a best-effort token query across searchable text fields."""
-    escaper = TokenEscaper()
     tokens = [
-        escaper.escape(token.strip().strip(",").replace("“", "").replace("”", "").lower())
+        escape_redisearch_query_value(
+            token.strip().strip(",").replace("“", "").replace("”", "").lower()
+        )
         for token in str(query or "").split()
     ]
     tokens = [token for token in tokens if token]
@@ -471,7 +470,7 @@ def _hybrid_text_query(query: str) -> str:
         normalized_query, _ = _strip_outer_quotes(query)
         if not normalized_query:
             return "*"
-        tokens = [escaper.escape(normalized_query.lower())]
+        tokens = [escape_redisearch_query_value(normalized_query.lower())]
 
     token_query = " | ".join(tokens)
     return (

--- a/redis_sre_agent/core/redisearch.py
+++ b/redis_sre_agent/core/redisearch.py
@@ -1,0 +1,24 @@
+"""Helpers for constructing RediSearch query fragments from user text."""
+
+import re
+from typing import Any
+
+from redisvl.query.filter import FilterExpression
+from redisvl.query.query import TokenEscaper
+
+_REDISEARCH_ESCAPER = TokenEscaper(re.compile(r"[,.<>{}\[\]\\\"\':;!@#$%^&*()\-+=~\/ \?\|]"))
+
+
+def escape_redisearch_query_value(value: Any) -> str:
+    """Escape user-controlled text before inserting it into a RediSearch query."""
+    return _REDISEARCH_ESCAPER.escape(str(value or ""))
+
+
+def tag_equals_expression(field_name: str, value: Any) -> FilterExpression:
+    """Build a TAG equality expression with user text escaped."""
+    return FilterExpression(f"@{field_name}:{{{escape_redisearch_query_value(value)}}}")
+
+
+def tag_contains_expression(field_name: str, value: Any) -> FilterExpression:
+    """Build a TAG wildcard contains expression with user text escaped."""
+    return FilterExpression(f"@{field_name}:{{*{escape_redisearch_query_value(value)}*}}")

--- a/tests/integration/core/test_redisearch_symbol_query_filters.py
+++ b/tests/integration/core/test_redisearch_symbol_query_filters.py
@@ -1,0 +1,83 @@
+"""Live RediSearch regressions for symbol-heavy user search filters."""
+
+import base64
+import os
+import uuid
+
+import pytest
+
+from redis_sre_agent.core.clusters import (
+    RedisCluster,
+    RedisClusterType,
+    query_clusters,
+    save_clusters,
+)
+from redis_sre_agent.core.instances import (
+    RedisInstance,
+    RedisInstanceType,
+    query_instances,
+    save_instances,
+)
+
+SYMBOL_HEAVY_SEARCHES = [
+    "cache/prod",
+    "cache|prod",
+    "cache[prod]",
+    "cache{prod}",
+    "cache?prod",
+    "cache prod",
+    "*cache*",
+]
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+@pytest.mark.parametrize("search_text", SYMBOL_HEAVY_SEARCHES)
+async def test_query_instances_symbol_heavy_search_filters_execute_against_redis(
+    async_redis_client,
+    monkeypatch,
+    search_text,
+):
+    monkeypatch.setenv("REDIS_SRE_MASTER_KEY", base64.b64encode(os.urandom(32)).decode("ascii"))
+
+    instance_id = f"redis-symbol-{uuid.uuid4().hex[:8]}"
+    instance = RedisInstance(
+        id=instance_id,
+        name=f"primary {search_text} shard",
+        connection_url="redis://example-host:6379/0",
+        environment="production",
+        usage="cache",
+        description="Symbol-heavy search regression fixture",
+        instance_type=RedisInstanceType.oss_single,
+    )
+
+    assert await save_instances([instance]) is True
+
+    result = await query_instances(environment="production", search=search_text)
+
+    assert result.total >= 1
+    assert any(found.id == instance_id for found in result.instances)
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+@pytest.mark.parametrize("search_text", SYMBOL_HEAVY_SEARCHES)
+async def test_query_clusters_symbol_heavy_search_filters_execute_against_redis(
+    async_redis_client,
+    search_text,
+):
+    cluster_id = f"cluster-symbol-{uuid.uuid4().hex[:8]}"
+    cluster = RedisCluster(
+        id=cluster_id,
+        name=f"primary {search_text} cluster",
+        cluster_type=RedisClusterType.unknown,
+        environment="production",
+        description="Symbol-heavy search regression fixture",
+    )
+
+    assert await save_clusters([cluster]) is True
+
+    result = await query_clusters(environment="production", search=search_text)
+
+    assert result.total >= 1
+    assert any(found.id == cluster_id for found in result.clusters)

--- a/tests/unit/core/test_cluster_storage.py
+++ b/tests/unit/core/test_cluster_storage.py
@@ -109,6 +109,34 @@ class TestClusterStorage:
         assert result.clusters[0].id == "cluster-1"
 
     @pytest.mark.asyncio
+    async def test_query_clusters_escapes_symbol_heavy_search_filter(self):
+        mock_index = AsyncMock()
+        mock_index.query = AsyncMock(side_effect=[1, []])
+
+        with (
+            patch(
+                "redis_sre_agent.core.clusters._ensure_clusters_index_exists",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "redis_sre_agent.core.clusters.get_clusters_index",
+                new_callable=AsyncMock,
+                return_value=mock_index,
+            ),
+        ):
+            result = await query_clusters(
+                environment="production",
+                search="foo|bar/baz[prod]",
+            )
+
+        count_query = str(mock_index.query.await_args_list[0].args[0])
+        result_query = str(mock_index.query.await_args_list[1].args[0])
+        assert r"@name:{*foo\|bar\/baz\[prod\]*}" in count_query
+        assert r"@name:{*foo\|bar\/baz\[prod\]*}" in result_query
+        assert result.total == 1
+        assert result.clusters == []
+
+    @pytest.mark.asyncio
     async def test_upsert_cluster_index_doc_encrypts_admin_password(self):
         mock_client = AsyncMock()
         cluster = _enterprise_cluster("cluster-enc")

--- a/tests/unit/core/test_instance_manager.py
+++ b/tests/unit/core/test_instance_manager.py
@@ -558,6 +558,59 @@ class TestQueryInstances:
             assert result.instances == []
 
     @pytest.mark.asyncio
+    async def test_query_instances_escapes_symbol_heavy_search_filter(self):
+        """User search text should be escaped before entering wildcard TAG filters."""
+        mock_index = AsyncMock()
+        mock_index.query = AsyncMock(side_effect=[1, []])
+
+        with (
+            patch(
+                "redis_sre_agent.core.instances.get_instances_index",
+                new_callable=AsyncMock,
+                return_value=mock_index,
+            ),
+            patch(
+                "redis_sre_agent.core.instances._ensure_instances_index_exists",
+                new_callable=AsyncMock,
+            ),
+        ):
+            result = await query_instances(
+                environment="production",
+                search="foo|bar/baz[prod]",
+            )
+
+        count_query = str(mock_index.query.await_args_list[0].args[0])
+        result_query = str(mock_index.query.await_args_list[1].args[0])
+        assert r"@name:{*foo\|bar\/baz\[prod\]*}" in count_query
+        assert r"@name:{*foo\|bar\/baz\[prod\]*}" in result_query
+        assert result.total == 1
+        assert result.instances == []
+
+    @pytest.mark.asyncio
+    async def test_query_instances_ignores_blank_search_filter(self):
+        """Whitespace-only search should not create an invalid wildcard TAG query."""
+        mock_index = AsyncMock()
+        mock_index.query = AsyncMock(return_value=0)
+
+        with (
+            patch(
+                "redis_sre_agent.core.instances.get_instances_index",
+                new_callable=AsyncMock,
+                return_value=mock_index,
+            ),
+            patch(
+                "redis_sre_agent.core.instances._ensure_instances_index_exists",
+                new_callable=AsyncMock,
+            ),
+        ):
+            result = await query_instances(search="   ")
+
+        count_query = str(mock_index.query.await_args_list[0].args[0])
+        assert "@name:" not in count_query
+        assert result.total == 0
+        assert result.instances == []
+
+    @pytest.mark.asyncio
     async def test_query_instances_error(self):
         """Test query_instances returns empty on error."""
         with patch(

--- a/tests/unit/core/test_knowledge_helpers.py
+++ b/tests/unit/core/test_knowledge_helpers.py
@@ -10,6 +10,7 @@ from redis_sre_agent.core.knowledge_helpers import (
     _dedupe_docs,
     _doc_matches_requested_version,
     _exact_match_sort_key,
+    _hybrid_text_query,
     _quoted_text_phrase_query,
     _RawTextQuery,
     get_all_document_fragments,
@@ -82,6 +83,42 @@ class TestKnowledgeHelpers:
         assert str(knowledge_helpers._tag_equals_expression("name", "foo|bar/baz[prod]")) == (
             r"@name:{foo\|bar\/baz\[prod\]}"
         )
+
+    @pytest.mark.parametrize(
+        ("value", "expected_fragment"),
+        [
+            ("prod cache/{tenant}:v1?", r"prod\ cache\/\{tenant\}\:v1\?"),
+            ("*literal*|I/O", r"\*literal\*\|I\/O"),
+            ("name{one},two", r"name\{one\}\,two"),
+        ],
+    )
+    def test_tag_equals_expression_escapes_symbol_heavy_user_values(self, value, expected_fragment):
+        """Exact TAG filters should escape user-supplied RediSearch metacharacters."""
+        assert str(knowledge_helpers._tag_equals_expression("name", value)) == (
+            f"@name:{{{expected_fragment}}}"
+        )
+
+    @pytest.mark.parametrize(
+        ("query", "expected_fragment"),
+        [
+            ("I/O", r"i\/o"),
+            ("foo|bar/baz[prod]", r"foo\|bar\/baz\[prod\]"),
+            ("prod cache/{tenant}:v1?", r"prod | cache\/\{tenant\}\:v1\?"),
+        ],
+    )
+    def test_hybrid_text_query_escapes_symbol_heavy_tokens(self, query, expected_fragment):
+        """The RRF text fallback should not pass user query metacharacters through raw."""
+        text_query = _hybrid_text_query(query)
+
+        assert expected_fragment in text_query
+
+    def test_quoted_text_phrase_query_escapes_quotes_and_backslashes(self):
+        """Literal phrase search should escape quote delimiters and backslashes."""
+        query = _quoted_text_phrase_query('DB "memory" full \\ path')
+
+        assert r'@title:("db \"memory\" full \\ path")' in query
+        assert r'@summary:("db \"memory\" full \\ path")' in query
+        assert r'@content:("db \"memory\" full \\ path")' in query
 
     def test_hybrid_unsupported_error_detector_avoids_generic_ft_hybrid_mentions(self):
         """Only explicit capability/command failures should trip the fallback detector."""
@@ -430,6 +467,39 @@ class TestSearchKnowledgeBaseHelper:
         assert result["results_count"] == 2
         assert result["results"][0]["id"] == "doc-phrase"
         assert result["results"][1]["id"] == "doc-semantic"
+
+    @pytest.mark.asyncio
+    async def test_search_knowledge_base_symbol_heavy_query_escapes_exact_filters(self):
+        """Symbol-heavy user queries should be escaped anywhere they enter TAG filters."""
+        mock_index = AsyncMock()
+        mock_index.query = AsyncMock(return_value=[])
+
+        mock_vectorizer = MagicMock()
+        mock_vectorizer.aembed_many = AsyncMock(return_value=[[0.1, 0.2, 0.3]])
+
+        with (
+            patch(
+                "redis_sre_agent.core.knowledge_helpers.get_knowledge_index",
+                new_callable=AsyncMock,
+                return_value=mock_index,
+            ),
+            patch(
+                "redis_sre_agent.core.knowledge_helpers.get_vectorizer",
+                return_value=mock_vectorizer,
+            ),
+        ):
+            result = await search_knowledge_base_helper(
+                query="foo|bar/baz[prod]",
+                category="ops/team[one]",
+                version="7.2/latest?",
+                limit=10,
+            )
+
+        exact_name_query = str(mock_index.query.await_args_list[0].args[0])
+        assert r"@name:{foo\|bar\/baz\[prod\]}" in exact_name_query
+        assert r"@version:{7\.2\/latest\?}" in exact_name_query
+        assert r"@category:{ops\/team\[one\]}" in exact_name_query
+        assert result["results_count"] == 0
 
     @pytest.mark.asyncio
     async def test_search_knowledge_base_quoted_phrase_runs_literal_text_query(self):

--- a/tests/unit/core/test_redisearch.py
+++ b/tests/unit/core/test_redisearch.py
@@ -1,0 +1,34 @@
+"""Tests for safe RediSearch query fragment helpers."""
+
+import pytest
+
+from redis_sre_agent.core.redisearch import (
+    escape_redisearch_query_value,
+    tag_contains_expression,
+    tag_equals_expression,
+)
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("foo|bar/baz[prod]", r"foo\|bar\/baz\[prod\]"),
+        ("prod cache/{tenant}:v1?", r"prod\ cache\/\{tenant\}\:v1\?"),
+        ("name{one},two", r"name\{one\}\,two"),
+        ("quote'\"back\\slash", r"quote\'\"back\\slash"),
+        ("*literal*", r"\*literal\*"),
+        ("I/O", r"I\/O"),
+    ],
+)
+def test_escape_redisearch_query_value_escapes_common_user_symbols(value, expected):
+    assert escape_redisearch_query_value(value) == expected
+
+
+def test_tag_equals_expression_escapes_user_supplied_text():
+    assert str(tag_equals_expression("name", "foo|bar/baz[prod]")) == (
+        r"@name:{foo\|bar\/baz\[prod\]}"
+    )
+
+
+def test_tag_contains_expression_keeps_wildcards_outside_escaped_user_text():
+    assert str(tag_contains_expression("name", "*prod/cache?")) == (r"@name:{*\*prod\/cache\?*}")


### PR DESCRIPTION
## Summary
- Add shared RediSearch query escaping helpers for user-controlled TAG and text fragments.
- Escape instance and cluster name wildcard filters, plus knowledge exact-match filters and RedisVL RRF fallback text queries.
- Add unit and live Redis regression coverage for slash, pipe, brackets, braces, spaces, question marks, and literal wildcard characters.

Fixes #98

## Validation
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run pytest -m "not integration"`
- `uv run pytest --run-api-tests tests/integration/core/test_redisearch_symbol_query_filters.py -q`
- pre-commit hook on commit: ruff format check, ruff check, pytest unit tests

Note: `uvx run mfcqi analyze --skip-llm .` is not valid for the installed `uvx` and exits with `Package run does not provide any executables.` The corrected `uvx mfcqi analyze --skip-llm .` form started but stayed silent for about two minutes after optional LiteLLM warnings, so I stopped that analyzer process and did not use it as a PR gate.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes query construction on user-facing search paths; incorrect escaping could break searches or alter match semantics, but scope is limited to filter building with broad test coverage.
> 
> **Overview**
> Introduces shared **`redisearch`** helpers (`escape_redisearch_query_value`, `tag_equals_expression`, `tag_contains_expression`) so user-controlled text is escaped before it is embedded in RediSearch TAG and text query fragments.
> 
> **Instance and cluster list search** now builds name wildcard filters through `tag_contains_expression` instead of raw `@name:{*search*}` strings, skips whitespace-only `search`, and trims input.
> 
> **Knowledge search** routes exact-match TAG filters and hybrid RRF fallback token queries through the same escaping (replacing ad-hoc `TokenEscaper` usage in `knowledge_helpers`).
> 
> Unit tests assert escaped query shapes; integration tests run symbol-heavy searches against live Redis for instances and clusters.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5bfc89139cfd791061faa2018c87577d5e0bff43. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->