### PR TITLE
Ignore private KB exports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -149,3 +149,5 @@ eval_reports
 specs/
 docs/superpowers/
 source_documents/packs
+# Private/generated KB exports.
+source_documents/kb/


### PR DESCRIPTION
## Summary
- Ignore private/generated KB export directories under source_documents/kb.
- Prevent local export output, credentials, and caches from appearing as public repo commit candidates.

## Verification
- git check-ignore -v source_documents/kb/.env source_documents/kb/High_Memory_Usage_Warning_in_Redis_Cloud_What_It_Means_and_What_to_Do_Next.md
- git diff --check
- pre-commit hooks during commit: trailing whitespace, end-of-file, YAML check, merge-conflict check, large-file check, ruff format check, ruff check, pytest unit tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> `.gitignore` only; no product code or deployment behavior changes.
> 
> **Overview**
> **Adds** `source_documents/kb/` to `.gitignore`, following the same approach as `source_documents/packs`, so local KB export output (markdown, `.env`, caches) is not offered as commit candidates.
> 
> This is a repository hygiene change only; nothing in the application build or runtime is modified.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95a1140047e3f7fb6007bf5e5deffdaf5e12592f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->