### PR TITLE
Fix manual QA findings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -105,7 +105,9 @@ MAX_TASK_RETRIES=3
 TASK_TIMEOUT=300
 
 # Agent Configuration
-MAX_ITERATIONS=25
+# Built-in default is 50. Uncomment to reduce reasoning cycles for faster,
+# lower-cost local runs.
+# MAX_ITERATIONS=25
 TOOL_TIMEOUT=60
 
 # Monitoring Integration (Optional)

--- a/docs/concepts/core.md
+++ b/docs/concepts/core.md
@@ -88,7 +88,7 @@ The system uses **three specialized agents** selected automatically based on you
 |-------|-----------|-----------------|----------|
 | **Knowledge Agent** | No Redis instance linked | Knowledge base search only | General Redis questions, best practices, documentation lookup |
 | **Chat Agent** | Instance linked (default) | All tools (Redis CLI, Prometheus, Loki, MCP servers, etc.) | Most queries: health checks, diagnostics, troubleshooting, status checks |
-| **Deep Triage Agent** | Instance linked + explicit "deep" request | All tools + parallel multi-topic research | Deep investigation with trigger phrases: "deep triage", "deep research", "go deep", "deep dive" |
+| **Deep Triage Agent** | Explicit "deep" request with linked scope or resolvable target text | All tools + parallel multi-topic research | Deep investigation with trigger phrases: "deep triage", "deep research", "go deep", "deep dive" |
 
 ### Automatic Routing
 
@@ -97,9 +97,12 @@ The router (`redis_sre_agent/agent/router.py`) uses a fast LLM (nano model) to c
 ```
 Query received
     │
-    ├── No instance_id? ──────────────────► Knowledge Agent
+    ├── No target scope?
+    │       │
+    │       ├── Explicit deep triage request? ──► Target discovery ──► Deep Triage Agent or clarification
+    │       └── General Redis question? ────────► Knowledge Agent
     │
-    └── Has instance_id?
+    └── Has target scope?
             │
             ├── Deep keywords (deep triage, go deep, deep dive)? ──► Deep Triage Agent
             │
@@ -110,10 +113,22 @@ Query received
 
 You can override routing via CLI (`--agent triage|chat|knowledge`) or API (`preferred_agent` in user preferences).
 
+### Zero-Scope Deep Triage
+
+A deep-triage request can start without `instance_id`, `cluster_id`, or existing target bindings. In that zero-scope case the task tries natural-language target discovery before running live diagnostics:
+
+- If discovery resolves one exact target, the task binds that target and runs deep triage against it.
+- If discovery resolves two to five exact targets, the task can fan out to one child deep-triage task per target.
+- If discovery finds more than five targets, the task asks you to narrow the scope instead of triaging a partial set.
+- If discovery is fuzzy or ambiguous, the task requests clarification and does not attach those matches as live targets.
+- If discovery finds no target, the request remains zero-scope; the agent can still answer with general knowledge and available non-target tools, but target-specific Redis diagnostics are not attached.
+
+Continue the same thread with exact instance names, cluster IDs, environment, region, or other stable identifiers to narrow the scope.
+
 ### Agent Details
 
 **Knowledge Agent** (`knowledge_agent.py`)
-- Searches the vector knowledge base (runbooks, docs, KB articles)
+- Searches the vector knowledge base (runbooks, Redis docs, source documents)
 - No live system access - safe for general questions
 - Fast response, single-turn conversation
 
@@ -173,7 +188,10 @@ redis-sre-agent mcp serve --transport stdio
 ```
 
 **Available MCP tools exposed:**
-- `redis_sre_deep_triage` - Start a comprehensive triage session
+- `redis_sre_deep_triage` - Start a comprehensive triage session. Natural-language target
+  discovery can fan out to one child task per matched Redis target, up to five targets. If more
+  than five targets match, narrow the request by exact instance names, cluster IDs, environment,
+  or region and continue the same thread.
 - `redis_sre_general_chat` - Quick Q&A with a Redis instance
 - `redis_sre_database_chat` - Chat about a specific database
 - `redis_sre_knowledge_query` - Query the knowledge base

--- a/docs/how-to/api.md
+++ b/docs/how-to/api.md
@@ -201,7 +201,7 @@ curl -fsS -X POST http://localhost:8080/api/v1/tasks \
   }' | jq
 ```
 
-For deep triage, the agent can fan out to one triage run per selected target, up to five targets in one request. If target discovery matches more than five Redis targets, the task response asks you to narrow the request instead of triaging a partial set. Continue the same thread with the smaller set:
+For deep triage, the agent can start from a query-only request, run target discovery first, and fan out to one triage run per selected target, up to five targets in one request. Only resolved target matches are attached for live diagnostics; fuzzy or ambiguous matches request clarification instead. If target discovery matches more than five Redis targets, the task response asks you to narrow the request instead of triaging a partial set. Continue the same thread with the smaller set:
 
 ```bash
 curl -fsS -X POST http://localhost:8080/api/v1/tasks \

--- a/docs/how-to/cli.md
+++ b/docs/how-to/cli.md
@@ -89,7 +89,7 @@ uv run redis-sre-agent query -t <thread_id> \
   "Keep only the production caches and summarize which one needs attention first"
 ```
 
-For deep triage, the agent can fan out to one triage run per selected target, up to five targets in one request. If target discovery matches more than five Redis targets, the agent asks you to narrow the request instead of triaging a partial set.
+For deep triage, the agent can start from a query-only request, run target discovery first, and fan out to one triage run per selected target, up to five targets in one request. Only resolved target matches are attached for live diagnostics; fuzzy or ambiguous matches request clarification instead. If target discovery matches more than five Redis targets, the agent asks you to narrow the request instead of triaging a partial set.
 
 Continue the same thread with the smaller set:
 
@@ -156,6 +156,7 @@ uv run redis-sre-agent knowledge-pack build \
 - Wrap a query in quotes to force the precise-search path for exact names, document hashes, source filenames, or literal phrases.
 - Unquoted single-token identifiers that contain digits or punctuation also trigger exact matching automatically.
 - Exact-looking queries first check identifier-style fields such as `name` and `source`, then run a literal phrase search across `title`, `summary`, and `content` before semantic results are merged in.
+- If the embedding provider is unavailable, exact identifier and literal phrase searches can still return those RediSearch matches. General semantic ranking still requires a configured vectorizer.
 - General knowledge search excludes pinned docs, skills, and support tickets. Use the support-ticket tools for historical ticket lookups.
 
 Examples:

--- a/docs/how-to/configuration.md
+++ b/docs/how-to/configuration.md
@@ -108,6 +108,7 @@ export SRE_AGENT_CONFIG=/path/to/my-config.toml
 - `PROMETHEUS_URL` / `GRAFANA_URL`: Optional app-level URLs for integrations
 - `TOOLS_PROMETHEUS_URL` / `TOOLS_LOKI_URL`: Tool-specific endpoints
 - `API_KEY`: API auth key (if you enable auth)
+- `MAX_ITERATIONS`: Main-agent reasoning-cycle limit (built-in default: `50`)
 - `LLM_CONTEXT_TOKEN_BUDGET`: Optional positive integer cap for estimated input/context tokens sent in one LLM request
 - `ALLOWED_HOSTS`: CORS origins (default: `["*"]`)
 
@@ -132,6 +133,8 @@ LLM_CONTEXT_TOKEN_BUDGET=120000
 ```
 
 Choose a value below the context window of the model you deploy, leaving room for the model's answer. For example, with a 128k-token model, a value around `120000` gives the request guard space for completion tokens and provider-specific overhead. This setting is separate from `MAX_ITERATIONS`: `MAX_ITERATIONS` limits reasoning cycles, while `LLM_CONTEXT_TOKEN_BUDGET` limits the size of each outbound request.
+
+The built-in `MAX_ITERATIONS` default is `50`. The `.env.example` file shows a commented lower override for local runs, but an unset value uses the settings default.
 
 ### Tool caching
 

--- a/docs/how-to/feedback.md
+++ b/docs/how-to/feedback.md
@@ -40,7 +40,47 @@ Expected 200 response:
 curl -fsS http://localhost:8080/api/v1/tasks/<task_id>/feedback | jq
 ```
 
-Returns the `FeedbackRecord` JSON above (200) or a 404 when no feedback has been submitted yet.
+Returns a joined `FeedbackView` (200) or a 404 when no feedback has been submitted yet. `FeedbackView` contains the stored feedback plus a compact task summary:
+
+```json
+{
+  "feedback": {
+    "task_id": "task-abc123",
+    "verdict": "down",
+    "comment": "Missed the eviction policy angle",
+    "created_at": "2026-05-18T10:00:00.000000+00:00",
+    "updated_at": "2026-05-18T10:05:00.000000+00:00"
+  },
+  "task": {
+    "task_id": "task-abc123",
+    "thread_id": "thread-xyz789",
+    "status": "done",
+    "subject": "Redis memory investigation",
+    "created_at": "2026-05-18T09:59:00.000000+00:00",
+    "updated_at": "2026-05-18T10:04:00.000000+00:00",
+    "error_message": null,
+    "pending_approval": null,
+    "messages": [
+      {
+        "role": "user",
+        "content": "Why is memory high?"
+      },
+      {
+        "role": "assistant",
+        "content": "Memory is high because..."
+      }
+    ],
+    "tool_calls": [
+      {
+        "tool": "redis_info",
+        "args_summary": "section=memory"
+      }
+    ]
+  }
+}
+```
+
+`task.messages` includes trimmed user and assistant messages only. `task.tool_calls` is a compact summary and does not include raw tool outputs.
 
 #### Validation errors (422)
 
@@ -74,6 +114,54 @@ redis_sre_submit_feedback(
 
 Returns the same `FeedbackRecord` dict on success. Unlike most other tools in this server, validation errors (`verdict` outside the enum, `comment` exceeding 2048 chars) and `TaskNotFoundError` propagate as native MCP errors rather than success-shaped `{"error": ..., "status": "failed"}` dicts. Handle them accordingly in your MCP client.
 
+Read the current feedback for one task with `redis_sre_get_feedback`:
+
+```python
+redis_sre_get_feedback(task_id="task-abc123")
+```
+
+This returns the same joined `FeedbackView` shape shown in the HTTP example, or `null` when the task exists but has not been rated yet. If the task itself does not exist, `TaskNotFoundError` propagates as a native MCP error.
+
+List recent feedback with `redis_sre_list_feedback`:
+
+```python
+redis_sre_list_feedback()
+redis_sre_list_feedback(since="24h", verdict="down", status="done", limit=50)
+```
+
+`redis_sre_list_feedback` returns:
+
+```json
+{
+  "items": [
+    {
+      "feedback": {
+        "task_id": "task-abc123",
+        "verdict": "down",
+        "comment": "Missed the eviction policy angle",
+        "created_at": "2026-05-18T10:00:00.000000+00:00",
+        "updated_at": "2026-05-18T10:05:00.000000+00:00"
+      },
+      "task": {
+        "task_id": "task-abc123",
+        "thread_id": "thread-xyz789",
+        "status": "done",
+        "subject": "Redis memory investigation",
+        "created_at": "2026-05-18T09:59:00.000000+00:00",
+        "updated_at": "2026-05-18T10:04:00.000000+00:00",
+        "error_message": null,
+        "pending_approval": null,
+        "messages": [],
+        "tool_calls": []
+      }
+    }
+  ],
+  "count": 1
+}
+```
+
+Filters use AND semantics. `since` accepts `<N>{s,m,h,d}` only, `verdict` accepts `up`, `down`, or `withdrawn`, and `status` filters by task status. `limit` defaults to 50 and is clamped to 500. Invalid filters propagate as MCP-native validation errors.
+
 ### CLI usage
 
 All feedback commands are under the `feedback` subgroup:
@@ -97,6 +185,8 @@ uv run redis-sre-agent feedback show <task_id>
 uv run redis-sre-agent feedback list
 uv run redis-sre-agent feedback list --since 24h --verdict down --limit 50
 ```
+
+**Read output shape**: `feedback show` prints the same joined `FeedbackView` JSON shown above, or `null` when the task exists but has no feedback yet. `feedback list` emits one `FeedbackView` JSON object per line by default, or a table with `--table`.
 
 **`feedback show` exit-code contract**: exits 0 and prints `null` when the task exists but has no feedback yet; exits non-zero only on hard errors (task not found, Redis error).
 

--- a/docs/how-to/pipelines.md
+++ b/docs/how-to/pipelines.md
@@ -15,7 +15,6 @@ This separation allows you to prepare artifacts once (slow) and re-ingest them m
 flowchart TB
     subgraph Sources["📥 Data Sources"]
         WEB["redis.io/docs"]
-        KB["redis.io/kb"]
         API["Cloud API Spec"]
         LOCAL["Local Docs Clone"]
         USER["source_documents/"]
@@ -25,7 +24,6 @@ flowchart TB
         direction TB
         SCRAPERS["Scrapers"]
         WEB --> SCRAPERS
-        KB --> SCRAPERS
         API --> SCRAPERS
         LOCAL --> SCRAPERS
 
@@ -410,7 +408,11 @@ The pipeline uses content hashing for deduplication:
 
 - **Document hash**: SHA-256 of content
 - **Chunk hash**: SHA-256 of chunk content
-- **Deterministic IDs**: `{document_hash}_{chunk_index}`
+- **Deterministic Redis keys**: `sre_knowledge:{document_hash}:chunk:{chunk_index}`
+
+Other corpus indexes use the same shape with their own prefix, for example
+`sre_skills:{document_hash}:chunk:{chunk_index}` and
+`sre_support_tickets:{document_hash}:chunk:{chunk_index}`.
 
 When re-ingesting:
 

--- a/docs/how-to/source-document-features.md
+++ b/docs/how-to/source-document-features.md
@@ -164,7 +164,83 @@ get_support_ticket("RET-4421")
 get_support_ticket("sre_support_tickets:RET-4421:chunk:0")
 ```
 
-For general knowledge documents, quoted queries trigger the same precise-search path. Use quotes when you need an exact name, source match, or literal phrase search over the document text.
+For general knowledge documents, quoted queries trigger the same precise-search path. Use quotes when you need an exact name, source match, or literal phrase search over the document text. If the embedding provider is unavailable, this path can still return exact RediSearch matches; general semantic ranking still requires a configured vectorizer.
+
+---
+
+## Knowledge Chunk Drill-Down
+
+Search results and citations are chunk-level because ingestion splits each source document before indexing it. Use the shared `document_hash` to open the full indexed document assembled from all chunks.
+
+### UI workflow
+
+From the Knowledge page:
+
+1. Search for a term, source name, quoted exact phrase, or document hash.
+2. Click the result title or **Open document**.
+3. The UI opens `/knowledge/document-chunks/<document_hash>`.
+4. If the search result includes `chunk_index`, the link also includes `#chunk-<chunk_index>` and scrolls to that chunk.
+
+The Triage page uses the same drill-down route for knowledge citations attached to agent responses. Use **Back to Knowledge** on the chunk page to return to the search surface.
+
+You can also paste a chunk reference into Knowledge search:
+
+```text
+chunk:sre_knowledge:<document_hash>:chunk:<chunk_index>
+chunk:<document_hash>:<chunk_index>
+chunk:<document_hash>#<chunk_index>
+chunk:<document_hash>@<chunk_index>
+```
+
+Those forms navigate directly to the document chunks page and target the matching chunk anchor.
+
+### HTTP workflow
+
+Fetch all indexed chunks for one source document:
+
+```bash
+curl -fsS \
+  'http://localhost:8080/api/v1/knowledge/document-chunks/<document_hash>?include_metadata=true&index_type=knowledge&version=latest' \
+  | jq
+```
+
+Response shape:
+
+```json
+{
+  "document_hash": "RET-4421",
+  "index_type": "knowledge",
+  "chunk_count": 2,
+  "title": "Failover Reset Runbook",
+  "source": "source_documents/shared/failover-reset.md",
+  "category": "shared",
+  "doc_type": "runbook",
+  "summary": "Failover reset investigation steps.",
+  "chunks": [
+    {
+      "document_hash": "RET-4421",
+      "chunk_index": 0,
+      "total_chunks": 2,
+      "title": "Failover Reset Runbook",
+      "content": "..."
+    },
+    {
+      "document_hash": "RET-4421",
+      "chunk_index": 1,
+      "total_chunks": 2,
+      "title": "Failover Reset Runbook",
+      "content": "..."
+    }
+  ],
+  "metadata": {}
+}
+```
+
+Chunks are sorted numerically by `chunk_index`. `include_metadata=false` omits the metadata lookup but still returns chunk fields. `index_type` selects the corpus (`knowledge`, `skills`, or `support_tickets`). `version` filters chunks to a specific indexed source version when the corpus includes versioned documents.
+
+### Source-document relationship
+
+`document_hash` identifies one indexed source document; `chunk_index` identifies one fragment within that document. Opening the document-chunks route does not re-read files from `source_documents/`; it reconstructs the view from Redis records that share the same `document_hash`. If a source file is changed and re-ingested, it may receive a new `document_hash`, so old chunk links can stop resolving after cleanup.
 
 ---
 

--- a/docs/operations/gotchas.md
+++ b/docs/operations/gotchas.md
@@ -204,7 +204,7 @@ To resolve it:
 - Raise `LLM_CONTEXT_TOKEN_BUDGET`, or unset it to disable context budget enforcement
 
 ### Max iterations limit
-The agent has a max iterations limit (`MAX_ITERATIONS=25`) to prevent runaway loops. If you see "max iterations reached":
+The agent has a max iterations limit to prevent runaway loops. The built-in default is `MAX_ITERATIONS=50`; local `.env` files can override it. If you see "max iterations reached":
 - The query was too complex or ambiguous
 - Try breaking it into smaller, more specific queries
 - Increase `MAX_ITERATIONS` if needed (but monitor costs)

--- a/docs/quickstarts/vm-deployment.md
+++ b/docs/quickstarts/vm-deployment.md
@@ -430,7 +430,7 @@ scrape_configs:
 
 ### High memory usage
 - Reduce worker concurrency: `--concurrency 2`
-- Limit LLM context in `.env`: `MAX_ITERATIONS=15`
+- Cap oversized LLM requests in `.env`: `LLM_CONTEXT_TOKEN_BUDGET=120000`
 - Monitor with: `ps aux | grep redis-sre-agent`
 
 ---

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -100,6 +100,7 @@ For copy/paste workflows, see [Using the API](../how-to/api.md).
 | `DELETE` | `/api/v1/tasks/{task_id}` | delete_task |
 | `GET` | `/api/v1/tasks/{task_id}` | get_task |
 | `GET` | `/api/v1/tasks/{task_id}/approvals` | list_task_approvals |
+| `POST` | `/api/v1/tasks/{task_id}/cancel` | cancel_task |
 | `GET` | `/api/v1/tasks/{task_id}/feedback` | get_task_feedback |
 | `POST` | `/api/v1/tasks/{task_id}/feedback` | submit_task_feedback |
 | `POST` | `/api/v1/tasks/{task_id}/resume` | resume_task |

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -111,6 +111,7 @@ For copy/paste workflows, see [Using the API](../how-to/api.md).
 | `GET` | `/api/v1/threads/{thread_id}` | get_thread |
 | `PATCH` | `/api/v1/threads/{thread_id}` | update_thread |
 | `POST` | `/api/v1/threads/{thread_id}/append-messages` | append_messages |
+| `POST` | `/api/v1/threads/{thread_id}/cancel` | cancel_thread_tasks |
 
 ### OpenAPI & docs
 

--- a/redis_sre_agent/api/instances.py
+++ b/redis_sre_agent/api/instances.py
@@ -412,7 +412,7 @@ class UpdateInstanceRequest(BaseModel):
 @router.get("/instances", response_model=InstanceListResponse)
 async def list_instances(
     environment: Optional[str] = Query(
-        None, description="Filter by environment (development, staging, production)"
+        None, description="Filter by environment (development, staging, production, test)"
     ),
     usage: Optional[str] = Query(
         None, description="Filter by usage type (cache, analytics, session, queue, custom)"

--- a/redis_sre_agent/api/knowledge.py
+++ b/redis_sre_agent/api/knowledge.py
@@ -333,6 +333,8 @@ async def ingest_single_document(request: DocumentIngestionRequest):
         return {
             "success": True,
             "document_id": result.get("document_id"),
+            "document_hash": result.get("document_hash"),
+            "chunk_count": result.get("chunk_count"),
             "message": f"Document '{request.title}' ingested successfully",
         }
 

--- a/redis_sre_agent/api/tasks.py
+++ b/redis_sre_agent/api/tasks.py
@@ -35,6 +35,12 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
+TERMINAL_TASK_STATUSES = {
+    TaskStatus.DONE,
+    TaskStatus.FAILED,
+    TaskStatus.CANCELLED,
+}
+
 
 async def _build_task_response(task_id: str, task_manager: TaskManager) -> TaskResponse:
     state = await task_manager.get_task_state(task_id)
@@ -195,6 +201,42 @@ async def resume_task(task_id: str, req: TaskResumeRequest) -> TaskResponse:
             await task_manager.set_pending_approval(task_id, pending_approval)
             await task_manager.update_task_status(task_id, TaskStatus.AWAITING_APPROVAL)
         raise
+
+    return await _build_task_response(task_id, task_manager)
+
+
+@router.post("/tasks/{task_id}/cancel", response_model=TaskResponse)
+async def cancel_task(task_id: str) -> TaskResponse:
+    """Cancel a task without deleting its persisted status or history."""
+
+    redis_client = get_redis_client()
+    task_manager = TaskManager(redis_client=redis_client)
+    state = await task_manager.get_task_state(task_id)
+    if not state:
+        raise HTTPException(status_code=404, detail="Task not found")
+
+    if state.status not in TERMINAL_TASK_STATUSES:
+        cancel_msg = ""
+        try:
+            async with Docket(url=await get_redis_url(), name="sre_docket") as docket:
+                try:
+                    await docket.cancel(task_id)
+                except Exception as e:  # pragma: no cover - defensive logging
+                    cancel_msg = f"Failed to cancel Docket task {task_id}: {e}"
+                    logger.warning("Failed to cancel Docket task %s: %s", task_id, e)
+        except Exception as e:  # pragma: no cover - defensive logging
+            cancel_msg = f"Failed to initialize Docket for cancel of {task_id}: {e}"
+            logger.warning("Failed to initialize Docket for cancel of %s: %s", task_id, e)
+
+        await task_manager.set_pending_approval(task_id, None)
+        await task_manager.set_resume_supported(task_id, False)
+        await task_manager.update_task_status(task_id, TaskStatus.CANCELLED)
+        await task_manager.add_task_update(
+            task_id,
+            "Task cancelled by user request",
+            "cancellation",
+            {"cancel_message": cancel_msg} if cancel_msg else None,
+        )
 
     return await _build_task_response(task_id, task_manager)
 

--- a/redis_sre_agent/api/tasks.py
+++ b/redis_sre_agent/api/tasks.py
@@ -42,6 +42,42 @@ TERMINAL_TASK_STATUSES = {
 }
 
 
+async def _cancel_docket_task(task_id: str) -> str:
+    cancel_msg = ""
+    try:
+        async with Docket(url=await get_redis_url(), name="sre_docket") as docket:
+            try:
+                await docket.cancel(task_id)
+            except Exception as e:  # pragma: no cover - defensive logging
+                cancel_msg = f"Failed to cancel Docket task {task_id}: {e}"
+                logger.warning("Failed to cancel Docket task %s: %s", task_id, e)
+    except Exception as e:  # pragma: no cover - defensive logging
+        cancel_msg = f"Failed to initialize Docket for cancel of {task_id}: {e}"
+        logger.warning("Failed to initialize Docket for cancel of %s: %s", task_id, e)
+    return cancel_msg
+
+
+async def cancel_task_without_deleting(task_id: str, task_manager: TaskManager) -> bool | None:
+    state = await task_manager.get_task_state(task_id)
+    if not state:
+        return None
+
+    if state.status in TERMINAL_TASK_STATUSES:
+        return False
+
+    cancel_msg = await _cancel_docket_task(task_id)
+    await task_manager.set_pending_approval(task_id, None)
+    await task_manager.set_resume_supported(task_id, False)
+    await task_manager.update_task_status(task_id, TaskStatus.CANCELLED)
+    await task_manager.add_task_update(
+        task_id,
+        "Task cancelled by user request",
+        "cancellation",
+        {"cancel_message": cancel_msg} if cancel_msg else None,
+    )
+    return True
+
+
 async def _build_task_response(task_id: str, task_manager: TaskManager) -> TaskResponse:
     state = await task_manager.get_task_state(task_id)
     if not state:
@@ -211,32 +247,9 @@ async def cancel_task(task_id: str) -> TaskResponse:
 
     redis_client = get_redis_client()
     task_manager = TaskManager(redis_client=redis_client)
-    state = await task_manager.get_task_state(task_id)
-    if not state:
+    cancelled = await cancel_task_without_deleting(task_id, task_manager)
+    if cancelled is None:
         raise HTTPException(status_code=404, detail="Task not found")
-
-    if state.status not in TERMINAL_TASK_STATUSES:
-        cancel_msg = ""
-        try:
-            async with Docket(url=await get_redis_url(), name="sre_docket") as docket:
-                try:
-                    await docket.cancel(task_id)
-                except Exception as e:  # pragma: no cover - defensive logging
-                    cancel_msg = f"Failed to cancel Docket task {task_id}: {e}"
-                    logger.warning("Failed to cancel Docket task %s: %s", task_id, e)
-        except Exception as e:  # pragma: no cover - defensive logging
-            cancel_msg = f"Failed to initialize Docket for cancel of {task_id}: {e}"
-            logger.warning("Failed to initialize Docket for cancel of %s: %s", task_id, e)
-
-        await task_manager.set_pending_approval(task_id, None)
-        await task_manager.set_resume_supported(task_id, False)
-        await task_manager.update_task_status(task_id, TaskStatus.CANCELLED)
-        await task_manager.add_task_update(
-            task_id,
-            "Task cancelled by user request",
-            "cancellation",
-            {"cancel_message": cancel_msg} if cancel_msg else None,
-        )
 
     return await _build_task_response(task_id, task_manager)
 

--- a/redis_sre_agent/api/threads.py
+++ b/redis_sre_agent/api/threads.py
@@ -17,8 +17,11 @@ from redis_sre_agent.api.schemas import (
     ThreadResponse,
     ThreadUpdateRequest,
 )
+from redis_sre_agent.api.tasks import cancel_task_without_deleting
 from redis_sre_agent.core.citation_message import extract_citation_groups_from_task_result
+from redis_sre_agent.core.keys import RedisKeys
 from redis_sre_agent.core.redis import get_redis_client
+from redis_sre_agent.core.tasks import TaskManager
 from redis_sre_agent.core.threads import ThreadManager
 from redis_sre_agent.core.threads import delete_thread as delete_thread_model
 
@@ -243,6 +246,38 @@ async def append_messages(thread_id: str, req: ThreadAppendMessagesRequest):
     if not ok:
         raise HTTPException(status_code=500, detail="Failed to append messages")
     return None
+
+
+@router.post("/threads/{thread_id}/cancel")
+async def cancel_thread_tasks(thread_id: str) -> Dict[str, Any]:
+    rc = get_redis_client()
+    tm = ThreadManager(redis_client=rc)
+    state = await tm.get_thread(thread_id)
+    if not state:
+        raise HTTPException(status_code=404, detail="Thread not found")
+
+    raw_task_ids = await rc.zrange(RedisKeys.thread_tasks_index(thread_id), 0, -1)
+    task_manager = TaskManager(redis_client=rc)
+    cancelled_task_ids: List[str] = []
+    terminal_task_ids: List[str] = []
+    missing_task_ids: List[str] = []
+
+    for raw_task_id in raw_task_ids or []:
+        task_id = raw_task_id.decode() if isinstance(raw_task_id, bytes) else raw_task_id
+        result = await cancel_task_without_deleting(task_id, task_manager)
+        if result is None:
+            missing_task_ids.append(task_id)
+        elif result:
+            cancelled_task_ids.append(task_id)
+        else:
+            terminal_task_ids.append(task_id)
+
+    return {
+        "thread_id": thread_id,
+        "cancelled_task_ids": cancelled_task_ids,
+        "terminal_task_ids": terminal_task_ids,
+        "missing_task_ids": missing_task_ids,
+    }
 
 
 @router.delete("/threads/{thread_id}", status_code=status.HTTP_204_NO_CONTENT)

--- a/redis_sre_agent/cli/main.py
+++ b/redis_sre_agent/cli/main.py
@@ -72,7 +72,7 @@ class LazyGroup(click.MultiCommand):
     def invoke(self, ctx):
         try:
             return super().invoke(ctx)
-        except (click.ClickException, click.Abort, SystemExit):
+        except (click.exceptions.Exit, click.ClickException, click.Abort, SystemExit):
             raise
         except Exception as exc:
             if not was_cli_exception_logged(exc):

--- a/redis_sre_agent/core/docket_tasks.py
+++ b/redis_sre_agent/core/docket_tasks.py
@@ -2210,7 +2210,11 @@ async def _process_agent_turn_impl(
                     except Exception:
                         pass
                     return result
-                if resolution.selected_matches:
+                if (
+                    resolution.status == "resolved"
+                    and not resolution.clarification_required
+                    and resolution.selected_matches
+                ):
                     bound_scope = await materialize_bound_target_scope(
                         matches=resolution.selected_matches,
                         thread_id=thread_id,

--- a/redis_sre_agent/core/docket_tasks.py
+++ b/redis_sre_agent/core/docket_tasks.py
@@ -766,6 +766,51 @@ def _format_target_limit_response(
     return "\n".join(lines)
 
 
+def _build_terminal_task_result(task_id: str, thread_id: str, status: TaskStatus) -> Dict[str, Any]:
+    return {
+        "status": status.value,
+        "thread_id": thread_id,
+        "task_id": task_id,
+    }
+
+
+async def _complete_task_if_open(
+    *,
+    task_manager: TaskManager,
+    task_id: str,
+    thread_id: str,
+    result: Dict[str, Any],
+) -> bool:
+    complete_task = getattr(task_manager, "complete_task_if_open", None)
+    if complete_task is None:
+        task_state = await task_manager.get_task_state(task_id)
+        if task_state and task_state.status in {
+            TaskStatus.DONE,
+            TaskStatus.FAILED,
+            TaskStatus.CANCELLED,
+        }:
+            return False
+        await task_manager.set_task_result(task_id, result)
+        await task_manager.update_task_status(task_id, TaskStatus.DONE)
+        return True
+
+    completed = await complete_task(task_id, result)
+    if completed:
+        return True
+
+    try:
+        task_state = await task_manager.get_task_state(task_id)
+    except Exception:
+        task_state = None
+    status = task_state.status.value if task_state else "missing"
+    logger.info(
+        "Skipped successful completion for task %s because current status is %s",
+        task_id,
+        status,
+    )
+    return False
+
+
 async def _complete_deep_triage_target_limit_response(
     *,
     task_manager: TaskManager,
@@ -834,8 +879,14 @@ async def _complete_deep_triage_target_limit_response(
         ),
         "turn_completed_at": datetime.now(timezone.utc).isoformat(),
     }
-    await task_manager.set_task_result(task_id, result)
-    await task_manager.update_task_status(task_id, TaskStatus.DONE)
+    completed = await _complete_task_if_open(
+        task_manager=task_manager,
+        task_id=task_id,
+        thread_id=thread_id,
+        result=result,
+    )
+    if not completed:
+        return _build_terminal_task_result(task_id, thread_id, TaskStatus.CANCELLED)
     await task_manager._publish_stream_update(
         thread_id,
         "turn_complete",
@@ -974,6 +1025,19 @@ async def _run_single_target_triage_child(
         "turn_completed_at": datetime.now(timezone.utc).isoformat(),
     }
 
+    completed = await _complete_task_if_open(
+        task_manager=task_manager,
+        task_id=child_task_id,
+        thread_id=thread_id,
+        result=result,
+    )
+    if not completed:
+        return {
+            **_build_terminal_task_result(child_task_id, thread_id, TaskStatus.CANCELLED),
+            "parent_task_id": parent_task_id,
+            "target": target_metadata,
+        }
+
     await thread_manager.append_messages(
         thread_id,
         [
@@ -988,8 +1052,6 @@ async def _run_single_target_triage_child(
             }
         ],
     )
-    await task_manager.set_task_result(child_task_id, result)
-    await task_manager.update_task_status(child_task_id, TaskStatus.DONE)
 
     tool_envelopes = agent_response.get("tool_envelopes", [])
     if tool_envelopes:
@@ -1146,8 +1208,14 @@ async def _run_multi_target_deep_triage_fanout(
         ],
         "turn_completed_at": datetime.now(timezone.utc).isoformat(),
     }
-    await task_manager.set_task_result(task_id, result)
-    await task_manager.update_task_status(task_id, TaskStatus.DONE)
+    completed = await _complete_task_if_open(
+        task_manager=task_manager,
+        task_id=task_id,
+        thread_id=thread_id,
+        result=result,
+    )
+    if not completed:
+        return _build_terminal_task_result(task_id, thread_id, TaskStatus.CANCELLED)
     await task_manager._publish_stream_update(
         thread_id,
         "turn_complete",
@@ -2446,6 +2514,9 @@ async def _process_agent_turn_impl(
         except Exception:
             logger.debug("Unable to read task state for %s after agent execution", task_id)
             current_task_state = None
+        if current_task_state and current_task_state.status == TaskStatus.CANCELLED:
+            logger.info("Task %s was cancelled before completion", task_id)
+            return _build_terminal_task_result(task_id, thread_id, TaskStatus.CANCELLED)
         if pending_approval or (
             current_task_state and current_task_state.status == TaskStatus.AWAITING_APPROVAL
         ):
@@ -2566,8 +2637,14 @@ async def _process_agent_turn_impl(
             "citation_groups": citation_groups,
         }
 
-        await task_manager.set_task_result(task_id, result)
-        await task_manager.update_task_status(task_id, TaskStatus.DONE)
+        completed = await _complete_task_if_open(
+            task_manager=task_manager,
+            task_id=task_id,
+            thread_id=thread_id,
+            result=result,
+        )
+        if not completed:
+            return _build_terminal_task_result(task_id, thread_id, TaskStatus.CANCELLED)
 
         # Store decision trace for this message (tool calls + citations)
         tool_envelopes = agent_response.get("tool_envelopes", [])
@@ -2857,6 +2934,9 @@ async def resume_task_after_approval(
             raise
 
         current_task_state = await task_manager.get_task_state(task_id)
+        if current_task_state and current_task_state.status == TaskStatus.CANCELLED:
+            await approval_manager.delete_resume_state(task_id)
+            return _build_terminal_task_result(task_id, thread_id, TaskStatus.CANCELLED)
         if current_task_state and current_task_state.status == TaskStatus.AWAITING_APPROVAL:
             result = _build_awaiting_approval_result(
                 task_id=task_id,
@@ -2875,8 +2955,15 @@ async def resume_task_after_approval(
             "instance_id": instance_id,
             "cluster_id": cluster_id,
         }
-        await task_manager.set_task_result(task_id, result)
-        await task_manager.update_task_status(task_id, TaskStatus.DONE)
+        completed = await _complete_task_if_open(
+            task_manager=task_manager,
+            task_id=task_id,
+            thread_id=thread_id,
+            result=result,
+        )
+        if not completed:
+            await approval_manager.delete_resume_state(task_id)
+            return _build_terminal_task_result(task_id, thread_id, TaskStatus.CANCELLED)
         await approval_manager.delete_resume_state(task_id)
 
         message_id = str(ULID())
@@ -2965,6 +3052,9 @@ async def resume_task_after_approval(
     }
 
     current_task_state = await task_manager.get_task_state(task_id)
+    if current_task_state and current_task_state.status == TaskStatus.CANCELLED:
+        await approval_manager.delete_resume_state(task_id)
+        return _build_terminal_task_result(task_id, thread_id, TaskStatus.CANCELLED)
     if current_task_state and current_task_state.status == TaskStatus.AWAITING_APPROVAL:
         result = _build_awaiting_approval_result(
             task_id=task_id,
@@ -3033,8 +3123,15 @@ async def resume_task_after_approval(
         "turn_completed_at": datetime.now(timezone.utc).isoformat(),
         "citation_groups": citation_groups,
     }
-    await task_manager.set_task_result(task_id, result)
-    await task_manager.update_task_status(task_id, TaskStatus.DONE)
+    completed = await _complete_task_if_open(
+        task_manager=task_manager,
+        task_id=task_id,
+        thread_id=thread_id,
+        result=result,
+    )
+    if not completed:
+        await approval_manager.delete_resume_state(task_id)
+        return _build_terminal_task_result(task_id, thread_id, TaskStatus.CANCELLED)
     await approval_manager.delete_resume_state(task_id)
 
     tool_envelopes = agent_response.get("tool_envelopes", [])

--- a/redis_sre_agent/core/instances.py
+++ b/redis_sre_agent/core/instances.py
@@ -95,7 +95,7 @@ class RedisInstance(BaseModel):
     connection_url: SecretStr = Field(
         ..., description="Redis connection URL (e.g., redis://localhost:6379)"
     )
-    environment: str = Field(..., description="Environment: development, staging, production")
+    environment: str = Field(..., description="Environment: development, staging, production, test")
 
     @field_serializer("connection_url", "admin_password", when_used="json")
     def dump_secret(self, v):
@@ -435,7 +435,7 @@ async def query_instances(
     """Query instances with server-side filtering and pagination.
 
     Args:
-        environment: Filter by environment (development, staging, production)
+        environment: Filter by environment (development, staging, production, test)
         usage: Filter by usage type (cache, analytics, session, queue, custom)
         status: Filter by status (healthy, unhealthy, unknown)
         instance_type: Filter by type (oss_single, oss_cluster, redis_enterprise, redis_cloud)

--- a/redis_sre_agent/core/knowledge_helpers.py
+++ b/redis_sre_agent/core/knowledge_helpers.py
@@ -6,6 +6,7 @@ They are called by:
 - Tools (in agent.knowledge_agent) for LLM access with custom docstrings
 """
 
+import hashlib
 import logging
 import re
 import time
@@ -1170,17 +1171,6 @@ async def search_knowledge_base_helper(
         category_filter = Tag("category") == category
         filter_expr = category_filter if filter_expr is None else (filter_expr & category_filter)
         logger.debug("Applying category filter: %s", category)
-    # Always use vector search (tests rely on embedding being used)
-    vectorizer = get_vectorizer(config=config)
-
-    # Measure embedding latency and trace it
-    _t0 = time.monotonic()
-    with tracer.start_as_current_span("knowledge.embed") as _span:
-        _span.set_attribute("query.length", len(query))
-        vectors = await vectorizer.aembed_many([query])
-    _t1 = time.monotonic()
-
-    query_vector = vectors[0] if vectors else []
 
     exact_match_search = _looks_like_precise_search_query(query, normalized_index_type)
     precise_search = hybrid_search or exact_match_search
@@ -1212,6 +1202,29 @@ async def search_knowledge_base_helper(
         else []
     )
     effective_hybrid_search = hybrid_search or precise_search
+    query_vector: List[float] = []
+    semantic_search_available = True
+
+    # Measure embedding latency and trace it. Exact-looking queries can still
+    # return identifier/text hits when the embedding provider is unavailable.
+    _t0 = time.monotonic()
+    try:
+        vectorizer = get_vectorizer(config=config)
+        with tracer.start_as_current_span("knowledge.embed") as _span:
+            _span.set_attribute("query.length", len(query))
+            vectors = await vectorizer.aembed_many([query])
+        _t1 = time.monotonic()
+        query_vector = vectors[0] if vectors else []
+    except Exception as exc:
+        _t1 = time.monotonic()
+        if exact_match_search and (exact_matches or precise_text_matches):
+            semantic_search_available = False
+            logger.warning(
+                "Embedding search unavailable for exact knowledge query; returning exact matches: %s",
+                exc,
+            )
+        else:
+            raise
 
     # We need to fetch more results if there's an offset, then slice.
     # This path merges exact/quoted prequery results with semantic results and
@@ -1293,17 +1306,20 @@ async def search_knowledge_base_helper(
 
     # Perform vector search
     _t2 = time.monotonic()
-    with tracer.start_as_current_span("knowledge.index.query") as _span:
-        _span.set_attribute("limit", int(limit))
-        _span.set_attribute("offset", int(offset))
-        _span.set_attribute("hybrid_search", bool(effective_hybrid_search))
-        _span.set_attribute("version", version or "all")
-        _span.set_attribute(
-            "distance_threshold",
-            float(distance_threshold) if distance_threshold is not None else -1.0,
-        )
-        _span.set_attribute("query.filtered", bool(filter_expr is not None))
-        all_results = await _run_query(filter_expr, fetch_limit)
+    if semantic_search_available:
+        with tracer.start_as_current_span("knowledge.index.query") as _span:
+            _span.set_attribute("limit", int(limit))
+            _span.set_attribute("offset", int(offset))
+            _span.set_attribute("hybrid_search", bool(effective_hybrid_search))
+            _span.set_attribute("version", version or "all")
+            _span.set_attribute(
+                "distance_threshold",
+                float(distance_threshold) if distance_threshold is not None else -1.0,
+            )
+            _span.set_attribute("query.filtered", bool(filter_expr is not None))
+            all_results = await _run_query(filter_expr, fetch_limit)
+    else:
+        all_results = []
     _t3 = time.monotonic()
 
     merged_results = _dedupe_docs([*exact_matches, *precise_text_matches, *all_results])
@@ -1324,17 +1340,20 @@ async def search_knowledge_base_helper(
     # while preserving other filters such as version/doc_type.
     if category is not None and len(filtered_results) == 0:
         category_fallback_expr = Tag("version") == version if version is not None else None
-        with tracer.start_as_current_span("knowledge.index.query") as _span:
-            _span.set_attribute("limit", int(limit))
-            _span.set_attribute("offset", int(offset))
-            _span.set_attribute("hybrid_search", bool(effective_hybrid_search))
-            _span.set_attribute("version", version or "all")
-            _span.set_attribute(
-                "distance_threshold",
-                float(distance_threshold) if distance_threshold is not None else -1.0,
-            )
-            _span.set_attribute("query.filtered", bool(category_fallback_expr is not None))
-            category_fallback_results = await _run_query(category_fallback_expr, fetch_limit)
+        if semantic_search_available:
+            with tracer.start_as_current_span("knowledge.index.query") as _span:
+                _span.set_attribute("limit", int(limit))
+                _span.set_attribute("offset", int(offset))
+                _span.set_attribute("hybrid_search", bool(effective_hybrid_search))
+                _span.set_attribute("version", version or "all")
+                _span.set_attribute(
+                    "distance_threshold",
+                    float(distance_threshold) if distance_threshold is not None else -1.0,
+                )
+                _span.set_attribute("query.filtered", bool(category_fallback_expr is not None))
+                category_fallback_results = await _run_query(category_fallback_expr, fetch_limit)
+        else:
+            category_fallback_results = []
 
         fallback_exact_matches = (
             await _find_exact_document_matches(
@@ -1487,15 +1506,18 @@ async def ingest_sre_document_helper(
     # Create document embedding (as_buffer=True for Redis storage)
     content_vector = await vectorizer.aembed(content, as_buffer=True)
 
-    # Prepare document data
-    doc_id = str(ULID())
+    # Prepare document data using the same chunk schema as pipeline ingestion.
+    document_hash = hashlib.sha256(f"{title}||{content}||{source}".encode()).hexdigest()[:16]
+    content_hash = hashlib.sha256(content.encode()).hexdigest()
     key_prefix = _INDEX_TYPE_TO_PREFIX.get(index_type, "sre_knowledge")
-    doc_key = f"{key_prefix}:{doc_id}"
+    doc_key = f"{key_prefix}:{document_hash}:chunk:0"
 
     # Convert product_labels list to comma-separated string for tag field
     product_labels_str = ",".join(product_labels) if product_labels else ""
     document = {
-        "id": doc_id,
+        "id": doc_key,
+        "document_hash": document_hash,
+        "content_hash": content_hash,
         "title": title,
         "content": content,
         "source": source,
@@ -1510,6 +1532,8 @@ async def ingest_sre_document_helper(
         "product_labels": product_labels_str,
         "product_label_tags": product_labels_str,  # Duplicate for tag searching
         "pinned": "false",
+        "version": "latest",
+        "chunk_index": 0,
     }
 
     # Store in vector index
@@ -1517,7 +1541,9 @@ async def ingest_sre_document_helper(
 
     result = {
         "task_id": str(ULID()),
-        "document_id": doc_id,
+        "document_id": doc_key,
+        "document_hash": document_hash,
+        "chunk_count": 1,
         "title": title,
         "source": source,
         "category": category,
@@ -1526,7 +1552,7 @@ async def ingest_sre_document_helper(
         "status": "ingested",
     }
 
-    logger.info(f"Document ingested successfully: {doc_id}")
+    logger.info(f"Document ingested successfully: {doc_key}")
     return result
 
 

--- a/redis_sre_agent/core/targets.py
+++ b/redis_sre_agent/core/targets.py
@@ -1148,10 +1148,17 @@ def _contains_token_sequence(haystack: Sequence[str], needle: Sequence[str]) -> 
     return False
 
 
+def _query_contains_exact_term(normalized_query: str, normalized_term: str) -> bool:
+    """Return True when an exact target term appears on identifier boundaries."""
+    if not normalized_query or not normalized_term:
+        return False
+    pattern = re.compile(rf"(?<![a-z0-9_-]){re.escape(normalized_term)}(?![a-z0-9_-])")
+    return bool(pattern.search(normalized_query))
+
+
 def _query_mentions_exact_target(doc: TargetCatalogDoc, hints: Dict[str, Any]) -> bool:
     """Detect exact target mentions embedded inside a larger user query."""
     normalized = hints["normalized"]
-    query_token_list = hints.get("token_list") or _tokenize(normalized)
     exact_terms = _exact_target_terms(doc)
     if normalized and normalized in exact_terms:
         return True
@@ -1159,7 +1166,7 @@ def _query_mentions_exact_target(doc: TargetCatalogDoc, hints: Dict[str, Any]) -
         term_tokens = _tokenize(term)
         if len(term_tokens) < 2:
             continue
-        if _contains_token_sequence(query_token_list, term_tokens):
+        if _query_contains_exact_term(normalized, term):
             return True
     return False
 

--- a/redis_sre_agent/core/tasks.py
+++ b/redis_sre_agent/core/tasks.py
@@ -166,6 +166,41 @@ class TaskManager:
         await self._upsert_task_search_doc(task_id)
         return True
 
+    async def complete_task_if_open(self, task_id: str, result: Dict[str, Any]) -> bool:
+        """Atomically persist a successful result unless the task is already terminal."""
+        import json
+
+        now_iso = datetime.now(timezone.utc).isoformat()
+        script = """
+        local status = redis.call('GET', KEYS[1])
+        if not status then
+            return 0
+        end
+        if status == ARGV[1] or status == ARGV[2] or status == ARGV[3] then
+            return 0
+        end
+        redis.call('SET', KEYS[2], ARGV[4])
+        redis.call('SET', KEYS[1], ARGV[5])
+        redis.call('HSET', KEYS[3], 'updated_at', ARGV[6])
+        return 1
+        """
+        completed = await self._redis.eval(
+            script,
+            3,
+            RedisKeys.task_status(task_id),
+            RedisKeys.task_result(task_id),
+            RedisKeys.task_metadata(task_id),
+            TaskStatus.DONE.value,
+            TaskStatus.FAILED.value,
+            TaskStatus.CANCELLED.value,
+            json.dumps(result),
+            TaskStatus.DONE.value,
+            now_iso,
+        )
+        if bool(completed):
+            await self._upsert_task_search_doc(task_id)
+        return bool(completed)
+
     async def set_task_error(self, task_id: str, error_message: str) -> bool:
         await self._redis.set(RedisKeys.task_error(task_id), error_message)
         await self._redis.hset(

--- a/redis_sre_agent/mcp_server/server.py
+++ b/redis_sre_agent/mcp_server/server.py
@@ -50,8 +50,10 @@ the background. You MUST watch each task for:
 | `redis_sre_cleanup_pipeline_batches()` | Remove old pipeline batches | Varies |
 
 **Note**: Deep triage performs comprehensive analysis including metrics collection, log analysis,
-knowledge base searches, and multi-topic recommendation synthesis. Complex queries or
-instances with many data sources may take longer.
+knowledge base searches, and multi-topic recommendation synthesis. If target discovery finds
+multiple Redis targets, deep triage can fan out to one child task per target, up to five targets.
+If more than five targets match, the task asks you to narrow the scope instead of running a
+partial triage.
 
 After calling any of these, you MUST:
 1. Get the `task_id` from the response
@@ -207,6 +209,11 @@ async def redis_sre_deep_triage(
     - Synthesizes findings into actionable recommendations
     - Emits notifications as it works (visible via redis_sre_get_task_status)
     - Stores the final result on the task when complete
+    - Can fan out to one child triage task per discovered Redis target, up to five targets
+
+    If target discovery matches more than five Redis targets, the task returns guidance to
+    narrow the request instead of triaging a partial set. Continue the same thread with
+    a smaller target set, such as exact instance names, cluster IDs, environment, or region.
 
     ## How to Use the Task
 
@@ -232,7 +239,9 @@ async def redis_sre_deep_triage(
     """
     from docket import Docket
 
+    from redis_sre_agent.core.clusters import get_cluster_by_id
     from redis_sre_agent.core.docket_tasks import get_redis_url, process_agent_turn
+    from redis_sre_agent.core.instances import get_instance_by_id
     from redis_sre_agent.core.redis import get_redis_client
     from redis_sre_agent.core.tasks import create_task
 
@@ -243,6 +252,26 @@ async def redis_sre_deep_triage(
             return {
                 "status": "failed",
                 "message": "Please provide only one of instance_id or cluster_id",
+            }
+
+        if instance_id and await get_instance_by_id(instance_id) is None:
+            return {
+                "status": "failed",
+                "message": (
+                    f"Redis instance '{instance_id}' was not found. "
+                    "Use redis_sre_list_instances to choose a valid instance_id."
+                ),
+                "instance_id": instance_id,
+            }
+
+        if cluster_id and await get_cluster_by_id(cluster_id) is None:
+            return {
+                "status": "failed",
+                "message": (
+                    f"Redis cluster '{cluster_id}' was not found. "
+                    "Use redis_sre_list_clusters to choose a valid cluster_id."
+                ),
+                "cluster_id": cluster_id,
             }
 
         redis_client = get_redis_client()

--- a/scripts/setup-knowledge.sh
+++ b/scripts/setup-knowledge.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Redis SRE Agent Knowledge Base Setup Script
-# Populates the knowledge base with Redis documentation and runbooks
+# Prepares and ingests source documents through the supported pipeline flow.
 
 set -euo pipefail
 
@@ -23,30 +23,44 @@ warning() {
 }
 
 main() {
+    API_URL="${API_URL:-http://localhost:8080}"
+    COMPOSE_SERVICE="${COMPOSE_SERVICE:-sre-agent}"
+
     echo "📚 Redis SRE Agent Knowledge Base Setup"
     echo "======================================="
     echo
 
     # Check if SRE Agent is running
-    if ! curl -s http://localhost:8000/api/v1/health >/dev/null; then
+    if ! curl -fsS "${API_URL}/api/v1/health" >/dev/null; then
         warning "SRE Agent API is not running. Please start it first:"
-        echo "  docker-compose up -d sre-agent"
+        echo "  docker compose up -d ${COMPOSE_SERVICE}"
         exit 1
     fi
 
-    log "Populating knowledge base with Redis documentation..."
+    log "Preparing source documents for ingestion..."
 
-    # Use the CLI to populate knowledge base
-    if docker-compose exec -T sre-agent uv run redis-sre-agent knowledge populate 2>/dev/null; then
-        success "Knowledge base populated successfully"
+    if docker compose exec -T "${COMPOSE_SERVICE}" \
+        uv run redis-sre-agent pipeline prepare-sources --prepare-only; then
+        success "Source documents prepared successfully"
     else
-        warning "Knowledge base population failed, but continuing..."
-        log "You can manually populate it later with:"
-        echo "  docker-compose exec sre-agent uv run redis-sre-agent knowledge populate"
+        warning "Source document preparation failed, but continuing..."
+        log "You can manually prepare sources later with:"
+        echo "  docker compose exec ${COMPOSE_SERVICE} uv run redis-sre-agent pipeline prepare-sources --prepare-only"
+    fi
+
+    log "Ingesting prepared source documents..."
+
+    if docker compose exec -T "${COMPOSE_SERVICE}" \
+        uv run redis-sre-agent pipeline ingest; then
+        success "Knowledge base ingested successfully"
+    else
+        warning "Knowledge base ingestion failed, but continuing..."
+        log "You can manually ingest prepared documents later with:"
+        echo "  docker compose exec ${COMPOSE_SERVICE} uv run redis-sre-agent pipeline ingest"
     fi
 
     log "Checking knowledge base status..."
-    if curl -s "http://localhost:8000/knowledge/search?q=redis+memory&limit=1" | grep -q "results"; then
+    if curl -fsS "${API_URL}/api/v1/knowledge/search?query=redis%20memory&limit=1" | grep -q "results"; then
         success "Knowledge base is working and searchable"
     else
         warning "Knowledge base search may not be working properly"
@@ -61,7 +75,7 @@ main() {
     echo "  • Best practices and configuration examples"
     echo
     echo "🔍 Test the knowledge base:"
-    echo "  curl 'http://localhost:8000/knowledge/search?q=memory+usage&limit=5'"
+    echo "  curl '${API_URL}/api/v1/knowledge/search?query=memory%20usage&limit=5'"
     echo
 }
 

--- a/specs/knowledge-pack-release-spec.md
+++ b/specs/knowledge-pack-release-spec.md
@@ -73,8 +73,8 @@ assumes each operator will rebuild indexable state on their own machine.
 - Auto-refreshing the pack after release publication.
 - Solving fully offline query embeddings in this change alone.
   The pack removes corpus-building work, but query-time embedding compatibility still matters.
-- Shipping LLM-generated `runbook_generator` output in the default release pack.
-  That source is less deterministic and should be handled separately if needed.
+- Shipping ad hoc LLM-generated runbook artifacts in the default release pack.
+  Generated artifacts are less deterministic and should be handled separately if needed.
 
 ## Current-State Constraints
 

--- a/tests/unit/api/test_knowledge_api.py
+++ b/tests/unit/api/test_knowledge_api.py
@@ -298,7 +298,11 @@ class TestKnowledgeIngestion:
             "severity": "info",
         }
 
-        mock_result = {"document_id": "test_doc_123"}
+        mock_result = {
+            "document_id": "sre_knowledge:test_doc_123:chunk:0",
+            "document_hash": "test_doc_123",
+            "chunk_count": 1,
+        }
 
         with patch(
             "redis_sre_agent.core.docket_tasks.ingest_sre_document", new_callable=AsyncMock
@@ -311,7 +315,9 @@ class TestKnowledgeIngestion:
             data = response.json()
 
             assert data["success"] is True
-            assert data["document_id"] == "test_doc_123"
+            assert data["document_id"] == "sre_knowledge:test_doc_123:chunk:0"
+            assert data["document_hash"] == "test_doc_123"
+            assert data["chunk_count"] == 1
             assert "message" in data
 
             # Verify the ingest function was called with correct parameters

--- a/tests/unit/api/test_tasks_api.py
+++ b/tests/unit/api/test_tasks_api.py
@@ -205,6 +205,145 @@ class TestTasksAPI:
         assert resp.status_code == 200
         assert resp.json()["tool_calls"] == tool_calls
 
+    def test_cancel_task_preserves_task_state(self, client):
+        """POST /api/v1/tasks/{task_id}/cancel cancels without deleting task data."""
+
+        class Metadata:
+            subject = "Running task"
+            created_at = "2024-01-01T00:00:00Z"
+            updated_at = "2024-01-01T00:01:00Z"
+
+        class ActiveState:
+            task_id = "t1"
+            thread_id = "th1"
+            status = TaskStatus.IN_PROGRESS
+            updates = []
+            result = None
+            error_message = None
+            metadata = Metadata()
+            pending_approval = {"approval_id": "approval-1"}
+            resume_supported = True
+
+        class CancelledState:
+            task_id = "t1"
+            thread_id = "th1"
+            status = TaskStatus.CANCELLED
+            updates = []
+            result = None
+            error_message = None
+            metadata = Metadata()
+            pending_approval = None
+            resume_supported = False
+
+        mock_tm = MagicMock()
+        mock_tm.get_task_state = AsyncMock(side_effect=[ActiveState(), CancelledState()])
+        mock_tm.get_task_tool_calls = AsyncMock(return_value=None)
+        mock_tm.set_pending_approval = AsyncMock()
+        mock_tm.set_resume_supported = AsyncMock()
+        mock_tm.update_task_status = AsyncMock()
+        mock_tm.add_task_update = AsyncMock()
+        docket_instance = AsyncMock()
+        docket_instance.__aenter__.return_value = docket_instance
+        docket_instance.__aexit__.return_value = False
+
+        with (
+            patch("redis_sre_agent.api.tasks.get_redis_client", return_value=MagicMock()),
+            patch("redis_sre_agent.api.tasks.TaskManager", return_value=mock_tm),
+            patch(
+                "redis_sre_agent.api.tasks.get_redis_url",
+                new=AsyncMock(return_value="redis://test"),
+            ),
+            patch("redis_sre_agent.api.tasks.Docket", return_value=docket_instance),
+            patch(
+                "redis_sre_agent.api.tasks.delete_task_core",
+                new_callable=AsyncMock,
+            ) as mock_delete,
+            patch(
+                "redis_sre_agent.api.tasks.get_feedback",
+                new=AsyncMock(return_value=None),
+            ),
+        ):
+            resp = client.post("/api/v1/tasks/t1/cancel")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["task_id"] == "t1"
+        assert data["status"] == TaskStatus.CANCELLED.value
+        docket_instance.cancel.assert_awaited_once_with("t1")
+        mock_tm.set_pending_approval.assert_awaited_once_with("t1", None)
+        mock_tm.set_resume_supported.assert_awaited_once_with("t1", False)
+        mock_tm.update_task_status.assert_awaited_once_with("t1", TaskStatus.CANCELLED)
+        mock_tm.add_task_update.assert_awaited_once_with(
+            "t1",
+            "Task cancelled by user request",
+            "cancellation",
+            None,
+        )
+        mock_delete.assert_not_awaited()
+
+    def test_cancel_task_not_found(self, client):
+        """POST /api/v1/tasks/{task_id}/cancel returns 404 when the task is missing."""
+
+        mock_tm = MagicMock()
+        mock_tm.get_task_state = AsyncMock(return_value=None)
+
+        with (
+            patch("redis_sre_agent.api.tasks.get_redis_client", return_value=MagicMock()),
+            patch("redis_sre_agent.api.tasks.TaskManager", return_value=mock_tm),
+            patch("redis_sre_agent.api.tasks.Docket") as mock_docket,
+        ):
+            resp = client.post("/api/v1/tasks/missing/cancel")
+
+        assert resp.status_code == 404
+        assert resp.json()["detail"] == "Task not found"
+        mock_docket.assert_not_called()
+
+    def test_cancel_task_terminal_state_is_idempotent(self, client):
+        """POST /api/v1/tasks/{task_id}/cancel leaves terminal tasks unchanged."""
+
+        class Metadata:
+            subject = "Done task"
+            created_at = "2024-01-01T00:00:00Z"
+            updated_at = "2024-01-01T00:01:00Z"
+
+        class DoneState:
+            task_id = "t1"
+            thread_id = "th1"
+            status = TaskStatus.DONE
+            updates = []
+            result = {"response": "ok"}
+            error_message = None
+            metadata = Metadata()
+            pending_approval = None
+            resume_supported = False
+
+        mock_tm = MagicMock()
+        mock_tm.get_task_state = AsyncMock(return_value=DoneState())
+        mock_tm.get_task_tool_calls = AsyncMock(return_value=[])
+        mock_tm.set_pending_approval = AsyncMock()
+        mock_tm.set_resume_supported = AsyncMock()
+        mock_tm.update_task_status = AsyncMock()
+        mock_tm.add_task_update = AsyncMock()
+
+        with (
+            patch("redis_sre_agent.api.tasks.get_redis_client", return_value=MagicMock()),
+            patch("redis_sre_agent.api.tasks.TaskManager", return_value=mock_tm),
+            patch("redis_sre_agent.api.tasks.Docket") as mock_docket,
+            patch(
+                "redis_sre_agent.api.tasks.get_feedback",
+                new=AsyncMock(return_value=None),
+            ),
+        ):
+            resp = client.post("/api/v1/tasks/t1/cancel")
+
+        assert resp.status_code == 200
+        assert resp.json()["status"] == TaskStatus.DONE.value
+        mock_docket.assert_not_called()
+        mock_tm.set_pending_approval.assert_not_awaited()
+        mock_tm.set_resume_supported.assert_not_awaited()
+        mock_tm.update_task_status.assert_not_awaited()
+        mock_tm.add_task_update.assert_not_awaited()
+
     def test_delete_task_success(self, client):
         """DELETE /api/v1/tasks/{task_id} cancels Docket task and deletes core state."""
 

--- a/tests/unit/api/test_threads_api.py
+++ b/tests/unit/api/test_threads_api.py
@@ -1,12 +1,13 @@
 """Unit tests for threads API endpoints mounted under /api/v1."""
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import pytest
 from fastapi.testclient import TestClient
 
 from redis_sre_agent.api.app import app
 from redis_sre_agent.core.approvals import ApprovalStatus, PendingApprovalSummary
+from redis_sre_agent.core.tasks import TaskStatus
 
 
 @pytest.fixture
@@ -209,3 +210,80 @@ class TestThreadsAPI:
         with patch("redis_sre_agent.api.threads.ThreadManager", return_value=mock_tm):
             resp = client.patch("/api/v1/threads/missing", json={"context": {"k": "v"}})
         assert resp.status_code == 404
+
+    def test_cancel_thread_tasks_cancels_all_active_tasks(self, client):
+        """POST /threads/{id}/cancel cancels every active task indexed to the thread."""
+        from redis_sre_agent.core.threads import Thread, ThreadMetadata
+
+        class ActiveParentState:
+            status = TaskStatus.IN_PROGRESS
+
+        class TerminalChildState:
+            status = TaskStatus.DONE
+
+        class ActiveChildState:
+            status = TaskStatus.QUEUED
+
+        mock_thread = Thread(thread_id="th1", context={}, metadata=ThreadMetadata(user_id="u"))
+        mock_tm = MagicMock()
+        mock_tm.get_thread = AsyncMock(return_value=mock_thread)
+        mock_task_manager = MagicMock()
+        mock_task_manager.get_task_state = AsyncMock(
+            side_effect=[ActiveParentState(), TerminalChildState(), ActiveChildState()]
+        )
+        mock_task_manager.set_pending_approval = AsyncMock()
+        mock_task_manager.set_resume_supported = AsyncMock()
+        mock_task_manager.update_task_status = AsyncMock()
+        mock_task_manager.add_task_update = AsyncMock()
+        mock_redis = AsyncMock()
+        mock_redis.zrange.return_value = [b"parent-task", b"done-child", b"active-child"]
+        docket_instance = AsyncMock()
+        docket_instance.__aenter__.return_value = docket_instance
+        docket_instance.__aexit__.return_value = False
+
+        with (
+            patch("redis_sre_agent.api.threads.get_redis_client", return_value=mock_redis),
+            patch("redis_sre_agent.api.threads.ThreadManager", return_value=mock_tm),
+            patch("redis_sre_agent.api.threads.TaskManager", return_value=mock_task_manager),
+            patch(
+                "redis_sre_agent.api.tasks.get_redis_url",
+                new=AsyncMock(return_value="redis://test"),
+            ),
+            patch("redis_sre_agent.api.tasks.Docket", return_value=docket_instance),
+        ):
+            resp = client.post("/api/v1/threads/th1/cancel")
+
+        assert resp.status_code == 200
+        assert resp.json() == {
+            "thread_id": "th1",
+            "cancelled_task_ids": ["parent-task", "active-child"],
+            "terminal_task_ids": ["done-child"],
+            "missing_task_ids": [],
+        }
+        assert docket_instance.cancel.await_args_list == [
+            call("parent-task"),
+            call("active-child"),
+        ]
+        assert mock_task_manager.update_task_status.await_args_list == [
+            call("parent-task", TaskStatus.CANCELLED),
+            call("active-child", TaskStatus.CANCELLED),
+        ]
+        assert mock_task_manager.add_task_update.await_count == 2
+
+    def test_cancel_thread_tasks_not_found(self, client):
+        """POST /threads/{id}/cancel returns 404 when the thread is missing."""
+        mock_tm = MagicMock()
+        mock_tm.get_thread = AsyncMock(return_value=None)
+        mock_redis = AsyncMock()
+
+        with (
+            patch("redis_sre_agent.api.threads.get_redis_client", return_value=mock_redis),
+            patch("redis_sre_agent.api.threads.ThreadManager", return_value=mock_tm),
+            patch("redis_sre_agent.api.threads.TaskManager") as mock_task_manager,
+        ):
+            resp = client.post("/api/v1/threads/missing/cancel")
+
+        assert resp.status_code == 404
+        assert resp.json()["detail"] == "Thread not found"
+        mock_redis.zrange.assert_not_called()
+        mock_task_manager.assert_not_called()

--- a/tests/unit/cli/test_cli_logging_utils.py
+++ b/tests/unit/cli/test_cli_logging_utils.py
@@ -6,9 +6,10 @@ from unittest.mock import patch
 
 import click
 import pytest
+from click.testing import CliRunner
 
 from redis_sre_agent.cli.logging_utils import log_cli_exception
-from redis_sre_agent.cli.main import LazyGroup
+from redis_sre_agent.cli.main import LazyGroup, main
 
 
 def test_log_cli_exception_uses_explicit_exception_info_outside_except(caplog):
@@ -46,3 +47,28 @@ def test_lazy_group_skips_duplicate_logging_for_already_logged_exception():
                     group.invoke(ctx)
 
     mock_log.assert_not_called()
+
+
+def test_lazy_group_does_not_log_successful_click_exit():
+    group = LazyGroup(name="test")
+    ctx = click.Context(group)
+
+    with patch("redis_sre_agent.cli.main.log_cli_exception") as mock_log:
+        with patch.object(click.MultiCommand, "invoke", side_effect=click.exceptions.Exit(0)):
+            with pytest.raises(click.exceptions.Exit) as raised:
+                group.invoke(ctx)
+
+    assert raised.value.exit_code == 0
+    mock_log.assert_not_called()
+
+
+def test_nested_help_does_not_log_cli_failure():
+    result = CliRunner().invoke(main, ["pipeline", "--help"])
+    combined_output = result.output
+    if result.stderr:
+        combined_output += result.stderr
+
+    assert result.exit_code == 0
+    assert "Usage:" in result.output
+    assert "CLI command failed" not in combined_output
+    assert "click.exceptions.Exit" not in combined_output

--- a/tests/unit/core/test_docket_resume.py
+++ b/tests/unit/core/test_docket_resume.py
@@ -89,6 +89,7 @@ async def test_resume_task_after_approval_completes_chat_turn():
     mock_task_manager.update_task_status = AsyncMock()
     mock_task_manager.add_task_update = AsyncMock()
     mock_task_manager.set_task_result = AsyncMock()
+    mock_task_manager.complete_task_if_open = AsyncMock(return_value=True)
 
     mock_thread_manager = AsyncMock()
     mock_thread_manager.get_thread = AsyncMock(return_value=thread)
@@ -129,7 +130,8 @@ async def test_resume_task_after_approval_completes_chat_turn():
     mock_approval_manager.record_decision.assert_awaited_once()
     mock_approval_manager.delete_resume_state.assert_awaited_once_with("task-1")
     mock_task_manager.update_task_status.assert_any_call("task-1", TaskStatus.IN_PROGRESS)
-    mock_task_manager.update_task_status.assert_any_call("task-1", TaskStatus.DONE)
+    mock_task_manager.complete_task_if_open.assert_awaited_once()
+    assert mock_task_manager.complete_task_if_open.await_args.args[0] == "task-1"
     mock_thread_manager.append_messages.assert_awaited_once()
 
 

--- a/tests/unit/core/test_knowledge_helpers.py
+++ b/tests/unit/core/test_knowledge_helpers.py
@@ -1,5 +1,6 @@
 """Tests for knowledge helper functions."""
 
+import hashlib
 import inspect
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -403,6 +404,52 @@ class TestSearchKnowledgeBaseHelper:
         assert result["results_count"] == 2
         assert result["results"][0]["document_hash"] == "abc123def456"
         assert result["results"][1]["id"] == "doc-semantic"
+
+    @pytest.mark.asyncio
+    async def test_search_knowledge_base_returns_exact_match_when_embedding_unavailable(self):
+        """Exact identifier searches should degrade to exact RediSearch hits."""
+        mock_index = AsyncMock()
+        mock_index.query = AsyncMock(
+            side_effect=[
+                [],
+                [
+                    {
+                        "id": "doc-exact",
+                        "document_hash": "abc123def456",
+                        "chunk_index": 0,
+                        "title": "Exact doc",
+                        "content": "Exact hash match",
+                        "source": "docs",
+                        "category": "general",
+                        "doc_type": "runbook",
+                        "version": "latest",
+                    }
+                ],
+                [],
+                [],
+            ]
+        )
+
+        mock_vectorizer = MagicMock()
+        mock_vectorizer.aembed_many = AsyncMock(side_effect=Exception("OpenAI API error"))
+
+        with (
+            patch(
+                "redis_sre_agent.core.knowledge_helpers.get_knowledge_index",
+                new_callable=AsyncMock,
+                return_value=mock_index,
+            ),
+            patch(
+                "redis_sre_agent.core.knowledge_helpers.get_vectorizer",
+                return_value=mock_vectorizer,
+            ),
+        ):
+            result = await search_knowledge_base_helper(query="abc123def456", limit=10)
+
+        assert result["results_count"] == 1
+        assert result["results"][0]["document_hash"] == "abc123def456"
+        assert mock_index.query.call_count == 4
+        assert mock_vectorizer.aembed_many.await_count == 1
 
     @pytest.mark.asyncio
     async def test_search_knowledge_base_identifier_query_runs_literal_text_query(self):
@@ -1263,7 +1310,24 @@ class TestIngestSreDocumentHelper:
         assert result["category"] == "runbook"
         assert result["doc_type"] == "knowledge"
         assert "document_id" in result
+        expected_document_hash = hashlib.sha256(
+            "Test Document||This is test content||test".encode()
+        ).hexdigest()[:16]
+        expected_content_hash = hashlib.sha256("This is test content".encode()).hexdigest()
+        expected_key = f"sre_knowledge:{expected_document_hash}:chunk:0"
+        assert result["document_id"] == expected_key
+        assert result["document_hash"] == expected_document_hash
+        assert result["chunk_count"] == 1
         mock_index.load.assert_called_once()
+        call_args = mock_index.load.call_args
+        doc_data = call_args.kwargs.get("data") or call_args[1].get("data")
+        keys = call_args.kwargs.get("keys") or call_args[1].get("keys")
+        assert keys == [expected_key]
+        assert doc_data[0]["id"] == expected_key
+        assert doc_data[0]["document_hash"] == expected_document_hash
+        assert doc_data[0]["content_hash"] == expected_content_hash
+        assert doc_data[0]["chunk_index"] == 0
+        assert doc_data[0]["version"] == "latest"
 
     @pytest.mark.asyncio
     async def test_ingest_document_with_product_labels(self):
@@ -1302,6 +1366,9 @@ class TestIngestSreDocumentHelper:
         assert doc_data[0]["product_labels"] == "redis-cloud,enterprise"
         assert doc_data[0]["doc_type"] == "skill"
         assert doc_data[0]["pinned"] == "false"
+        assert doc_data[0]["id"].startswith("sre_skills:")
+        assert doc_data[0]["id"].endswith(":chunk:0")
+        assert doc_data[0]["chunk_index"] == 0
 
     @pytest.mark.asyncio
     async def test_ingest_support_ticket_defaults_pinned_false(self):
@@ -1337,6 +1404,9 @@ class TestIngestSreDocumentHelper:
         call_args = mock_index.load.call_args
         doc_data = call_args.kwargs.get("data") or call_args[1].get("data")
         assert doc_data[0]["pinned"] == "false"
+        assert doc_data[0]["id"].startswith("sre_support_tickets:")
+        assert doc_data[0]["id"].endswith(":chunk:0")
+        assert doc_data[0]["document_hash"]
 
 
 class TestGetAllDocumentFragments:

--- a/tests/unit/core/test_targets.py
+++ b/tests/unit/core/test_targets.py
@@ -367,6 +367,62 @@ async def test_resolve_target_query_allow_multiple_uses_exact_mentions_inside_co
 
 
 @pytest.mark.asyncio
+async def test_resolve_target_query_allow_multiple_does_not_treat_prefix_as_exact_mention():
+    base = TargetCatalogDoc(
+        target_id="instance:redis-prod-cache",
+        target_kind="instance",
+        resource_id="redis-prod-cache",
+        display_name="prod-cache",
+        name="prod-cache",
+        environment="production",
+        usage="cache",
+        target_type="oss_single",
+        capabilities=["redis", "diagnostics"],
+        search_text="prod cache production cache",
+        search_aliases=[],
+    )
+    numbered = TargetCatalogDoc(
+        target_id="instance:redis-prod-cache-1",
+        target_kind="instance",
+        resource_id="redis-prod-cache-1",
+        display_name="prod-cache-1",
+        name="prod-cache-1",
+        environment="production",
+        usage="cache",
+        target_type="oss_single",
+        capabilities=["redis", "diagnostics"],
+        search_text="prod cache 1 production cache",
+        search_aliases=[],
+    )
+    longer_prefix = TargetCatalogDoc(
+        target_id="instance:redis-prod-cache-10",
+        target_kind="instance",
+        resource_id="redis-prod-cache-10",
+        display_name="prod-cache-10",
+        name="prod-cache-10",
+        environment="production",
+        usage="cache",
+        target_type="oss_single",
+        capabilities=["redis", "diagnostics"],
+        search_text="prod cache 10 production cache",
+        search_aliases=[],
+    )
+
+    with patch(
+        "redis_sre_agent.core.targets.get_target_catalog",
+        new=AsyncMock(return_value=[base, numbered, longer_prefix]),
+    ):
+        resolved = await resolve_target_query(
+            query="deep triage prod-cache-1",
+            allow_multiple=True,
+        )
+
+    assert resolved.status == "resolved"
+    assert resolved.clarification_required is False
+    assert [match.resource_id for match in resolved.selected_matches] == ["redis-prod-cache-1"]
+
+
+@pytest.mark.asyncio
 async def test_resolve_target_query_allow_multiple_honors_max_results_for_exact_mentions():
     targets = [
         TargetCatalogDoc(

--- a/tests/unit/core/test_task_manager.py
+++ b/tests/unit/core/test_task_manager.py
@@ -305,6 +305,45 @@ class TestTaskManagerSetResult:
             result = await task_manager.set_task_result("task-123", complex_result)
             assert result is True
 
+    @pytest.mark.asyncio
+    async def test_complete_task_if_open_success(self):
+        """Successful completion should atomically write result and done status."""
+        mock_redis = AsyncMock()
+        mock_redis.eval = AsyncMock(return_value=1)
+        task_manager = TaskManager(redis_client=mock_redis)
+
+        with patch.object(
+            task_manager, "_upsert_task_search_doc", new_callable=AsyncMock
+        ) as mock_upsert:
+            result = await task_manager.complete_task_if_open("task-123", {"response": "Done"})
+
+        assert result is True
+        mock_redis.eval.assert_awaited_once()
+        eval_args = mock_redis.eval.await_args.args
+        assert eval_args[1] == 3
+        assert eval_args[5:8] == (
+            TaskStatus.DONE.value,
+            TaskStatus.FAILED.value,
+            TaskStatus.CANCELLED.value,
+        )
+        assert json.loads(eval_args[8]) == {"response": "Done"}
+        mock_upsert.assert_awaited_once_with("task-123")
+
+    @pytest.mark.asyncio
+    async def test_complete_task_if_open_skips_terminal_task(self):
+        """Completion should not reindex when Redis reports a terminal task."""
+        mock_redis = AsyncMock()
+        mock_redis.eval = AsyncMock(return_value=0)
+        task_manager = TaskManager(redis_client=mock_redis)
+
+        with patch.object(
+            task_manager, "_upsert_task_search_doc", new_callable=AsyncMock
+        ) as mock_upsert:
+            result = await task_manager.complete_task_if_open("task-123", {"response": "Done"})
+
+        assert result is False
+        mock_upsert.assert_not_awaited()
+
 
 class TestTaskManagerSetError:
     """Test TaskManager.set_task_error method."""

--- a/tests/unit/core/test_tasks.py
+++ b/tests/unit/core/test_tasks.py
@@ -1372,6 +1372,7 @@ class TestProcessAgentTurn:
         mock_task_manager.add_task_update = AsyncMock()
         mock_task_manager.set_task_result = AsyncMock()
         mock_task_manager.set_task_error = AsyncMock()
+        mock_task_manager.complete_task_if_open = AsyncMock(return_value=True)
 
         mock_chat_agent = AsyncMock()
         mock_response = AgentResponse(
@@ -1419,9 +1420,9 @@ class TestProcessAgentTurn:
         assert result["message_id"] == "01HXTESTMESSAGEID1234567890"
 
         # Result payload should include the assistant message_id for trace lookup.
-        set_result_call = mock_task_manager.set_task_result.await_args
-        assert set_result_call.args[0] == "provided-task-123"
-        assert set_result_call.args[1]["message_id"] == "01HXTESTMESSAGEID1234567890"
+        complete_call = mock_task_manager.complete_task_if_open.await_args
+        assert complete_call.args[0] == "provided-task-123"
+        assert complete_call.args[1]["message_id"] == "01HXTESTMESSAGEID1234567890"
 
         # The assistant message persisted on thread should preserve message_id + task linkage metadata.
         assistant_msgs = [m for m in mock_thread.messages if m.role == "assistant"]
@@ -1438,6 +1439,79 @@ class TestProcessAgentTurn:
             tool_envelopes=[{"name": "redis_info", "status": "success"}],
             otel_trace_id=None,
         )
+
+    @pytest.mark.asyncio
+    async def test_process_agent_turn_skips_completion_when_cancelled_after_agent_response(self):
+        mock_redis = AsyncMock()
+
+        mock_thread = MagicMock()
+        mock_thread.id = "thread-123"
+        mock_thread.context = {}
+        mock_thread.metadata = MagicMock()
+        mock_thread.metadata.user_id = "user-1"
+        mock_thread.metadata.subject = "Redis question"
+        mock_thread.messages = []
+
+        mock_thread_manager = AsyncMock()
+        mock_thread_manager.get_thread = AsyncMock(return_value=mock_thread)
+        mock_thread_manager.update_thread_context = AsyncMock()
+        mock_thread_manager._save_thread_state = AsyncMock()
+        mock_thread_manager.set_message_trace = AsyncMock()
+
+        mock_task_manager = AsyncMock()
+        mock_task_manager.update_task_status = AsyncMock()
+        mock_task_manager.add_task_update = AsyncMock()
+        mock_task_manager.set_task_error = AsyncMock()
+        mock_task_manager.complete_task_if_open = AsyncMock(return_value=True)
+        mock_task_manager.get_task_state = AsyncMock(
+            return_value=MagicMock(status=TaskStatus.CANCELLED)
+        )
+
+        mock_chat_agent = AsyncMock()
+        mock_chat_agent.process_query = AsyncMock(
+            return_value=AgentResponse(
+                response="Late response",
+                search_results=[],
+                tool_envelopes=[{"name": "redis_info", "status": "success"}],
+            )
+        )
+
+        with (
+            patch("redis_sre_agent.core.docket_tasks.get_redis_client", return_value=mock_redis),
+            patch(
+                "redis_sre_agent.core.docket_tasks.ThreadManager", return_value=mock_thread_manager
+            ),
+            patch("redis_sre_agent.core.docket_tasks.TaskManager", return_value=mock_task_manager),
+            patch(
+                "redis_sre_agent.core.docket_tasks._extract_instance_details_from_message",
+                return_value=None,
+            ),
+            patch(
+                "redis_sre_agent.core.docket_tasks.get_chat_agent",
+                return_value=mock_chat_agent,
+            ),
+            patch("opentelemetry.trace.get_tracer") as mock_tracer,
+        ):
+            mock_span = MagicMock()
+            mock_span.end = MagicMock()
+            mock_span.set_attribute = MagicMock()
+            mock_tracer.return_value.start_span.return_value = mock_span
+
+            result = await process_agent_turn(
+                thread_id="thread-123",
+                message="What are Redis best practices?",
+                context={"requested_agent_type": "chat"},
+                task_id="provided-task-123",
+            )
+
+        assert result == {
+            "status": TaskStatus.CANCELLED.value,
+            "thread_id": "thread-123",
+            "task_id": "provided-task-123",
+        }
+        mock_task_manager.complete_task_if_open.assert_not_awaited()
+        mock_thread_manager._save_thread_state.assert_not_awaited()
+        mock_thread_manager.set_message_trace.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_process_agent_turn_approval_result_returns_awaiting_approval(self):
@@ -1763,6 +1837,7 @@ class TestProcessAgentTurn:
         mock_task_manager.add_task_update = AsyncMock()
         mock_task_manager.set_task_result = AsyncMock()
         mock_task_manager.set_task_error = AsyncMock()
+        mock_task_manager.complete_task_if_open = AsyncMock(return_value=True)
         mock_task_manager.get_task_state = AsyncMock(return_value=MagicMock(updates=[]))
         mock_task_manager._publish_stream_update = AsyncMock()
 
@@ -2151,7 +2226,7 @@ class TestProcessAgentTurn:
             assert "cluster_id" not in context
 
         result_payloads = [
-            call.args[1] for call in mock_task_manager.set_task_result.await_args_list
+            call.args[1] for call in mock_task_manager.complete_task_if_open.await_args_list
         ]
         assert {payload["task_id"] for payload in result_payloads} == {
             "child-task-1",
@@ -2365,6 +2440,7 @@ class TestProcessAgentTurn:
         mock_task_manager.set_task_result = AsyncMock()
         mock_task_manager.update_task_status = AsyncMock()
         mock_task_manager._publish_stream_update = AsyncMock()
+        mock_task_manager.complete_task_if_open = AsyncMock(return_value=True)
         mock_task_manager.get_task_state = AsyncMock(return_value=MagicMock(updates=[]))
 
         resolution = DiscoveryResponse(
@@ -2433,7 +2509,8 @@ class TestProcessAgentTurn:
         assert "narrow" in result["response"]
         appended_messages = mock_thread_manager.append_messages.await_args.args[1]
         assert [message["role"] for message in appended_messages] == ["user", "assistant"]
-        mock_task_manager.update_task_status.assert_any_await("provided-task-123", TaskStatus.DONE)
+        mock_task_manager.complete_task_if_open.assert_awaited_once()
+        assert mock_task_manager.complete_task_if_open.await_args.args[0] == "provided-task-123"
 
     @pytest.mark.asyncio
     async def test_bound_over_limit_deep_triage_recovers_user_append_failure(self):
@@ -2475,6 +2552,7 @@ class TestProcessAgentTurn:
         mock_task_manager.set_task_result = AsyncMock()
         mock_task_manager.update_task_status = AsyncMock()
         mock_task_manager._publish_stream_update = AsyncMock()
+        mock_task_manager.complete_task_if_open = AsyncMock(return_value=True)
         mock_task_manager.get_task_state = AsyncMock(return_value=MagicMock(updates=[]))
 
         async def _return_scope(**kwargs):
@@ -2531,7 +2609,8 @@ class TestProcessAgentTurn:
             "assistant",
         ]
         assert append_calls[1].args[1][0]["content"] == "Deep triage all attached caches"
-        mock_task_manager.update_task_status.assert_any_await("provided-task-123", TaskStatus.DONE)
+        mock_task_manager.complete_task_if_open.assert_awaited_once()
+        assert mock_task_manager.complete_task_if_open.await_args.args[0] == "provided-task-123"
 
     @pytest.mark.asyncio
     async def test_process_agent_turn_chat_path_does_not_bind_single_target_for_multi_scope(self):

--- a/tests/unit/core/test_tasks.py
+++ b/tests/unit/core/test_tasks.py
@@ -2170,6 +2170,114 @@ class TestProcessAgentTurn:
         ]
 
     @pytest.mark.asyncio
+    async def test_pre_resolved_deep_triage_does_not_bind_clarification_required_matches(self):
+        mock_redis = AsyncMock()
+        mock_thread = MagicMock()
+        mock_thread.context = {}
+        mock_thread.messages = []
+        mock_thread.metadata.user_id = "test-user"
+
+        mock_thread_manager = AsyncMock()
+        mock_thread_manager.get_thread = AsyncMock(return_value=mock_thread)
+        mock_thread_manager.update_thread_context = AsyncMock()
+        mock_thread_manager.append_messages = AsyncMock()
+        mock_thread_manager.set_message_trace = AsyncMock()
+
+        mock_task_manager = AsyncMock()
+        mock_task_manager.create_task = AsyncMock(return_value="provided-task-123")
+        mock_task_manager.update_task_status = AsyncMock()
+        mock_task_manager.add_task_update = AsyncMock()
+        mock_task_manager.set_task_result = AsyncMock()
+        mock_task_manager.set_task_error = AsyncMock()
+        mock_task_manager.get_task_state = AsyncMock(return_value=MagicMock(updates=[]))
+        mock_task_manager._publish_stream_update = AsyncMock()
+
+        resolution = TargetResolutionResult(
+            status="clarification_required",
+            clarification_required=True,
+            selected_matches=[
+                ResolvedTargetMatch(
+                    target_kind="instance",
+                    resource_id="redis-prod-cache",
+                    display_name="prod-cache",
+                    environment="production",
+                    target_type="oss_single",
+                    capabilities=["redis", "diagnostics"],
+                    confidence=0.68,
+                    match_reasons=["matched tokens=prod"],
+                ),
+                ResolvedTargetMatch(
+                    target_kind="instance",
+                    resource_id="redis-prod-cache-1",
+                    display_name="prod-cache-1",
+                    environment="production",
+                    target_type="oss_single",
+                    capabilities=["redis", "diagnostics"],
+                    confidence=0.76,
+                    match_reasons=["matched exact target reference"],
+                ),
+            ],
+        )
+        mock_materialize = AsyncMock()
+        mock_run_agent = AsyncMock(
+            return_value={
+                "response": "Triage response",
+                "search_results": [],
+                "tool_envelopes": [],
+                "metadata": {"agent_type": "redis_triage"},
+            }
+        )
+
+        with (
+            patch("redis_sre_agent.core.docket_tasks.get_redis_client", return_value=mock_redis),
+            patch(
+                "redis_sre_agent.core.docket_tasks.ThreadManager", return_value=mock_thread_manager
+            ),
+            patch("redis_sre_agent.core.docket_tasks.TaskManager", return_value=mock_task_manager),
+            patch(
+                "redis_sre_agent.core.docket_tasks._extract_instance_details_from_message",
+                return_value=None,
+            ),
+            patch(
+                "redis_sre_agent.core.docket_tasks.route_to_appropriate_agent",
+                new=AsyncMock(return_value=AgentType.REDIS_TRIAGE),
+            ),
+            patch(
+                "redis_sre_agent.core.targets.resolve_target_query",
+                new=AsyncMock(return_value=resolution),
+            ),
+            patch(
+                "redis_sre_agent.core.targets.materialize_bound_target_scope",
+                new=mock_materialize,
+            ),
+            patch("redis_sre_agent.core.docket_tasks.get_sre_agent", return_value=MagicMock()),
+            patch(
+                "redis_sre_agent.core.docket_tasks.run_agent_with_progress",
+                new=mock_run_agent,
+            ),
+            patch(
+                "redis_sre_agent.core.docket_tasks.ULID", return_value="01HXTESTMESSAGEID1234567890"
+            ),
+            patch("opentelemetry.trace.get_tracer") as mock_tracer,
+        ):
+            mock_span = MagicMock()
+            mock_span.end = MagicMock()
+            mock_span.set_attribute = MagicMock()
+            mock_tracer.return_value.start_span.return_value = mock_span
+
+            await process_agent_turn(
+                thread_id="thread-123",
+                message="Deep triage prod cache",
+                task_id="provided-task-123",
+            )
+
+        mock_materialize.assert_not_awaited()
+        mock_run_agent.assert_awaited_once()
+        _, kwargs = mock_run_agent.await_args
+        assert not kwargs["agent_context"].get("attached_target_handles")
+        assert not kwargs["agent_context"].get("target_bindings")
+
+    @pytest.mark.asyncio
     async def test_multi_target_deep_triage_fanout_cancels_pending_children_on_cancellation(
         self,
     ):

--- a/tests/unit/mcp_server/test_mcp_server.py
+++ b/tests/unit/mcp_server/test_mcp_server.py
@@ -1,5 +1,6 @@
 """Tests for MCP server tools."""
 
+import json
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -170,6 +171,14 @@ class TestMCPServerSetup:
         assert "redis_sre_backfill_empty_thread_subjects" in tool_names
         assert "redis_sre_purge_threads" in tool_names
 
+    def test_mcp_server_does_not_register_removed_runbook_generation_tools(self):
+        """Test that removed runbook-generation tools are absent from discovery metadata."""
+        tool_names = {t.name for t in mcp._tool_manager._tools.values()}
+
+        assert "redis_sre_generate_pipeline_runbooks" not in tool_names
+        assert "redis_sre_generate_runbook" not in tool_names
+        assert "redis_sre_evaluate_runbooks" not in tool_names
+
 
 class TestCliMcpParityAuditTool:
     """Test the redis_sre_audit_cli_mcp_parity MCP tool."""
@@ -333,9 +342,14 @@ class TestDeepTriageTool:
         }
 
         with (
+            patch(
+                "redis_sre_agent.core.instances.get_instance_by_id",
+                new_callable=AsyncMock,
+            ) as mock_get_instance,
             patch("redis_sre_agent.core.redis.get_redis_client"),
             patch("redis_sre_agent.core.tasks.create_task", new_callable=AsyncMock) as mock_create,
         ):
+            mock_get_instance.return_value = MagicMock()
             mock_create.return_value = mock_result
 
             result = await redis_sre_deep_triage(
@@ -383,9 +397,14 @@ class TestDeepTriageTool:
         }
 
         with (
+            patch(
+                "redis_sre_agent.core.clusters.get_cluster_by_id",
+                new_callable=AsyncMock,
+            ) as mock_get_cluster,
             patch("redis_sre_agent.core.redis.get_redis_client"),
             patch("redis_sre_agent.core.tasks.create_task", new_callable=AsyncMock) as mock_create,
         ):
+            mock_get_cluster.return_value = MagicMock()
             mock_create.return_value = mock_result
 
             result = await redis_sre_deep_triage(
@@ -408,6 +427,56 @@ class TestDeepTriageTool:
 
         assert result["status"] == "failed"
         assert "only one of instance_id or cluster_id" in result["message"]
+
+    @pytest.mark.asyncio
+    async def test_deep_triage_rejects_missing_instance_id(self):
+        """Test deep triage rejects stale explicit instance IDs before task creation."""
+        with (
+            patch(
+                "redis_sre_agent.core.instances.get_instance_by_id",
+                new_callable=AsyncMock,
+            ) as mock_get_instance,
+            patch(
+                "redis_sre_agent.core.tasks.create_task",
+                new_callable=AsyncMock,
+            ) as mock_create,
+        ):
+            mock_get_instance.return_value = None
+
+            result = await redis_sre_deep_triage(
+                query="High memory usage",
+                instance_id="missing-instance",
+            )
+
+            assert result["status"] == "failed"
+            assert result["instance_id"] == "missing-instance"
+            assert "redis_sre_list_instances" in result["message"]
+            mock_create.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_deep_triage_rejects_missing_cluster_id(self):
+        """Test deep triage rejects stale explicit cluster IDs before task creation."""
+        with (
+            patch(
+                "redis_sre_agent.core.clusters.get_cluster_by_id",
+                new_callable=AsyncMock,
+            ) as mock_get_cluster,
+            patch(
+                "redis_sre_agent.core.tasks.create_task",
+                new_callable=AsyncMock,
+            ) as mock_create,
+        ):
+            mock_get_cluster.return_value = None
+
+            result = await redis_sre_deep_triage(
+                query="Cluster check",
+                cluster_id="missing-cluster",
+            )
+
+            assert result["status"] == "failed"
+            assert result["cluster_id"] == "missing-cluster"
+            assert "redis_sre_list_clusters" in result["message"]
+            mock_create.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_deep_triage_error_handling(self):
@@ -2944,6 +3013,34 @@ class TestGetTaskStatusTool:
             assert result["pending_approval"] == {"approval_id": "approval-1"}
             assert result["resume_supported"] is True
             assert "tool_calls" not in result
+
+    @pytest.mark.asyncio
+    async def test_get_task_status_callable_through_fastmcp(self):
+        """Task status polling should work through the advertised MCP tool path."""
+        mock_task = {
+            "task_id": "task-123",
+            "thread_id": "thread-456",
+            "status": "done",
+            "updates": [],
+            "result": {"response": "Complete"},
+            "metadata": {"subject": "Health check"},
+        }
+
+        with patch(
+            "redis_sre_agent.core.tasks.get_task_by_id",
+            new_callable=AsyncMock,
+            return_value=mock_task,
+        ):
+            content, structured = await mcp.call_tool(
+                "redis_sre_get_task_status",
+                {"task_id": "task-123"},
+            )
+
+        payload = json.loads(content[0].text)
+        assert payload["task_id"] == "task-123"
+        assert payload["status"] == "done"
+        assert structured["result"]["task_id"] == "task-123"
+        assert structured["result"]["result"] == {"response": "Complete"}
 
     @pytest.mark.asyncio
     async def test_get_task_status_not_found(self):

--- a/ui/src/components/Modal.tsx
+++ b/ui/src/components/Modal.tsx
@@ -62,13 +62,13 @@ const Modal = ({
     <div className="fixed inset-0 z-50 flex items-center justify-center">
       {/* Backdrop */}
       <div
-        className="absolute inset-0 bg-black bg-opacity-50 transition-opacity"
+        className="absolute inset-0 z-0 bg-black bg-opacity-50 transition-opacity"
         onClick={handleOverlayClick}
       />
 
       {/* Modal */}
       <div
-        className={`relative rounded-redis-lg shadow-xl w-full ${sizeClasses[size]} max-h-[90vh] overflow-hidden`}
+        className={`relative z-10 rounded-redis-lg shadow-xl w-full ${sizeClasses[size]} max-h-[90vh] overflow-hidden`}
         style={{
           backgroundColor: "var(--card)",
           color: "var(--card-foreground)",

--- a/ui/src/pages/Instances.tsx
+++ b/ui/src/pages/Instances.tsx
@@ -101,6 +101,11 @@ const AddInstanceForm = ({
   onCancel,
   initialData,
 }: AddInstanceFormProps) => {
+  const fieldIdPrefix = initialData
+    ? `edit-instance-${initialData.id}`
+    : "add-instance";
+  const fieldId = (name: string) => `${fieldIdPrefix}-${name}`;
+
   // Check if the initial usage is a custom type (not in predefined list)
   const predefinedUsageTypes = [
     "cache",
@@ -441,10 +446,14 @@ const AddInstanceForm = ({
     <form onSubmit={handleSubmit} className="space-y-4">
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
         <div>
-          <label className="block text-redis-sm font-medium mb-1">
+          <label
+            htmlFor={fieldId("name")}
+            className="block text-redis-sm font-medium mb-1"
+          >
             Instance Name *
           </label>
           <input
+            id={fieldId("name")}
             type="text"
             required
             value={formData.name}
@@ -457,10 +466,14 @@ const AddInstanceForm = ({
         </div>
 
         <div>
-          <label className="block text-redis-sm font-medium mb-1">
+          <label
+            htmlFor={fieldId("environment")}
+            className="block text-redis-sm font-medium mb-1"
+          >
             Environment *
           </label>
           <select
+            id={fieldId("environment")}
             required
             value={formData.environment}
             onChange={(e) =>
@@ -471,15 +484,20 @@ const AddInstanceForm = ({
             <option value="development">Development</option>
             <option value="staging">Staging</option>
             <option value="production">Production</option>
+            <option value="test">Test</option>
           </select>
         </div>
       </div>
 
       <div>
-        <label className="block text-redis-sm font-medium mb-1">
+        <label
+          htmlFor={fieldId("connection-url")}
+          className="block text-redis-sm font-medium mb-1"
+        >
           Connection URL *
         </label>
         <input
+          id={fieldId("connection-url")}
           type="text"
           required
           value={formData.connectionUrl}
@@ -496,10 +514,14 @@ const AddInstanceForm = ({
       </div>
 
       <div>
-        <label className="block text-redis-sm font-medium mb-1">
+        <label
+          htmlFor={fieldId("usage")}
+          className="block text-redis-sm font-medium mb-1"
+        >
           Usage Type *
         </label>
         <select
+          id={fieldId("usage")}
           required
           value={formData.usage}
           onChange={(e) =>
@@ -517,6 +539,7 @@ const AddInstanceForm = ({
         {formData.usage === "custom" && (
           <div className="mt-2">
             <input
+              id={fieldId("custom-usage")}
               type="text"
               required
               value={formData.customUsage}
@@ -534,10 +557,14 @@ const AddInstanceForm = ({
       </div>
 
       <div>
-        <label className="block text-redis-sm font-medium mb-1">
+        <label
+          htmlFor={fieldId("instance-type")}
+          className="block text-redis-sm font-medium mb-1"
+        >
           Instance Type
         </label>
         <select
+          id={fieldId("instance-type")}
           value={formData.instanceType}
           onChange={(e) =>
             setFormData((prev) => ({ ...prev, instanceType: e.target.value }))
@@ -568,10 +595,14 @@ const AddInstanceForm = ({
         </p>
 
         <div>
-          <label className="block text-redis-sm font-medium mb-1">
+          <label
+            htmlFor={fieldId("cluster-id")}
+            className="block text-redis-sm font-medium mb-1"
+          >
             Linked Cluster
           </label>
           <select
+            id={fieldId("cluster-id")}
             value={formData.clusterId}
             onChange={(e) =>
               setFormData((prev) => ({ ...prev, clusterId: e.target.value }))
@@ -622,10 +653,14 @@ const AddInstanceForm = ({
           <div className="space-y-3 p-3 bg-white border border-redis-dusk-07 rounded-redis-sm">
             <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
               <div>
-                <label className="block text-redis-sm font-medium mb-1">
+                <label
+                  htmlFor={fieldId("cluster-name")}
+                  className="block text-redis-sm font-medium mb-1"
+                >
                   Cluster Name *
                 </label>
                 <input
+                  id={fieldId("cluster-name")}
                   type="text"
                   value={clusterFormData.name}
                   onChange={(e) =>
@@ -639,10 +674,14 @@ const AddInstanceForm = ({
                 />
               </div>
               <div>
-                <label className="block text-redis-sm font-medium mb-1">
+                <label
+                  htmlFor={fieldId("cluster-type")}
+                  className="block text-redis-sm font-medium mb-1"
+                >
                   Cluster Type *
                 </label>
                 <select
+                  id={fieldId("cluster-type")}
                   value={clusterFormData.clusterType}
                   onChange={(e) =>
                     setClusterFormData((prev) => ({
@@ -666,10 +705,14 @@ const AddInstanceForm = ({
 
             <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
               <div>
-                <label className="block text-redis-sm font-medium mb-1">
+                <label
+                  htmlFor={fieldId("cluster-environment")}
+                  className="block text-redis-sm font-medium mb-1"
+                >
                   Environment *
                 </label>
                 <select
+                  id={fieldId("cluster-environment")}
                   value={clusterFormData.environment}
                   onChange={(e) =>
                     setClusterFormData((prev) => ({
@@ -686,10 +729,14 @@ const AddInstanceForm = ({
                 </select>
               </div>
               <div>
-                <label className="block text-redis-sm font-medium mb-1">
+                <label
+                  htmlFor={fieldId("cluster-description")}
+                  className="block text-redis-sm font-medium mb-1"
+                >
                   Description *
                 </label>
                 <input
+                  id={fieldId("cluster-description")}
                   type="text"
                   value={clusterFormData.description}
                   onChange={(e) =>
@@ -709,43 +756,70 @@ const AddInstanceForm = ({
                 <p className="text-redis-xs text-redis-dusk-04">
                   Redis Enterprise clusters require admin API credentials.
                 </p>
-                <input
-                  type="url"
-                  value={clusterFormData.adminUrl}
-                  onChange={(e) =>
-                    setClusterFormData((prev) => ({
-                      ...prev,
-                      adminUrl: e.target.value,
-                    }))
-                  }
-                  className="w-full px-3 py-2 border rounded-redis-sm focus:outline-none focus:ring-2 focus:ring-redis-blue-03"
-                  placeholder="Admin URL (https://cluster:9443)"
-                />
+                <div>
+                  <label
+                    htmlFor={fieldId("cluster-admin-url")}
+                    className="block text-redis-sm font-medium mb-1"
+                  >
+                    Admin API URL
+                  </label>
+                  <input
+                    id={fieldId("cluster-admin-url")}
+                    type="url"
+                    value={clusterFormData.adminUrl}
+                    onChange={(e) =>
+                      setClusterFormData((prev) => ({
+                        ...prev,
+                        adminUrl: e.target.value,
+                      }))
+                    }
+                    className="w-full px-3 py-2 border rounded-redis-sm focus:outline-none focus:ring-2 focus:ring-redis-blue-03"
+                    placeholder="https://cluster:9443"
+                  />
+                </div>
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-                  <input
-                    type="text"
-                    value={clusterFormData.adminUsername}
-                    onChange={(e) =>
-                      setClusterFormData((prev) => ({
-                        ...prev,
-                        adminUsername: e.target.value,
-                      }))
-                    }
-                    className="w-full px-3 py-2 border rounded-redis-sm focus:outline-none focus:ring-2 focus:ring-redis-blue-03"
-                    placeholder="Admin username"
-                  />
-                  <input
-                    type="password"
-                    value={clusterFormData.adminPassword}
-                    onChange={(e) =>
-                      setClusterFormData((prev) => ({
-                        ...prev,
-                        adminPassword: e.target.value,
-                      }))
-                    }
-                    className="w-full px-3 py-2 border rounded-redis-sm focus:outline-none focus:ring-2 focus:ring-redis-blue-03"
-                    placeholder="Admin password"
-                  />
+                  <div>
+                    <label
+                      htmlFor={fieldId("cluster-admin-username")}
+                      className="block text-redis-sm font-medium mb-1"
+                    >
+                      Admin Username
+                    </label>
+                    <input
+                      id={fieldId("cluster-admin-username")}
+                      type="text"
+                      value={clusterFormData.adminUsername}
+                      onChange={(e) =>
+                        setClusterFormData((prev) => ({
+                          ...prev,
+                          adminUsername: e.target.value,
+                        }))
+                      }
+                      className="w-full px-3 py-2 border rounded-redis-sm focus:outline-none focus:ring-2 focus:ring-redis-blue-03"
+                      placeholder="admin@redis.com"
+                    />
+                  </div>
+                  <div>
+                    <label
+                      htmlFor={fieldId("cluster-admin-password")}
+                      className="block text-redis-sm font-medium mb-1"
+                    >
+                      Admin Password
+                    </label>
+                    <input
+                      id={fieldId("cluster-admin-password")}
+                      type="password"
+                      value={clusterFormData.adminPassword}
+                      onChange={(e) =>
+                        setClusterFormData((prev) => ({
+                          ...prev,
+                          adminPassword: e.target.value,
+                        }))
+                      }
+                      className="w-full px-3 py-2 border rounded-redis-sm focus:outline-none focus:ring-2 focus:ring-redis-blue-03"
+                      placeholder="Password"
+                    />
+                  </div>
                 </div>
               </div>
             )}
@@ -792,10 +866,14 @@ const AddInstanceForm = ({
           </p>
 
           <div>
-            <label className="block text-redis-sm font-medium mb-1">
+            <label
+              htmlFor={fieldId("admin-url")}
+              className="block text-redis-sm font-medium mb-1"
+            >
               Admin API URL
             </label>
             <input
+              id={fieldId("admin-url")}
               type="url"
               value={formData.adminUrl}
               onChange={(e) =>
@@ -811,10 +889,14 @@ const AddInstanceForm = ({
 
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             <div>
-              <label className="block text-redis-sm font-medium mb-1">
+              <label
+                htmlFor={fieldId("admin-username")}
+                className="block text-redis-sm font-medium mb-1"
+              >
                 Admin Username
               </label>
               <input
+                id={fieldId("admin-username")}
                 type="text"
                 value={formData.adminUsername}
                 onChange={(e) =>
@@ -829,10 +911,14 @@ const AddInstanceForm = ({
             </div>
 
             <div>
-              <label className="block text-redis-sm font-medium mb-1">
+              <label
+                htmlFor={fieldId("admin-password")}
+                className="block text-redis-sm font-medium mb-1"
+              >
                 Admin Password
               </label>
               <input
+                id={fieldId("admin-password")}
                 type="password"
                 value={formData.adminPassword}
                 onChange={(e) =>
@@ -892,10 +978,14 @@ const AddInstanceForm = ({
           </p>
 
           <div>
-            <label className="block text-redis-sm font-medium mb-1">
+            <label
+              htmlFor={fieldId("cloud-subscription-type")}
+              className="block text-redis-sm font-medium mb-1"
+            >
               Subscription Type
             </label>
             <select
+              id={fieldId("cloud-subscription-type")}
               value={formData.cloudSubscriptionType}
               onChange={(e) =>
                 setFormData((prev) => ({
@@ -912,10 +1002,14 @@ const AddInstanceForm = ({
           </div>
 
           <div>
-            <label className="block text-redis-sm font-medium mb-1">
+            <label
+              htmlFor={fieldId("cloud-subscription-id")}
+              className="block text-redis-sm font-medium mb-1"
+            >
               Subscription ID
             </label>
             <input
+              id={fieldId("cloud-subscription-id")}
               type="text"
               inputMode="numeric"
               pattern="[0-9]*"
@@ -932,10 +1026,14 @@ const AddInstanceForm = ({
           </div>
 
           <div>
-            <label className="block text-redis-sm font-medium mb-1">
+            <label
+              htmlFor={fieldId("cloud-database-id")}
+              className="block text-redis-sm font-medium mb-1"
+            >
               Database ID
             </label>
             <input
+              id={fieldId("cloud-database-id")}
               type="text"
               inputMode="numeric"
               pattern="[0-9]*"
@@ -956,10 +1054,14 @@ const AddInstanceForm = ({
           </div>
 
           <div>
-            <label className="block text-redis-sm font-medium mb-1">
+            <label
+              htmlFor={fieldId("cloud-database-name")}
+              className="block text-redis-sm font-medium mb-1"
+            >
               Database Name
             </label>
             <input
+              id={fieldId("cloud-database-name")}
               type="text"
               value={formData.cloudDatabaseName}
               onChange={(e) =>
@@ -979,10 +1081,14 @@ const AddInstanceForm = ({
       )}
 
       <div>
-        <label className="block text-redis-sm font-medium text-foreground mb-1">
+        <label
+          htmlFor={fieldId("description")}
+          className="block text-redis-sm font-medium text-foreground mb-1"
+        >
           Description *
         </label>
         <textarea
+          id={fieldId("description")}
           required
           value={formData.description}
           onChange={(e) =>
@@ -995,10 +1101,14 @@ const AddInstanceForm = ({
       </div>
 
       <div>
-        <label className="block text-redis-sm font-medium text-foreground mb-1">
+        <label
+          htmlFor={fieldId("repo-url")}
+          className="block text-redis-sm font-medium text-foreground mb-1"
+        >
           Repository URL (optional)
         </label>
         <input
+          id={fieldId("repo-url")}
           type="url"
           value={formData.repoUrl}
           onChange={(e) =>
@@ -1011,10 +1121,14 @@ const AddInstanceForm = ({
 
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
         <div>
-          <label className="block text-redis-sm font-medium text-foreground mb-1">
+          <label
+            htmlFor={fieldId("monitoring-identifier")}
+            className="block text-redis-sm font-medium text-foreground mb-1"
+          >
             Monitoring Identifier (optional)
           </label>
           <input
+            id={fieldId("monitoring-identifier")}
             type="text"
             value={formData.monitoringIdentifier}
             onChange={(e) =>
@@ -1033,10 +1147,14 @@ const AddInstanceForm = ({
         </div>
 
         <div>
-          <label className="block text-redis-sm font-medium text-foreground mb-1">
+          <label
+            htmlFor={fieldId("logging-identifier")}
+            className="block text-redis-sm font-medium text-foreground mb-1"
+          >
             Logging Identifier (optional)
           </label>
           <input
+            id={fieldId("logging-identifier")}
             type="text"
             value={formData.loggingIdentifier}
             onChange={(e) =>
@@ -1055,10 +1173,14 @@ const AddInstanceForm = ({
       </div>
 
       <div>
-        <label className="block text-redis-sm font-medium text-foreground mb-1">
+        <label
+          htmlFor={fieldId("notes")}
+          className="block text-redis-sm font-medium text-foreground mb-1"
+        >
           Notes (optional)
         </label>
         <textarea
+          id={fieldId("notes")}
           value={formData.notes}
           onChange={(e) =>
             setFormData((prev) => ({ ...prev, notes: e.target.value }))

--- a/ui/src/pages/Triage.tsx
+++ b/ui/src/pages/Triage.tsx
@@ -948,10 +948,22 @@ const Triage = () => {
 
         // Add error message if task failed
         if (status.status === "failed") {
+          const resultError =
+            typeof status.result?.error === "string"
+              ? status.result.error
+              : undefined;
+          const resultMessage =
+            typeof status.result?.message === "string"
+              ? status.result.message
+              : undefined;
+          const failureDetail =
+            status.error_message || resultError || resultMessage;
           newMessages.push({
             id: `error-${status.thread_id}`,
             role: "assistant",
-            content: `Chat failed. Please try again or contact support if the issue persists.`,
+            content: failureDetail
+              ? `Chat failed: ${failureDetail}`
+              : `Chat failed. Please try again or contact support if the issue persists.`,
             timestamp: status.metadata.updated_at,
           });
         }

--- a/ui/src/services/__tests__/sreAgentApi.test.ts
+++ b/ui/src/services/__tests__/sreAgentApi.test.ts
@@ -72,37 +72,11 @@ describe("SREAgentAPI", () => {
   });
 
   describe("cancelTask", () => {
-    it("cancels the task associated with a thread without deleting it", async () => {
-      (fetch as jest.Mock)
-        .mockResolvedValueOnce({
-          ok: true,
-          json: async () => ({
-            thread_id: "test-thread-123",
-            task_id: "task-456",
-            status: "in_progress",
-            messages: [],
-            updates: [],
-            metadata: {
-              created_at: "2023-01-01T00:00:00Z",
-              updated_at: "2023-01-01T00:01:00Z",
-              tags: [],
-            },
-            context: {},
-            resume_supported: false,
-          }),
-        })
-        .mockResolvedValueOnce({
-          ok: true,
-          json: async () => ({
-            task_id: "task-456",
-            tool_calls: [],
-            citation_groups: [],
-          }),
-        })
-        .mockResolvedValueOnce({
-          ok: true,
-          text: async () => "",
-        });
+    it("cancels active tasks for a thread without deleting it", async () => {
+      (fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        text: async () => "",
+      });
 
       await expect(
         sreAgentApi.cancelTask("test-thread-123"),
@@ -110,41 +84,23 @@ describe("SREAgentAPI", () => {
 
       expect(fetch).toHaveBeenNthCalledWith(
         1,
-        "http://localhost:8080/api/v1/threads/test-thread-123",
-      );
-      expect(fetch).toHaveBeenNthCalledWith(
-        2,
-        "http://localhost:8080/api/v1/tasks/task-456",
-      );
-      expect(fetch).toHaveBeenNthCalledWith(
-        3,
-        "http://localhost:8080/api/v1/tasks/task-456/cancel",
+        "http://localhost:8080/api/v1/threads/test-thread-123/cancel",
         {
           method: "POST",
         },
       );
+      expect(fetch).toHaveBeenCalledTimes(1);
     });
 
-    it("throws when the thread has no cancellable task", async () => {
+    it("throws when thread cancellation fails", async () => {
       (fetch as jest.Mock).mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          thread_id: "test-thread-123",
-          status: "in_progress",
-          messages: [],
-          updates: [],
-          metadata: {
-            created_at: "2023-01-01T00:00:00Z",
-            updated_at: "2023-01-01T00:01:00Z",
-            tags: [],
-          },
-          context: {},
-          resume_supported: false,
-        }),
+        ok: false,
+        status: 404,
+        text: async () => "Thread not found",
       });
 
       await expect(sreAgentApi.cancelTask("test-thread-123")).rejects.toThrow(
-        "No cancellable task found for thread test-thread-123",
+        "HTTP 404: Thread not found",
       );
 
       expect(fetch).toHaveBeenCalledTimes(1);

--- a/ui/src/services/__tests__/sreAgentApi.test.ts
+++ b/ui/src/services/__tests__/sreAgentApi.test.ts
@@ -72,7 +72,7 @@ describe("SREAgentAPI", () => {
   });
 
   describe("cancelTask", () => {
-    it("cancels the task associated with a thread", async () => {
+    it("cancels the task associated with a thread without deleting it", async () => {
       (fetch as jest.Mock)
         .mockResolvedValueOnce({
           ok: true,
@@ -118,9 +118,9 @@ describe("SREAgentAPI", () => {
       );
       expect(fetch).toHaveBeenNthCalledWith(
         3,
-        "http://localhost:8080/api/v1/tasks/task-456",
+        "http://localhost:8080/api/v1/tasks/task-456/cancel",
         {
-          method: "DELETE",
+          method: "POST",
         },
       );
     });

--- a/ui/src/services/__tests__/sreAgentApi.test.ts
+++ b/ui/src/services/__tests__/sreAgentApi.test.ts
@@ -72,12 +72,82 @@ describe("SREAgentAPI", () => {
   });
 
   describe("cancelTask", () => {
-    it("does not delete a thread when cancelling an in-flight task", async () => {
+    it("cancels the task associated with a thread", async () => {
+      (fetch as jest.Mock)
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            thread_id: "test-thread-123",
+            task_id: "task-456",
+            status: "in_progress",
+            messages: [],
+            updates: [],
+            metadata: {
+              created_at: "2023-01-01T00:00:00Z",
+              updated_at: "2023-01-01T00:01:00Z",
+              tags: [],
+            },
+            context: {},
+            resume_supported: false,
+          }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            task_id: "task-456",
+            tool_calls: [],
+            citation_groups: [],
+          }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          text: async () => "",
+        });
+
       await expect(
         sreAgentApi.cancelTask("test-thread-123"),
       ).resolves.toBeUndefined();
 
-      expect(fetch).not.toHaveBeenCalled();
+      expect(fetch).toHaveBeenNthCalledWith(
+        1,
+        "http://localhost:8080/api/v1/threads/test-thread-123",
+      );
+      expect(fetch).toHaveBeenNthCalledWith(
+        2,
+        "http://localhost:8080/api/v1/tasks/task-456",
+      );
+      expect(fetch).toHaveBeenNthCalledWith(
+        3,
+        "http://localhost:8080/api/v1/tasks/task-456",
+        {
+          method: "DELETE",
+        },
+      );
+    });
+
+    it("throws when the thread has no cancellable task", async () => {
+      (fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          thread_id: "test-thread-123",
+          status: "in_progress",
+          messages: [],
+          updates: [],
+          metadata: {
+            created_at: "2023-01-01T00:00:00Z",
+            updated_at: "2023-01-01T00:01:00Z",
+            tags: [],
+          },
+          context: {},
+          resume_supported: false,
+        }),
+      });
+
+      await expect(sreAgentApi.cancelTask("test-thread-123")).rejects.toThrow(
+        "No cancellable task found for thread test-thread-123",
+      );
+
+      expect(fetch).toHaveBeenCalledTimes(1);
     });
 
     it("should throw error for failed thread deletion", async () => {

--- a/ui/src/services/sreAgentApi.ts
+++ b/ui/src/services/sreAgentApi.ts
@@ -897,9 +897,19 @@ export class SREAgentAPI {
       return;
     }
 
-    // Cancelling an in-flight task by thread is not yet supported by the backend.
-    // No-op for now to avoid accidental deletions on Stop.
-    return;
+    const status = await this.getTaskStatus(threadId);
+    const taskId = status.task_id;
+    if (!taskId) {
+      throw new Error(`No cancellable task found for thread ${threadId}`);
+    }
+
+    const response = await fetch(`${this.tasksBaseUrl}/tasks/${taskId}`, {
+      method: "DELETE",
+    });
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`HTTP ${response.status}: ${errorText}`);
+    }
   }
 
   // Polling utility for waiting for task completion

--- a/ui/src/services/sreAgentApi.ts
+++ b/ui/src/services/sreAgentApi.ts
@@ -903,9 +903,12 @@ export class SREAgentAPI {
       throw new Error(`No cancellable task found for thread ${threadId}`);
     }
 
-    const response = await fetch(`${this.tasksBaseUrl}/tasks/${taskId}`, {
-      method: "DELETE",
-    });
+    const response = await fetch(
+      `${this.tasksBaseUrl}/tasks/${taskId}/cancel`,
+      {
+        method: "POST",
+      },
+    );
     if (!response.ok) {
       const errorText = await response.text();
       throw new Error(`HTTP ${response.status}: ${errorText}`);

--- a/ui/src/services/sreAgentApi.ts
+++ b/ui/src/services/sreAgentApi.ts
@@ -897,14 +897,8 @@ export class SREAgentAPI {
       return;
     }
 
-    const status = await this.getTaskStatus(threadId);
-    const taskId = status.task_id;
-    if (!taskId) {
-      throw new Error(`No cancellable task found for thread ${threadId}`);
-    }
-
     const response = await fetch(
-      `${this.tasksBaseUrl}/tasks/${taskId}/cancel`,
+      `${this.tasksBaseUrl}/threads/${threadId}/cancel`,
       {
         method: "POST",
       },


### PR DESCRIPTION
## Summary
- Fixes manual QA findings across knowledge ingest/search, deep-triage target handling, MCP task/feedback surfaces, CLI help behavior, setup-knowledge flow, and UI stop/form behavior.
- Updates docs for feedback reads, knowledge chunk drill-down, pipeline chunk IDs, zero-scope deep triage, target fanout/caps, and removed runbook/redis.io KB surfaces.
- Adds focused unit coverage for target matching, pre-resolved triage scope, single-document ingest, MCP tool discovery/status/deep-triage validation, CLI help, and UI task cancellation.

## Verification
- `make lint`
- `make test`
- `make test-integration` (all integration-marked tests skipped under local prerequisites)
- `make docs-build`
- `npm --prefix ui test -- src/services/__tests__/sreAgentApi.test.ts`
- `npm --prefix ui run build`
- `bash -n scripts/setup-knowledge.sh`
- GitNexus impact checks for edited symbols and `detect-changes --scope compare --base-ref origin/main`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes task cancellation, atomic completion, and deep-triage target binding—core execution paths—with broad doc/UI touch but strong unit coverage.
> 
> **Overview**
> Addresses manual QA gaps across **task lifecycle**, **deep triage**, **knowledge**, **MCP**, and **UI** behavior, with matching doc and test updates.
> 
> **Cancellation and completion:** Adds `POST /api/v1/tasks/{task_id}/cancel` and `POST /api/v1/threads/{thread_id}/cancel` to stop Docket work and mark tasks `cancelled` without deleting history. Workers use atomic `complete_task_if_open` and bail out when a task is already cancelled so late agent results cannot flip a stopped run back to `done`. The Triage **Stop** action now calls thread cancel via the API instead of a no-op.
> 
> **Deep triage and targets:** Zero-scope deep triage can run target discovery first; only **resolved** matches are bound (ambiguous/clarification paths no longer attach live targets). Target exact-mention matching uses identifier boundaries so names like `prod-cache-1` are not confused with `prod-cache-10`. MCP `redis_sre_deep_triage` rejects unknown `instance_id` / `cluster_id` before enqueue.
> 
> **Knowledge:** Single-document ingest writes pipeline-style chunk keys and returns `document_hash` / `chunk_count`. Exact/quoted searches can still return RediSearch hits when the embedding provider fails; general semantic search still needs a vectorizer. `scripts/setup-knowledge.sh` switches from deprecated populate to **prepare-sources + ingest**.
> 
> **Smaller fixes:** Documents built-in `MAX_ITERATIONS=50`; instance **test** environment in API/models/UI; knowledge ingest API fields; CLI treats successful `click.exceptions.Exit` as non-failures; modal stacking; clearer failed-task messages in Triage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1355800766857461d3e16617b4c950b65467f270. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->