### PR TITLE
Force MCP deep triage tool to route to triage

### DIFF
--- a/redis_sre_agent/mcp_server/server.py
+++ b/redis_sre_agent/mcp_server/server.py
@@ -250,6 +250,7 @@ async def redis_sre_deep_triage(
             instance_id=instance_id,
             cluster_id=cluster_id,
             user_id=user_id,
+            extra_context={"requested_agent_type": "triage"},
         )
 
         result = await create_task(

--- a/tests/unit/mcp_server/test_mcp_server.py
+++ b/tests/unit/mcp_server/test_mcp_server.py
@@ -350,6 +350,29 @@ class TestDeepTriageTool:
             mock_create.assert_called_once()
 
     @pytest.mark.asyncio
+    async def test_deep_triage_forces_triage_routing_without_explicit_target(self):
+        """Deep triage tool calls should not depend on trigger words in the query."""
+        mock_result = {
+            "thread_id": "thread-123",
+            "task_id": "task-456",
+            "status": "queued",
+            "message": "Task created",
+        }
+
+        with (
+            patch("redis_sre_agent.core.redis.get_redis_client"),
+            patch("redis_sre_agent.core.tasks.create_task", new_callable=AsyncMock) as mock_create,
+        ):
+            mock_create.return_value = mock_result
+
+            result = await redis_sre_deep_triage(query="high memory on prod cache")
+
+            assert result["task_id"] == "task-456"
+            call_kwargs = mock_create.call_args.kwargs
+            assert call_kwargs["context"]["requested_agent_type"] == "triage"
+            assert call_kwargs["context"]["turn_scope"]["scope_kind"] == "zero_scope"
+
+    @pytest.mark.asyncio
     async def test_deep_triage_with_cluster_id(self):
         """Test deep triage accepts cluster_id and forwards context."""
         mock_result = {


### PR DESCRIPTION
## Summary

- force `redis_sre_deep_triage()` tasks to request the triage agent explicitly
- add MCP regression coverage for a zero-scope deep-triage tool call whose query does not contain deep-triage trigger words

Fixes #189.

## Validation

- `uv run pytest tests/unit/mcp_server/test_mcp_server.py::TestDeepTriageTool -q` -> `5 passed`
- `uv run pytest tests/unit/core/test_tasks.py::TestProcessAgentTurn::test_process_agent_turn_honors_requested_agent_type -q` -> `1 passed`
- `make lint` -> passed
- `npx gitnexus detect-changes --scope all --repo /Users/andrew.brookins/src/redis-sre-agent-issue-189` -> risk `low`
- commit hook -> passed

Note: `make test` was run locally and failed on unrelated `tests/api/test_feedback_route.py::test_list_limit_bounds` because no Redis was reachable at `localhost:7843` in this local worktree environment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow MCP routing hint plus unit test only; no auth, data, or broad behavioral refactors beyond ensuring the deep-triage tool selects the triage agent.
> 
> **Overview**
> The MCP **`redis_sre_deep_triage`** tool now sets **`requested_agent_type: triage`** on the task context when queueing work, so deep-triage runs always use the triage agent instead of relying on wording in the user query.
> 
> A unit test covers a **zero-scope** call (no instance/cluster) with a plain query and asserts the created task context includes triage routing and **`turn_scope.scope_kind == zero_scope`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f81113d4971054873b84be0bc6f15b76e74a9c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->