### PR TITLE
Prevent projected BDB responses from hiding CRDBs

### DIFF
--- a/redis_sre_agent/agent/chat_agent.py
+++ b/redis_sre_agent/agent/chat_agent.py
@@ -319,6 +319,14 @@ For Redis diagnostics:
 - Start with diagnostics-category tools for a comprehensive overview
 - Add diagnostics/admin-api category tools for Redis Enterprise/Cloud configuration details
 - Add knowledge-category tools when you need troubleshooting guidance
+- For Redis Enterprise CRDB/Active-Active questions, do not decide from `get_database`
+  alone. Call the available CRDB admin-api tools first: `list_crdbs` to confirm
+  CRDB identity/topology, then `get_crdb`, `get_crdb_health_report`,
+  `get_crdt_syncer_state`, `get_sync_source_stats`, and `get_logs` as needed for
+  peers/sites, link status, syncer state, lag, and recent CRDB/CRDT/resync events.
+  Match CRDBs by CRDB name, CRDB GUID, local BDB UID, or instance DB UID. Do not
+  declare a database "not CRDB" solely because optional CRDT fields are absent
+  from a BDB response.
 
 For code/repo investigation:
 - **First:** One targeted repos-category search with a specific query
@@ -379,6 +387,8 @@ Only call categories that are available in your current tool list.
 - For managed Redis, INFO output can be misleading
 - Use available diagnostics/admin-api tools for accurate configuration details
 - Don't suggest CONFIG SET for managed deployments
+- For Redis Enterprise CRDB/Active-Active checks, `list_crdbs` is the source of
+  truth before saying whether a database is part of a CRDB.
 """
 
 

--- a/redis_sre_agent/agent/langgraph_agent.py
+++ b/redis_sre_agent/agent/langgraph_agent.py
@@ -1113,7 +1113,8 @@ The INFO command shows RUNTIME STATE, not CONFIGURATION. These are NORMAL and EX
 2. **Call `get_database` tool** to get the ACTUAL database configuration from the Admin REST API
 3. **Call `list_nodes` tool** to check node status (especially maintenance mode: `accept_servers=false`)
 4. **Call `list_shards` tool** to check shard distribution
-5. Use INFO only for runtime metrics (ops/sec, connected clients, keyspace stats)
+5. **For CRDB/Active-Active questions**, call `list_crdbs` first, then `get_crdb`, `get_crdb_health_report`, `get_crdt_syncer_state`, and `get_sync_source_stats` as needed to inspect CRDB topology, peers/sites, replication link health, syncer state, and lag.
+6. Use INFO only for runtime metrics (ops/sec, connected clients, keyspace stats)
 
 ### What You CANNOT Suggest
 - ❌ CONFIG SET for persistence, replication, clustering, maxmemory
@@ -1128,9 +1129,11 @@ The INFO command shows RUNTIME STATE, not CONFIGURATION. These are NORMAL and EX
 2. Call `list_nodes` to check for nodes in maintenance mode or degraded state
 3. Call `get_database` to get database configuration from Admin REST API
 4. Call `list_shards` to check shard distribution
-5. Use INFO for runtime metrics only
-6. Compare actual usage vs: configured limits
-7. Provide recommendations based on ACTUAL configuration, not INFO output
+5. For CRDB/Active-Active questions, call `list_crdbs` and match by CRDB name, CRDB GUID, local BDB UID (`local_databases[].bdb_uid`), or instance `db_uid`; do not claim a database is not CRDB solely because a `get_database` response lacks optional CRDT fields.
+6. For CRDB sync failures or lag, call `get_crdb_health_report`, `get_crdt_syncer_state`, `get_sync_source_stats`, and `get_logs` for recent CRDB/CRDT/syncer/resync/link events.
+7. Use INFO for runtime metrics only
+8. Compare actual usage vs. configured limits
+9. Provide recommendations based on ACTUAL configuration, not INFO output
 
 ### Critical: Check for Maintenance Mode
 Nodes with `accept_servers=false` are in MAINTENANCE MODE and won't accept new shards. This is a common cause of issues!

--- a/redis_sre_agent/agent/prompts.py
+++ b/redis_sre_agent/agent/prompts.py
@@ -161,6 +161,11 @@ The `INFO` command output is MISLEADING for Redis Enterprise:
     Redis Enterprise Admin API tool descriptions to see all available tools):
    - `get_cluster_info` - Cluster-level information
    - `get_database` - Database configuration (memory limits, persistence, replication, clustering, modules, etc.)
+   - `list_crdbs` - CRDB/Active-Active inventory, GUIDs, local database mappings, and participating instances/sites
+   - `get_crdb` - CRDB/Active-Active topology and per-instance configuration by GUID
+   - `get_crdb_health_report` - CRDB inter-cluster connection and replication link health by GUID
+   - `get_crdt_syncer_state` - Local BDB CRDT syncer state for Active-Active troubleshooting
+   - `get_sync_source_stats` - Syncer lag and ingress stats, including `local_ingress_lag_time`
    - `list_nodes` - Node status (check for maintenance mode: `accept_servers=false`)
    - `list_shards` - Shard distribution across nodes
    - `get_database_stats` - Database performance metrics
@@ -178,6 +183,13 @@ The `INFO` command output is MISLEADING for Redis Enterprise:
    - Call `list_nodes` to check if any nodes are in maintenance mode (`accept_servers=false`), failed, or degraded
    - Call `list_databases` and `get_database` to check database status and configuration
    - Call `list_shards` to check if shards are properly distributed across nodes
+
+4. **For CRDB/Active-Active questions, validate with CRDB-specific Admin API tools**:
+   - Call `list_crdbs` and match by CRDB name, CRDB GUID, local database UID (`local_databases[].bdb_uid`), or instance `db_uid`.
+   - If a matching CRDB is found, call `get_crdb` and `get_crdb_health_report` before summarizing peers/sites or link status.
+   - For sync failures or lag, call `get_crdt_syncer_state` for the local BDB UID and `get_sync_source_stats` for lag counters.
+   - Check `get_logs` for recent CRDB, CRDT, syncer, resync, replication link, or connection events.
+   - Do not claim a database is not CRDB solely because a `get_database` response lacks optional CRDT fields. First check `/v1/crdbs` via `list_crdbs`.
 
 ### Example: Correct Redis Enterprise Health Check
 
@@ -220,6 +232,7 @@ but these are normal for Redis Enterprise - persistence and replication are mana
 ```
 
 **ALWAYS call get_database and get_cluster_info for Redis Enterprise instances to get accurate configuration!**
+**For Redis Enterprise CRDB/Active-Active questions, ALWAYS call list_crdbs before declaring a database is not CRDB.**
 
 ## Redis Cloud Management
 

--- a/redis_sre_agent/tools/admin/redis_enterprise/provider.py
+++ b/redis_sre_agent/tools/admin/redis_enterprise/provider.py
@@ -31,6 +31,196 @@ from redis_sre_agent.tools.protocols import ToolProvider
 
 logger = logging.getLogger(__name__)
 _API_ERROR_CODE_RE = re.compile(r"\(code:\s*(\d+)\)")
+# BDB field names are seeded from the Redis Enterprise REST API BDB object docs
+# and supplemented with fields observed in live Redis Enterprise BDB responses.
+# Docs: https://redis.io/docs/latest/operate/rs/references/rest-api/objects/bdb/
+BDB_FIELD_NAMES: Tuple[str, ...] = (
+    "acl",
+    "account_id",
+    "action_uid",
+    "active_defrag_cycle_max",
+    "active_defrag_cycle_min",
+    "active_defrag_ignore_bytes",
+    "active_defrag_max_scan_fields",
+    "active_defrag_threshold_lower",
+    "active_defrag_threshold_upper",
+    "activedefrag",
+    "aof_policy",
+    "authentication_admin_pass",
+    "authentication_redis_pass",
+    "authentication_sasl_pass",
+    "authentication_sasl_uname",
+    "authentication_ssl_client_certs",
+    "authentication_ssl_crdt_certs",
+    "authorized_names",
+    "authorized_subjects",
+    "auto_shards_balancing",
+    "auto_shards_balancing_grace_period",
+    "auto_upgrade",
+    "avoid_nodes",
+    "background_op",
+    "backup",
+    "backup_failure_reason",
+    "backup_history",
+    "backup_interval",
+    "backup_interval_offset",
+    "backup_location",
+    "backup_progress",
+    "backup_status",
+    "bigstore",
+    "bigstore_max_ram_ratio",
+    "bigstore_ram_size",
+    "bigstore_ram_weights",
+    "bigstore_version",
+    "client_cert_subject_validation_type",
+    "compare_key_hslot",
+    "conns",
+    "conns_global_maximum_dedicated",
+    "conns_minimum_dedicated",
+    "conns_type",
+    "crdt",
+    "crdt_causal_consistency",
+    "crdt_config_version",
+    "crdt_featureset_version",
+    "crdt_ghost_replica_ids",
+    "crdt_guid",
+    "crdt_modules",
+    "crdt_protocol_version",
+    "crdt_repl_backlog_size",
+    "crdt_replica_id",
+    "crdt_replicas",
+    "crdt_sources",
+    "crdt_sync",
+    "crdt_sync_connection_alarm_timeout_seconds",
+    "crdt_sync_dist",
+    "crdt_syncer_auto_oom_unlatch",
+    "crdt_xadd_id_uniqueness_mode",
+    "created_time",
+    "data_internode_encryption",
+    "data_persistence",
+    "dataset_import_sources",
+    "db_conns_auditing",
+    "default_user",
+    "disabled_commands",
+    "disconnect_clients_on_password_removal",
+    "dns_address_master",
+    "dns_suffixes",
+    "email_alerts",
+    "endpoint",
+    "endpoint_ip",
+    "endpoint_node",
+    "endpoints",
+    "enforce_client_authentication",
+    "eviction_policy",
+    "export_failure_reason",
+    "export_progress",
+    "export_status",
+    "flush_on_fullsync",
+    "generate_text_monitor",
+    "gradual_src_max_sources",
+    "gradual_src_mode",
+    "gradual_sync_max_shards_per_source",
+    "gradual_sync_mode",
+    "group_uid",
+    "hash_slots_policy",
+    "implicit_shard_key",
+    "import_failure_reason",
+    "import_progress",
+    "import_status",
+    "internal",
+    "last_backup_time",
+    "last_changed_time",
+    "last_export_time",
+    "link_sconn_on_full_request",
+    "master_persistence",
+    "max_aof_file_size",
+    "max_aof_load_time",
+    "max_client_pipeline",
+    "max_connections",
+    "max_pipelined",
+    "maxclients",
+    "memory_size",
+    "metrics_export_all",
+    "mkms",
+    "module_list",
+    "mtls_allow_outdated_certs",
+    "mtls_allow_weak_hashing",
+    "multi_commands_opt",
+    "name",
+    "oss_cluster",
+    "oss_cluster_api_preferred_endpoint_type",
+    "oss_cluster_api_preferred_ip_type",
+    "oss_sharding",
+    "partial_request_timeout_seconds",
+    "port",
+    "preemptive_drain_timeout_seconds",
+    "probabilistic",
+    "proxy_policy",
+    "query_performance_factor",
+    "rack_aware",
+    "recovery_wait_time",
+    "redis_cluster_enabled",
+    "redis_version",
+    "repl_backlog_size",
+    "replica_read_only",
+    "replica_sconns_on_demand",
+    "replica_sources",
+    "replica_sync",
+    "replica_sync_connection_alarm_timeout_seconds",
+    "replica_sync_dist",
+    "replication",
+    "replication_oom_threshold_percent",
+    "resp3",
+    "roles_permissions",
+    "sched_policy",
+    "search",
+    "search_on_bigstore",
+    "shard_block_crossslot_keys",
+    "shard_block_foreign_keys",
+    "shard_imbalance_threshold",
+    "shard_imbalance_threshold_percentage",
+    "shard_key_regex",
+    "shard_list",
+    "sharding",
+    "shards_count",
+    "shards_placement",
+    "skip_import_analyze",
+    "slave_buffer",
+    "slave_ha",
+    "slave_ha_priority",
+    "snapshot_policy",
+    "ssl",
+    "status",
+    "support_syncer_reconf",
+    "sync",
+    "sync_dedicated_threads",
+    "sync_sources",
+    "syncer_log_level",
+    "syncer_mode",
+    "tags",
+    "throughput_ingress",
+    "timeseries",
+    "tls_mode",
+    "topology_epoch",
+    "tracking_table_max_keys",
+    "traffic_manually_disabled",
+    "type",
+    "uid",
+    "use_nodes",
+    "use_selective_flush",
+    "version",
+    "wait_command",
+)
+BDB_FIELD_NAMES_TEXT = ", ".join(BDB_FIELD_NAMES)
+_BDB_FIELDS_PARAMETER_DESCRIPTION = (
+    "Comma-separated list of BDB field names to return. Documented and observed "
+    "BDB fields are: "
+    f"{BDB_FIELD_NAMES_TEXT}. Leave empty to return all fields. This is a projection: "
+    "omitted fields are unknown, not false. For CRDB checks, leave empty or include "
+    "crdt,crdt_guid, and verify topology with list_crdbs before declaring a database "
+    "not CRDB. Some fields can include credentials or certificates; request "
+    "authentication_* and *_cert* fields only when specifically needed."
+)
 
 
 class RedisEnterpriseAdminConfig(BaseSettings):
@@ -289,7 +479,9 @@ class RedisEnterpriseAdminToolProvider(ToolProvider):
                 description=(
                     "List all databases (BDBs) in the Redis Enterprise cluster. "
                     "Returns database UIDs, names, and optionally other fields. "
-                    "Use this to discover what databases exist in the cluster."
+                    "Use this to discover what databases exist in the cluster. "
+                    "For CRDB/Active-Active checks, local BDB payloads may expose "
+                    "membership as crdt=true and crdt_guid."
                 ),
                 capability=ToolCapability.DIAGNOSTICS,
                 parameters={
@@ -297,11 +489,7 @@ class RedisEnterpriseAdminToolProvider(ToolProvider):
                     "properties": {
                         "fields": {
                             "type": "string",
-                            "description": (
-                                "Comma-separated list of field names to return. "
-                                "Examples: 'uid,name,memory_size,status'. "
-                                "Leave empty to return all fields."
-                            ),
+                            "description": _BDB_FIELDS_PARAMETER_DESCRIPTION,
                         }
                     },
                     "required": [],
@@ -312,7 +500,12 @@ class RedisEnterpriseAdminToolProvider(ToolProvider):
                 description=(
                     "Get detailed information about a specific database (BDB) by its UID. "
                     "Returns configuration, status, memory usage, replication settings, "
-                    "persistence configuration, and more. Use this to inspect a specific database."
+                    "persistence configuration, and more. Use this to inspect a specific database. "
+                    "Redis Enterprise can identify local CRDB membership with crdt=true and "
+                    "crdt_guid. "
+                    "For CRDB/Active-Active questions, also call the CRDB tools such as "
+                    "list_crdbs, get_crdb, get_crdb_health_report, get_crdt_syncer_state, "
+                    "and get_sync_source_stats before concluding a database is not CRDB."
                 ),
                 capability=ToolCapability.DIAGNOSTICS,
                 parameters={
@@ -324,10 +517,127 @@ class RedisEnterpriseAdminToolProvider(ToolProvider):
                         },
                         "fields": {
                             "type": "string",
+                            "description": _BDB_FIELDS_PARAMETER_DESCRIPTION,
+                        },
+                    },
+                    "required": ["uid"],
+                },
+            ),
+            ToolDefinition(
+                name=self._make_tool_name("list_crdbs"),
+                description=(
+                    "List all CRDB/Active-Active databases in the Redis Enterprise cluster "
+                    "from /v1/crdbs. Use this for CRDB or active-active questions to confirm "
+                    "database identity, CRDB GUID, local database mapping, and participating "
+                    "instances/sites before deciding whether a local BDB is part of a CRDB."
+                ),
+                capability=ToolCapability.DIAGNOSTICS,
+                parameters={
+                    "type": "object",
+                    "properties": {},
+                    "required": [],
+                },
+            ),
+            ToolDefinition(
+                name=self._make_tool_name("get_crdb"),
+                description=(
+                    "Get a CRDB/Active-Active database by GUID from /v1/crdbs/{crdb_guid}. "
+                    "Returns the CRDB object, including name, instances/sites, local database "
+                    "mapping, and default database configuration. Use this after list_crdbs "
+                    "or when a CRDB GUID is known."
+                ),
+                capability=ToolCapability.DIAGNOSTICS,
+                parameters={
+                    "type": "object",
+                    "properties": {
+                        "crdb_guid": {
+                            "type": "string",
+                            "description": "The globally unique CRDB/Active-Active database GUID",
+                        },
+                        "instance_id": {
+                            "type": "integer",
                             "description": (
-                                "Comma-separated list of field names to return. "
-                                "Leave empty to return all fields."
+                                "Optional CRDB instance ID from which to retrieve information"
                             ),
+                        },
+                    },
+                    "required": ["crdb_guid"],
+                },
+            ),
+            ToolDefinition(
+                name=self._make_tool_name("get_crdb_health_report"),
+                description=(
+                    "Get the CRDB/Active-Active health report from "
+                    "/v1/crdbs/{crdb_guid}/health_report. Use this to inspect inter-cluster "
+                    "connection status, replication link status, configuration versions, and "
+                    "connection errors for CRDB synchronization failures."
+                ),
+                capability=ToolCapability.DIAGNOSTICS,
+                parameters={
+                    "type": "object",
+                    "properties": {
+                        "crdb_guid": {
+                            "type": "string",
+                            "description": "The globally unique CRDB/Active-Active database GUID",
+                        },
+                        "instance_id": {
+                            "type": "integer",
+                            "description": (
+                                "Optional CRDB instance ID from which to retrieve the report"
+                            ),
+                        },
+                    },
+                    "required": ["crdb_guid"],
+                },
+            ),
+            ToolDefinition(
+                name=self._make_tool_name("get_crdt_syncer_state"),
+                description=(
+                    "Get a local CRDB BDB's CRDT syncer state from "
+                    "/v1/bdbs/{uid}/syncer_state/crdt. Use this to troubleshoot Active-Active "
+                    "syncer state after confirming the local BDB UID belongs to a CRDB."
+                ),
+                capability=ToolCapability.DIAGNOSTICS,
+                parameters={
+                    "type": "object",
+                    "properties": {
+                        "uid": {
+                            "type": "integer",
+                            "description": "The local database (BDB) UID",
+                        },
+                    },
+                    "required": ["uid"],
+                },
+            ),
+            ToolDefinition(
+                name=self._make_tool_name("get_sync_source_stats"),
+                description=(
+                    "Get syncer source statistics for a local database from "
+                    "/v1/bdbs/{uid}/sync_source_stats. Use this for CRDB or Replica Of lag "
+                    "analysis, including local_ingress_lag_time and ingress byte counters."
+                ),
+                capability=ToolCapability.DIAGNOSTICS,
+                parameters={
+                    "type": "object",
+                    "properties": {
+                        "uid": {
+                            "type": "integer",
+                            "description": "The local database (BDB) UID",
+                        },
+                        "interval": {
+                            "type": "string",
+                            "description": (
+                                "Stats interval: '1sec', '10sec', '5min', '15min', "
+                                "'1hour', '12hour', or '1week'. Default: '1sec'"
+                            ),
+                        },
+                        "stime": {
+                            "type": "string",
+                            "description": "Optional start time (RFC3339 or epoch seconds)",
+                        },
+                        "etime": {
+                            "type": "string",
+                            "description": "Optional end time (RFC3339 or epoch seconds)",
                         },
                     },
                     "required": ["uid"],
@@ -765,6 +1075,177 @@ class RedisEnterpriseAdminToolProvider(ToolProvider):
             }
         except Exception as e:
             logger.error(f"Failed to get database {uid}: {e}")
+            return {
+                "status": "error",
+                "error": str(e),
+                "uid": uid,
+            }
+
+    @status_update("I'm listing CRDBs via the Redis Enterprise Admin API.")
+    async def list_crdbs(self) -> Dict[str, Any]:
+        """List all CRDB/Active-Active databases in the cluster."""
+        logger.info("Listing CRDBs")
+        try:
+            crdbs = await self._get_json("/v1/crdbs")
+            if isinstance(crdbs, dict) and isinstance(crdbs.get("crdbs"), list):
+                count = len(crdbs["crdbs"])
+            elif isinstance(crdbs, list):
+                count = len(crdbs)
+            else:
+                count = 1
+
+            return {
+                "status": "success",
+                "count": count,
+                "crdbs": crdbs,
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+            }
+        except httpx.HTTPStatusError as e:
+            logger.error(f"HTTP error listing CRDBs: {e}")
+            return {
+                "status": "error",
+                "error": f"HTTP {e.response.status_code}: {e.response.text}",
+            }
+        except Exception as e:
+            logger.error(f"Failed to list CRDBs: {e}")
+            return {
+                "status": "error",
+                "error": str(e),
+            }
+
+    @status_update(
+        "I'm retrieving CRDB details from the Redis Enterprise Admin API for {crdb_guid}."
+    )
+    async def get_crdb(self, crdb_guid: str, instance_id: Optional[int] = None) -> Dict[str, Any]:
+        """Get a specific CRDB/Active-Active database by GUID."""
+        logger.info(f"Getting CRDB {crdb_guid} (instance_id={instance_id})")
+        try:
+            params: Dict[str, Any] = {}
+            if instance_id is not None:
+                params["instance_id"] = int(instance_id)
+
+            return {
+                "status": "success",
+                "crdb_guid": crdb_guid,
+                "crdb": await self._get_json(f"/v1/crdbs/{crdb_guid}", params=params),
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+            }
+        except httpx.HTTPStatusError as e:
+            logger.error(f"HTTP error getting CRDB {crdb_guid}: {e}")
+            return {
+                "status": "error",
+                "error": f"HTTP {e.response.status_code}: {e.response.text}",
+                "crdb_guid": crdb_guid,
+            }
+        except Exception as e:
+            logger.error(f"Failed to get CRDB {crdb_guid}: {e}")
+            return {
+                "status": "error",
+                "error": str(e),
+                "crdb_guid": crdb_guid,
+            }
+
+    @status_update(
+        "I'm retrieving the CRDB health report from the Redis Enterprise Admin API for {crdb_guid}."
+    )
+    async def get_crdb_health_report(
+        self, crdb_guid: str, instance_id: Optional[int] = None
+    ) -> Dict[str, Any]:
+        """Get a CRDB/Active-Active health report by GUID."""
+        logger.info(f"Getting CRDB health report {crdb_guid} (instance_id={instance_id})")
+        try:
+            params: Dict[str, Any] = {}
+            if instance_id is not None:
+                params["instance_id"] = int(instance_id)
+
+            return {
+                "status": "success",
+                "crdb_guid": crdb_guid,
+                "health_report": await self._get_json(
+                    f"/v1/crdbs/{crdb_guid}/health_report", params=params
+                ),
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+            }
+        except httpx.HTTPStatusError as e:
+            logger.error(f"HTTP error getting CRDB health report {crdb_guid}: {e}")
+            return {
+                "status": "error",
+                "error": f"HTTP {e.response.status_code}: {e.response.text}",
+                "crdb_guid": crdb_guid,
+            }
+        except Exception as e:
+            logger.error(f"Failed to get CRDB health report {crdb_guid}: {e}")
+            return {
+                "status": "error",
+                "error": str(e),
+                "crdb_guid": crdb_guid,
+            }
+
+    @status_update(
+        "I'm retrieving CRDT syncer state from the Redis Enterprise Admin API for database {uid}."
+    )
+    async def get_crdt_syncer_state(self, uid: int) -> Dict[str, Any]:
+        """Get CRDT syncer state for a local CRDB BDB."""
+        logger.info(f"Getting CRDT syncer state for database {uid}")
+        try:
+            return {
+                "status": "success",
+                "uid": uid,
+                "syncer_state": await self._get_json(f"/v1/bdbs/{uid}/syncer_state/crdt"),
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+            }
+        except httpx.HTTPStatusError as e:
+            logger.error(f"HTTP error getting CRDT syncer state for database {uid}: {e}")
+            return {
+                "status": "error",
+                "error": f"HTTP {e.response.status_code}: {e.response.text}",
+                "uid": uid,
+            }
+        except Exception as e:
+            logger.error(f"Failed to get CRDT syncer state for database {uid}: {e}")
+            return {
+                "status": "error",
+                "error": str(e),
+                "uid": uid,
+            }
+
+    @status_update(
+        "I'm fetching syncer source stats via the Admin API for database {uid} (interval={interval})."
+    )
+    async def get_sync_source_stats(
+        self,
+        uid: int,
+        interval: str = "1sec",
+        stime: Optional[str] = None,
+        etime: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Get syncer source stats for a local database."""
+        logger.info(f"Getting sync source stats for database {uid} (interval={interval})")
+        try:
+            params: Dict[str, Any] = {"interval": interval}
+            st = self._normalize_time_param(stime)
+            et = self._normalize_time_param(etime)
+            if st:
+                params["stime"] = st
+            if et:
+                params["etime"] = et
+
+            return {
+                "status": "success",
+                "uid": uid,
+                "interval": interval,
+                "stats": await self._get_json(f"/v1/bdbs/{uid}/sync_source_stats", params=params),
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+            }
+        except httpx.HTTPStatusError as e:
+            logger.error(f"HTTP error getting sync source stats for database {uid}: {e}")
+            return {
+                "status": "error",
+                "error": f"HTTP {e.response.status_code}: {e.response.text}",
+                "uid": uid,
+            }
+        except Exception as e:
+            logger.error(f"Failed to get sync source stats for database {uid}: {e}")
             return {
                 "status": "error",
                 "error": str(e),

--- a/tests/unit/agent/test_chat_agent.py
+++ b/tests/unit/agent/test_chat_agent.py
@@ -788,6 +788,15 @@ class TestSkillContractRuntimeRepair:
         assert "Enterprise" in CHAT_SYSTEM_PROMPT or "Cloud" in CHAT_SYSTEM_PROMPT
         assert "INFO" in CHAT_SYSTEM_PROMPT
 
+    def test_system_prompt_requires_crdb_inventory_before_not_crdb_claim(self):
+        """CRDB questions should not be answered from BDB optional fields alone."""
+        assert "list_crdbs" in CHAT_SYSTEM_PROMPT
+        assert "get_crdb_health_report" in CHAT_SYSTEM_PROMPT
+        assert "get_crdt_syncer_state" in CHAT_SYSTEM_PROMPT
+        assert "get_sync_source_stats" in CHAT_SYSTEM_PROMPT
+        assert 'declare a database "not CRDB"' in CHAT_SYSTEM_PROMPT
+        assert "optional CRDT fields are absent" in CHAT_SYSTEM_PROMPT
+
 
 class TestChatAgentState:
     """Test the ChatAgentState TypedDict."""

--- a/tests/unit/tools/admin/redis_enterprise/test_redis_enterprise_admin_provider.py
+++ b/tests/unit/tools/admin/redis_enterprise/test_redis_enterprise_admin_provider.py
@@ -12,6 +12,8 @@ from aiohttp import web
 
 from redis_sre_agent.core.instances import RedisInstance
 from redis_sre_agent.tools.admin.redis_enterprise.provider import (
+    BDB_FIELD_NAMES,
+    BDB_FIELD_NAMES_TEXT,
     RedisEnterpriseAdminConfig,
     RedisEnterpriseAdminToolProvider,
 )
@@ -222,6 +224,58 @@ async def test_create_tool_schemas(provider):
     assert any("modules" in name for name in tool_names)
     assert any("actions" in name for name in tool_names)
     assert any("shards" in name for name in tool_names)
+    assert any("list_crdbs" in name for name in tool_names)
+    assert any("get_crdb" in name for name in tool_names)
+    assert any("get_crdb_health_report" in name for name in tool_names)
+    assert any("get_crdt_syncer_state" in name for name in tool_names)
+    assert any("get_sync_source_stats" in name for name in tool_names)
+
+
+@pytest.mark.asyncio
+async def test_database_tool_descriptions_warn_about_crdb_field_projection(provider):
+    """Database schemas should prevent projected BDB payloads from negating CRDB identity."""
+    schemas = provider.create_tool_schemas()
+    get_database_schema = next(
+        schema for schema in schemas if schema.name.endswith("_get_database")
+    )
+    list_database_schema = next(
+        schema for schema in schemas if schema.name.endswith("_list_databases")
+    )
+
+    get_database_description = get_database_schema.description
+    get_database_fields_description = get_database_schema.parameters["properties"]["fields"][
+        "description"
+    ]
+    list_database_fields_description = list_database_schema.parameters["properties"]["fields"][
+        "description"
+    ]
+
+    assert "crdt" in get_database_description
+    assert "crdt_guid" in get_database_description
+    assert "omitted fields are unknown, not false" in get_database_fields_description
+    assert "crdt,crdt_guid" in get_database_fields_description
+    assert "list_crdbs" in get_database_fields_description
+    assert "omitted fields are unknown, not false" in list_database_fields_description
+    assert "crdt,crdt_guid" in list_database_fields_description
+    assert BDB_FIELD_NAMES_TEXT in get_database_fields_description
+    assert BDB_FIELD_NAMES_TEXT in list_database_fields_description
+    for documented_field_name in (
+        "account_id",
+        "action_uid",
+        "avoid_nodes",
+        "backup_location",
+        "endpoint",
+        "replication_oom_threshold_percent",
+        "search",
+        "traffic_manually_disabled",
+        "use_nodes",
+    ):
+        assert documented_field_name in BDB_FIELD_NAMES
+        assert documented_field_name in get_database_fields_description
+        assert documented_field_name in list_database_fields_description
+    for field_name in BDB_FIELD_NAMES:
+        assert field_name in get_database_fields_description
+        assert field_name in list_database_fields_description
 
 
 @pytest.mark.asyncio
@@ -413,6 +467,188 @@ async def test_get_database_preserves_crdt_guid_field_name(provider):
         assert result["database"]["crdt_guid"] == "crdt-123"
         mock_client.get.assert_called_once_with(
             "/v1/bdbs/1", params={"fields": "uid,name,crdt_guid"}
+        )
+
+
+@pytest.mark.asyncio
+async def test_list_crdbs_success(provider):
+    """Test CRDB listing."""
+    crdbs = [
+        {
+            "guid": "crdb-guid-1",
+            "name": "large-key",
+            "local_databases": [{"bdb_uid": "14", "id": 1}],
+            "instances": [
+                {"id": 1, "db_uid": "14", "cluster": {"name": "lab7"}},
+                {"id": 2, "cluster": {"name": "lab8"}},
+            ],
+        }
+    ]
+
+    mock_response = MagicMock()
+    mock_response.json.return_value = crdbs
+    mock_response.raise_for_status = MagicMock()
+
+    with patch.object(provider, "get_client") as mock_get_client:
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=mock_response)
+        mock_get_client.return_value = mock_client
+
+        result = await provider.list_crdbs()
+
+        assert result["status"] == "success"
+        assert result["count"] == 1
+        assert result["crdbs"] == crdbs
+        mock_client.get.assert_called_once_with("/v1/crdbs", params={})
+
+
+@pytest.mark.asyncio
+async def test_list_crdbs_counts_wrapped_payload(provider):
+    """Some Admin API wrappers return {'crdbs': [...]} instead of a bare list."""
+    payload = {"crdbs": [{"guid": "crdb-guid-1"}, {"guid": "crdb-guid-2"}]}
+
+    mock_response = MagicMock()
+    mock_response.json.return_value = payload
+    mock_response.raise_for_status = MagicMock()
+
+    with patch.object(provider, "get_client") as mock_get_client:
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=mock_response)
+        mock_get_client.return_value = mock_client
+
+        result = await provider.list_crdbs()
+
+        assert result["status"] == "success"
+        assert result["count"] == 2
+        assert result["crdbs"] == payload
+
+
+@pytest.mark.asyncio
+async def test_get_crdb_with_instance_id(provider):
+    """Test CRDB detail retrieval by GUID."""
+    payload = {
+        "guid": "crdb-guid-1",
+        "name": "large-key",
+        "local_databases": [{"bdb_uid": "14", "id": 1}],
+    }
+
+    mock_response = MagicMock()
+    mock_response.json.return_value = payload
+    mock_response.raise_for_status = MagicMock()
+
+    with patch.object(provider, "get_client") as mock_get_client:
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=mock_response)
+        mock_get_client.return_value = mock_client
+
+        result = await provider.get_crdb("crdb-guid-1", instance_id=2)
+
+        assert result["status"] == "success"
+        assert result["crdb_guid"] == "crdb-guid-1"
+        assert result["crdb"] == payload
+        mock_client.get.assert_called_once_with("/v1/crdbs/crdb-guid-1", params={"instance_id": 2})
+
+
+@pytest.mark.asyncio
+async def test_get_crdb_health_report(provider):
+    """Test CRDB health report retrieval."""
+    payload = [
+        {
+            "name": "large-key",
+            "cluster_name": "lab7",
+            "connections": [
+                {
+                    "name": "lab8",
+                    "status": "down",
+                    "replication_links": [
+                        {"link_uid": "14:2", "status": "down"},
+                    ],
+                }
+            ],
+        }
+    ]
+
+    mock_response = MagicMock()
+    mock_response.json.return_value = payload
+    mock_response.raise_for_status = MagicMock()
+
+    with patch.object(provider, "get_client") as mock_get_client:
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=mock_response)
+        mock_get_client.return_value = mock_client
+
+        result = await provider.get_crdb_health_report("crdb-guid-1")
+
+        assert result["status"] == "success"
+        assert result["health_report"] == payload
+        mock_client.get.assert_called_once_with("/v1/crdbs/crdb-guid-1/health_report", params={})
+
+
+@pytest.mark.asyncio
+async def test_get_crdt_syncer_state(provider):
+    """Test CRDT syncer state retrieval for a local BDB."""
+    payload = {"DB": 14, "RunID": 1584086516, "State": "syncing"}
+
+    mock_response = MagicMock()
+    mock_response.json.return_value = payload
+    mock_response.raise_for_status = MagicMock()
+
+    with patch.object(provider, "get_client") as mock_get_client:
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=mock_response)
+        mock_get_client.return_value = mock_client
+
+        result = await provider.get_crdt_syncer_state(uid=14)
+
+        assert result["status"] == "success"
+        assert result["uid"] == 14
+        assert result["syncer_state"] == payload
+        mock_client.get.assert_called_once_with("/v1/bdbs/14/syncer_state/crdt", params={})
+
+
+@pytest.mark.asyncio
+async def test_get_sync_source_stats_with_time_range(provider):
+    """Test syncer lag stats retrieval for a local BDB."""
+    payload = {
+        "sync_source_stats": [
+            {
+                "uid": "1",
+                "intervals": [
+                    {
+                        "interval": "5min",
+                        "local_ingress_lag_time": 12.5,
+                    }
+                ],
+            }
+        ]
+    }
+
+    mock_response = MagicMock()
+    mock_response.json.return_value = payload
+    mock_response.raise_for_status = MagicMock()
+
+    with patch.object(provider, "get_client") as mock_get_client:
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=mock_response)
+        mock_get_client.return_value = mock_client
+
+        result = await provider.get_sync_source_stats(
+            uid=14,
+            interval="5min",
+            stime="2026-06-25T10:00:00Z",
+            etime="2026-06-25T10:05:00Z",
+        )
+
+        assert result["status"] == "success"
+        assert result["uid"] == 14
+        assert result["stats"] == payload
+        mock_client.get.assert_called_once_with(
+            "/v1/bdbs/14/sync_source_stats",
+            params={
+                "interval": "5min",
+                "stime": "2026-06-25T10:00:00Z",
+                "etime": "2026-06-25T10:05:00Z",
+            },
         )
 
 


### PR DESCRIPTION
## Summary

- Adds Redis Enterprise CRDB/Active-Active admin tools for CRDB inventory, details, health reports, CRDT syncer state, and sync source lag stats.
- Updates chat, LangGraph, and shared prompt guidance so CRDB questions confirm topology with `list_crdbs` before declaring that a database is not CRDB.
- Documents the BDB `fields` projection vocabulary in the Redis Enterprise admin tool descriptions, including documented BDB fields and CRDB-related fields.
- Adds regression coverage for the CRDB prompt guardrail, projected BDB field warning, BDB field catalog, and new CRDB API methods.

## Why

The lab failure was caused by treating a narrow `/v1/bdbs` field projection as a complete database record. A query such as `uid,name,status,proxy_policy` can omit optional CRDB metadata entirely, so absence of `crdt` or `crdt_guid` in that response is unknown, not evidence that the database is not CRDB.

This change makes CRDB identity and topology come from the CRDB Admin API (`/v1/crdbs`) and teaches the agent to use CRDB-specific health, syncer, lag, and event evidence when investigating Active-Active sync issues.

## How Has This Been Tested?

- `git diff --check`
- `uv run pytest tests/unit/agent/test_chat_agent.py tests/unit/tools/admin/redis_enterprise/test_redis_enterprise_admin_provider.py -q`
- `uvx mfcqi analyze --skip-llm redis_sre_agent/agent/chat_agent.py redis_sre_agent/agent/langgraph_agent.py redis_sre_agent/agent/prompts.py redis_sre_agent/tools/admin/redis_enterprise/provider.py tests/unit/agent/test_chat_agent.py tests/unit/tools/admin/redis_enterprise/test_redis_enterprise_admin_provider.py`
- GitHub CI passed: lint, build, Python 3.11/3.12 tests, deterministic eval subset, live evals, image builds, CodeQL, and Compose smoke test.

## Linked Items

None.

## Breaking Changes

None. This adds read-only Admin API tools and updates prompt/schema descriptions; existing tool names and parameters remain compatible.

## Reviewer Notes

- The important behavioral rule is: omitted projected BDB fields are unknown, not false.
- CRDB matching now points the agent at CRDB name, CRDB GUID, local BDB UID, or instance DB UID instead of relying on a projected BDB payload alone.
- The BDB field vocabulary is based on the Redis Enterprise BDB object documentation plus fields observed from local Redis Enterprise admin payloads: https://redis.io/docs/latest/operate/rs/references/rest-api/objects/bdb/
