### PR TITLE
Track scraped documents by stable source_document_path to fix orphaned chunks on re-ingest

### DIFF
--- a/redis_sre_agent/pipelines/ingestion/_processor_impl.py
+++ b/redis_sre_agent/pipelines/ingestion/_processor_impl.py
@@ -131,12 +131,18 @@ class IngestionPipeline(PipelineWorkflowMixin):
 
     @staticmethod
     def _path_in_scope(source_document_path: str, scope_prefixes: set[str]) -> bool:
-        """Return True when a tracked source file belongs to the active ingest scope."""
-        if not scope_prefixes:
+        """Return True when a tracked source file belongs to the active ingest scope.
+
+        An empty/blank scope NEVER authorizes deletion. A source must declare a
+        bounded, non-empty scope prefix for the stale sweep to delete within it;
+        with no declared scope, nothing is swept. (A "" scope was previously
+        treated as match-everything — once documents are tracked, that let a
+        partial ingest hard-delete every tracked doc it did not re-emit.)
+        """
+        real_prefixes = {prefix for prefix in scope_prefixes if prefix and prefix.strip()}
+        if not real_prefixes:
             return False
-        if "" in scope_prefixes:
-            return True
-        return any(source_document_path.startswith(prefix) for prefix in scope_prefixes if prefix)
+        return any(source_document_path.startswith(prefix) for prefix in real_prefixes)
 
     @staticmethod
     def _empty_source_change_summary() -> Dict[str, Any]:

--- a/redis_sre_agent/pipelines/ingestion/_processor_impl.py
+++ b/redis_sre_agent/pipelines/ingestion/_processor_impl.py
@@ -8,27 +8,13 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 # Avoid importing Redis/vectorizer at module import time to keep optional deps lazy
-from ...pipelines.scraper.base import ArtifactStorage, ScrapedDocument, derive_stable_path
+from ...pipelines.scraper.base import ArtifactStorage, ScrapedDocument
 from .deduplication import DocumentDeduplicator
 from .document_processor import DocumentProcessor
 from .pipeline_workflow_mixin import PipelineWorkflowMixin
 from .processor_indexing_helpers import index_processed_document
 
 logger = logging.getLogger(__name__)
-
-
-def _effective_source_document_path(doc_data: Dict[str, Any]) -> str:
-    """Return the source_document_path a document will index under.
-
-    Mirrors the identity resolution in ``ScrapedDocument.__init__`` /
-    ``from_dict``: an explicit ``metadata['source_document_path']`` wins,
-    otherwise it is derived from ``source_url`` (empty for non-http(s)).
-    """
-    metadata = doc_data.get("metadata") or {}
-    explicit = str(metadata.get("source_document_path") or "").strip()
-    if explicit:
-        return explicit
-    return derive_stable_path(str(doc_data.get("source_url") or ""))
 
 
 def detect_source_path_collisions(
@@ -54,7 +40,9 @@ def detect_source_path_collisions(
         try:
             with open(json_file, "r", encoding="utf-8") as f:
                 doc_data = json.load(f)
-            path = _effective_source_document_path(doc_data)
+            # Resolve the identity exactly as indexing will: ScrapedDocument
+            # construction applies the explicit-path-or-derive_stable_path rule.
+            path = ScrapedDocument.from_dict(doc_data).metadata.get("source_document_path", "")
         except Exception as e:  # unreadable/invalid file: defer the error to processing
             logger.warning("Collision scan could not read %s: %s", json_file.name, e)
             files_to_process.append(json_file)

--- a/redis_sre_agent/pipelines/ingestion/_processor_impl.py
+++ b/redis_sre_agent/pipelines/ingestion/_processor_impl.py
@@ -8,13 +8,71 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 # Avoid importing Redis/vectorizer at module import time to keep optional deps lazy
-from ...pipelines.scraper.base import ArtifactStorage, ScrapedDocument
+from ...pipelines.scraper.base import ArtifactStorage, ScrapedDocument, derive_stable_path
 from .deduplication import DocumentDeduplicator
 from .document_processor import DocumentProcessor
 from .pipeline_workflow_mixin import PipelineWorkflowMixin
 from .processor_indexing_helpers import index_processed_document
 
 logger = logging.getLogger(__name__)
+
+
+def _effective_source_document_path(doc_data: Dict[str, Any]) -> str:
+    """Return the source_document_path a document will index under.
+
+    Mirrors the identity resolution in ``ScrapedDocument.__init__`` /
+    ``from_dict``: an explicit ``metadata['source_document_path']`` wins,
+    otherwise it is derived from ``source_url`` (empty for non-http(s)).
+    """
+    metadata = doc_data.get("metadata") or {}
+    explicit = str(metadata.get("source_document_path") or "").strip()
+    if explicit:
+        return explicit
+    return derive_stable_path(str(doc_data.get("source_url") or ""))
+
+
+def detect_source_path_collisions(
+    json_files: List[Path],
+) -> tuple[List[Path], Dict[str, List[Path]]]:
+    """Detect distinct documents that resolve to the same source_document_path.
+
+    Runs BEFORE any indexing. Two documents sharing one identity would clobber
+    each other on the tracked dedup branch (delete-prior-then-write on a shared
+    tracking key), silently dropping one every run — and under the parallel
+    ingest batch they would also race on that key. Detecting here lets us keep
+    the first occurrence and skip the rest before a single chunk is written.
+
+    Returns ``(files_to_process, collisions)`` where ``collisions`` maps a
+    colliding path to every file that resolved to it (first kept, rest skipped).
+    Files with an empty effective path (untracked branch) are never collided.
+    """
+    by_path: Dict[str, List[Path]] = {}
+    files_to_process: List[Path] = []
+    # Sort for a deterministic "keep first" across runs, so the collision
+    # skip-list is reproducible in audit logs regardless of directory order.
+    for json_file in sorted(json_files):
+        try:
+            with open(json_file, "r", encoding="utf-8") as f:
+                doc_data = json.load(f)
+            path = _effective_source_document_path(doc_data)
+        except Exception as e:  # unreadable/invalid file: defer the error to processing
+            logger.warning("Collision scan could not read %s: %s", json_file.name, e)
+            files_to_process.append(json_file)
+            continue
+
+        if not path:
+            # Untracked branch (e.g. file:// or non-http source): cannot collide.
+            files_to_process.append(json_file)
+            continue
+
+        if path in by_path:
+            by_path[path].append(json_file)  # duplicate: skip (do not index)
+        else:
+            by_path[path] = [json_file]
+            files_to_process.append(json_file)
+
+    collisions = {path: files for path, files in by_path.items() if len(files) > 1}
+    return files_to_process, collisions
 
 
 # Expose patchable wrappers so tests can monkeypatch these names
@@ -328,6 +386,22 @@ class IngestionPipeline(PipelineWorkflowMixin):
             )
 
         logger.info(f"Found {len(json_files)} documents in {category}")
+
+        # Pre-indexing collision guard (runs before any index_processed_document
+        # call): two distinct docs sharing one source_document_path would clobber
+        # each other on the tracked dedup branch. Keep the first, skip the rest,
+        # and surface the collision instead of silently dropping a document.
+        json_files, collisions = detect_source_path_collisions(json_files)
+        for path, files in collisions.items():
+            kept = files[0].name
+            skipped = ", ".join(f.name for f in files[1:])
+            message = (
+                f"source_document_path collision in {category}: "
+                f"{len(files)} documents resolve to '{path}'. "
+                f"Indexing '{kept}'; skipping {skipped}."
+            )
+            logger.error(message)
+            stats["errors"].append(message)
 
         # Process documents in parallel batches
         async def process_document(json_file: Path) -> Dict[str, Any]:

--- a/redis_sre_agent/pipelines/ingestion/_processor_impl.py
+++ b/redis_sre_agent/pipelines/ingestion/_processor_impl.py
@@ -41,8 +41,12 @@ def detect_source_path_collisions(
             with open(json_file, "r", encoding="utf-8") as f:
                 doc_data = json.load(f)
             # Resolve the identity exactly as indexing will: ScrapedDocument
-            # construction applies the explicit-path-or-derive_stable_path rule.
-            path = ScrapedDocument.from_dict(doc_data).metadata.get("source_document_path", "")
+            # construction applies the explicit-path-or-derive_stable_path rule,
+            # and the tracking side strips the value (get_source_tracking_fields),
+            # so strip here too — otherwise paths differing only by surrounding
+            # whitespace would slip the guard yet share one tracking key.
+            resolved = ScrapedDocument.from_dict(doc_data)
+            path = str(resolved.metadata.get("source_document_path") or "").strip()
         except Exception as e:  # unreadable/invalid file: defer the error to processing
             logger.warning("Collision scan could not read %s: %s", json_file.name, e)
             files_to_process.append(json_file)

--- a/redis_sre_agent/pipelines/scraper/base.py
+++ b/redis_sre_agent/pipelines/scraper/base.py
@@ -8,8 +8,47 @@ from datetime import datetime, timezone
 from enum import Enum
 from pathlib import Path
 from typing import Any, Awaitable, Callable, Dict, List, Optional, Union
+from urllib.parse import urlparse
 
 logger = logging.getLogger(__name__)
+
+
+def derive_stable_path(source_url: str) -> str:
+    """Derive a stable, content-independent logical identity from a source URL.
+
+    This is the document's logical identity used to route scraped documents
+    through the tracked dedup branch (replace-on-change). It is derived from
+    *where* a document lives, never from *what* it says.
+
+    Frozen contract (changing it re-keys the entire corpus — every path becomes
+    "new", old chunks orphan en masse on the next run):
+
+    - Only ``http`` / ``https`` URLs produce a path. Any other scheme
+      (``file://``, ``mailto:`` …), an empty string, or a relative/unparseable
+      input returns ``""`` so the document falls through to the untracked
+      branch rather than being assigned a machine-specific or garbage identity.
+    - Strip the scheme; lowercase the host; drop ``?query`` and ``#fragment``;
+      strip a single trailing slash.
+    - Do NOT fold ``index.html`` and do NOT collapse duplicate slashes — those
+      can merge legitimately distinct pages into one identity.
+
+    Idempotent: the same logical page maps to the same string on every run, so
+    the prior-version lookup in ``replace_source_document_chunks`` can find and
+    delete stale chunks before writing the new ones.
+    """
+    if not source_url:
+        return ""
+    try:
+        parsed = urlparse(source_url.strip())
+    except (ValueError, AttributeError):
+        return ""
+    if parsed.scheme not in ("http", "https"):
+        return ""
+    host = parsed.netloc.lower()
+    if not host:
+        return ""
+    path = parsed.path.rstrip("/")
+    return f"{host}{path}"
 
 
 class DocumentCategory(str, Enum):
@@ -76,6 +115,17 @@ class ScrapedDocument:
         self.doc_type = doc_type
         self.severity = severity
         self.metadata = metadata or {}
+        # Default a stable, content-independent source_document_path from the
+        # source URL when a scraper has not set one explicitly. This routes the
+        # document through the tracked dedup branch (replace-on-change). Only
+        # fires for http(s) URLs; file://, relative, and other schemes yield ""
+        # (derive_stable_path) and fall through to the untracked branch. Note:
+        # __init__ also runs via from_dict, so reingesting a legacy artifact
+        # that predates this field auto-migrates http(s) docs onto tracking.
+        if not str(self.metadata.get("source_document_path") or "").strip():
+            derived = derive_stable_path(source_url)
+            if derived:
+                self.metadata["source_document_path"] = derived
         self.scraped_at = datetime.now(timezone.utc)
         self.content_hash = self._generate_content_hash()
 

--- a/redis_sre_agent/pipelines/scraper/redis_cloud_api.py
+++ b/redis_sre_agent/pipelines/scraper/redis_cloud_api.py
@@ -110,6 +110,10 @@ class RedisCloudAPIScraper(BaseScraper):
                 "api_version": api_version,
                 "doc_type": "api_overview",
                 "scraped_from": "redis_cloud_api_scraper",
+                # Explicit identity: every endpoint shares the swagger source_url
+                # (differing only by #fragment, which derive_stable_path drops),
+                # so the URL-derived default would collide. Set it per document.
+                "source_document_path": "redis-cloud-api/overview",
             },
         )
         documents.append(overview_doc)
@@ -205,6 +209,10 @@ class RedisCloudAPIScraper(BaseScraper):
                     "operation_id": operation_id,
                     "doc_type": "api_endpoint",
                     "scraped_from": "redis_cloud_api_scraper",
+                    # Explicit, content-independent identity per endpoint. The
+                    # shared swagger source_url cannot disambiguate endpoints, so
+                    # key on METHOD + templated path instead.
+                    "source_document_path": f"redis-cloud-api/{method.upper()} {path}",
                 },
             )
 

--- a/redis_sre_agent/pipelines/scraper/redis_docs_local.py
+++ b/redis_sre_agent/pipelines/scraper/redis_docs_local.py
@@ -190,6 +190,11 @@ class RedisDocsLocalScraper(BaseScraper):
                 "file_size": md_file.stat().st_size,
                 "version": version,
                 **metadata,
+                # Explicit relative-path identity (not the github-URL default):
+                # stable, content-independent, and consistent with how local
+                # documents are keyed elsewhere. Set after the frontmatter
+                # spread so it cannot be overridden by document metadata.
+                "source_document_path": str(rel_path),
             },
         )
 

--- a/tests/unit/pipelines/ingestion/test_ingestion_processor.py
+++ b/tests/unit/pipelines/ingestion/test_ingestion_processor.py
@@ -604,9 +604,12 @@ class TestIngestionPipeline:
                 json.dump(doc_data, f)
 
         mock_deduplicator = AsyncMock()
-        mock_deduplicator.replace_document_chunks.return_value = (
-            3  # Return number of chunks indexed
-        )
+        # These docs carry http source_urls, so they now route through the
+        # tracked branch (source_document_path defaulted from the URL).
+        mock_deduplicator.replace_source_document_chunks.return_value = {
+            "action": "add",
+            "indexed_count": 3,
+        }
 
         result = await pipeline._process_category(
             category_path,
@@ -748,9 +751,12 @@ class TestIngestionPipeline:
             json.dump({"incomplete": "data"}, f)
 
         mock_deduplicator = AsyncMock()
-        mock_deduplicator.replace_document_chunks.return_value = (
-            1  # Return number of chunks indexed
-        )
+        # The valid doc has an http source_url, so it routes through the tracked
+        # branch; the invalid doc fails before indexing regardless of branch.
+        mock_deduplicator.replace_source_document_chunks.return_value = {
+            "action": "add",
+            "indexed_count": 1,
+        }
 
         result = await pipeline._process_category(
             category_path,

--- a/tests/unit/pipelines/ingestion/test_ingestion_processor.py
+++ b/tests/unit/pipelines/ingestion/test_ingestion_processor.py
@@ -1052,7 +1052,9 @@ class TestIngestionPipeline:
                                     }
                                 ],
                                 "source_document_paths": ["shared/current.md"],
-                                "source_document_scopes": [""],
+                                # Real bounded scope authorizes deletion within shared/;
+                                # an empty scope must never authorize the sweep.
+                                "source_document_scopes": ["shared/"],
                                 "errors": [],
                             },
                         ):

--- a/tests/unit/pipelines/ingestion/test_ingestion_processor_additional.py
+++ b/tests/unit/pipelines/ingestion/test_ingestion_processor_additional.py
@@ -393,7 +393,12 @@ async def test_process_category_latest_only_and_error_paths(pipeline, tmp_path):
             path.write_text(content, encoding="utf-8")
 
     deduplicator = AsyncMock()
-    deduplicator.replace_document_chunks.return_value = 1
+    # The surviving 'keep.json' has an http source_url, so it routes through the
+    # tracked branch (source_document_path defaulted from the URL).
+    deduplicator.replace_source_document_chunks.return_value = {
+        "action": "add",
+        "indexed_count": 1,
+    }
     latest_only_pipeline = IngestionPipeline(pipeline.storage, {"latest_only": True})
 
     result = await latest_only_pipeline._process_category(
@@ -403,7 +408,7 @@ async def test_process_category_latest_only_and_error_paths(pipeline, tmp_path):
         {"knowledge": deduplicator},
     )
 
-    deduplicator.replace_document_chunks.assert_awaited_once()
+    deduplicator.replace_source_document_chunks.assert_awaited_once()
     assert result["documents_processed"] == 1
     assert len(result["errors"]) == 1
     assert "broken.json" in result["errors"][0]

--- a/tests/unit/pipelines/ingestion/test_ingestion_processor_additional.py
+++ b/tests/unit/pipelines/ingestion/test_ingestion_processor_additional.py
@@ -246,7 +246,7 @@ async def test_build_deduplicators_and_tracking_helpers(pipeline):
         {"deduplicator_key": "skill", "document_hash": "s-hash"},
     ]
     assert IngestionPipeline._path_in_scope("shared/doc.md", set()) is False
-    assert IngestionPipeline._path_in_scope("shared/doc.md", {""}) is True
+    assert IngestionPipeline._path_in_scope("shared/doc.md", {""}) is False
     assert IngestionPipeline._path_in_scope("shared/doc.md", {"enterprise/"}) is False
     assert IngestionPipeline._path_in_scope("shared/doc.md", {"shared/"}) is True
 
@@ -646,7 +646,11 @@ async def test_ingest_source_documents_paths(pipeline, tmp_path):
             side_effect=chunk_document_side_effect,
         ),
     ):
-        results = await pipeline.ingest_source_documents(source_dir.parent)
+        # Ingest the bounded "shared/" subtree so the run declares a real,
+        # non-empty scope. (Ingesting the source_documents root yields an empty
+        # scope, which no longer authorizes deletion — empty scope must never
+        # match-everything, or a partial/cross-source run would wipe the corpus.)
+        results = await pipeline.ingest_source_documents(source_dir)
 
     skill.delete_tracked_source_document.assert_awaited_once_with(
         "old-skill-hash", "shared/tracked.md"

--- a/tests/unit/pipelines/ingestion/test_source_path_collision.py
+++ b/tests/unit/pipelines/ingestion/test_source_path_collision.py
@@ -30,9 +30,15 @@ def _write_doc(path: Path, source_url: str, source_document_path=None) -> Path:
 
 
 def test_explicit_path_collision_is_detected_and_deduped(tmp_path):
-    a = _write_doc(tmp_path / "a.json", "https://x/a#one", source_document_path="redis-cloud-api/GET /foo")
-    b = _write_doc(tmp_path / "b.json", "https://x/b#two", source_document_path="redis-cloud-api/GET /foo")
-    c = _write_doc(tmp_path / "c.json", "https://x/c", source_document_path="redis-cloud-api/GET /bar")
+    a = _write_doc(
+        tmp_path / "a.json", "https://x/a#one", source_document_path="redis-cloud-api/GET /foo"
+    )
+    b = _write_doc(
+        tmp_path / "b.json", "https://x/b#two", source_document_path="redis-cloud-api/GET /foo"
+    )
+    c = _write_doc(
+        tmp_path / "c.json", "https://x/c", source_document_path="redis-cloud-api/GET /bar"
+    )
 
     files_to_process, collisions = detect_source_path_collisions([a, b, c])
 

--- a/tests/unit/pipelines/ingestion/test_source_path_collision.py
+++ b/tests/unit/pipelines/ingestion/test_source_path_collision.py
@@ -72,6 +72,21 @@ def test_untracked_docs_never_collide(tmp_path):
     assert collisions == {}
 
 
+def test_whitespace_only_difference_is_a_collision(tmp_path):
+    """Paths differing only by surrounding whitespace collide (tracking strips them)."""
+    a = _write_doc(
+        tmp_path / "a.json", "https://x/a", source_document_path="redis-cloud-api/GET /foo"
+    )
+    b = _write_doc(
+        tmp_path / "b.json", "https://x/b", source_document_path="  redis-cloud-api/GET /foo  "
+    )
+
+    files_to_process, collisions = detect_source_path_collisions([a, b])
+
+    assert len(files_to_process) == 1
+    assert "redis-cloud-api/GET /foo" in collisions
+
+
 def test_no_collision_passes_all_through(tmp_path):
     a = _write_doc(tmp_path / "a.json", "https://redis.io/docs/a")
     b = _write_doc(tmp_path / "b.json", "https://redis.io/docs/b")

--- a/tests/unit/pipelines/ingestion/test_source_path_collision.py
+++ b/tests/unit/pipelines/ingestion/test_source_path_collision.py
@@ -1,0 +1,76 @@
+"""Pre-indexing collision detection for source_document_path (A3)."""
+
+import json
+from pathlib import Path
+
+from redis_sre_agent.pipelines.ingestion._processor_impl import (
+    detect_source_path_collisions,
+)
+
+
+def _write_doc(path: Path, source_url: str, source_document_path=None) -> Path:
+    metadata = {}
+    if source_document_path is not None:
+        metadata["source_document_path"] = source_document_path
+    path.write_text(
+        json.dumps(
+            {
+                "title": path.stem,
+                "content": "c",
+                "source_url": source_url,
+                "category": "enterprise",
+                "doc_type": "reference",
+                "severity": "medium",
+                "metadata": metadata,
+            }
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_explicit_path_collision_is_detected_and_deduped(tmp_path):
+    a = _write_doc(tmp_path / "a.json", "https://x/a#one", source_document_path="redis-cloud-api/GET /foo")
+    b = _write_doc(tmp_path / "b.json", "https://x/b#two", source_document_path="redis-cloud-api/GET /foo")
+    c = _write_doc(tmp_path / "c.json", "https://x/c", source_document_path="redis-cloud-api/GET /bar")
+
+    files_to_process, collisions = detect_source_path_collisions([a, b, c])
+
+    # The colliding pair is reduced to a single indexed file; the unique one stays.
+    assert a in files_to_process and c in files_to_process
+    assert b not in files_to_process
+    assert "redis-cloud-api/GET /foo" in collisions
+    assert set(collisions["redis-cloud-api/GET /foo"]) == {a, b}
+    assert "redis-cloud-api/GET /bar" not in collisions
+
+
+def test_derived_path_collision_is_detected(tmp_path):
+    """Two URLs that normalize to the same path collide even without explicit metadata."""
+    a = _write_doc(tmp_path / "a.json", "https://redis.io/docs/foo")
+    b = _write_doc(tmp_path / "b.json", "https://redis.io/docs/foo/?utm=1")
+
+    files_to_process, collisions = detect_source_path_collisions([a, b])
+
+    assert len(files_to_process) == 1
+    assert "redis.io/docs/foo" in collisions
+
+
+def test_untracked_docs_never_collide(tmp_path):
+    """Empty effective paths (file:// / non-http) route to the untracked branch."""
+    a = _write_doc(tmp_path / "a.json", "file:///Users/x/a.md")
+    b = _write_doc(tmp_path / "b.json", "file:///Users/y/b.md")
+
+    files_to_process, collisions = detect_source_path_collisions([a, b])
+
+    assert set(files_to_process) == {a, b}
+    assert collisions == {}
+
+
+def test_no_collision_passes_all_through(tmp_path):
+    a = _write_doc(tmp_path / "a.json", "https://redis.io/docs/a")
+    b = _write_doc(tmp_path / "b.json", "https://redis.io/docs/b")
+
+    files_to_process, collisions = detect_source_path_collisions([a, b])
+
+    assert set(files_to_process) == {a, b}
+    assert collisions == {}

--- a/tests/unit/pipelines/ingestion/test_stale_sweep_empty_scope.py
+++ b/tests/unit/pipelines/ingestion/test_stale_sweep_empty_scope.py
@@ -1,0 +1,97 @@
+"""Safety: an empty/blank source_document_scope must NEVER authorize deletion.
+
+Regression guard for the empty-scope landmine: once documents are tracked
+(via source_document_path), a "" scope previously matched everything in
+`_path_in_scope`, so a *partial* ingest would hard-delete every tracked doc it
+did not re-emit. The sweep must treat "no declared scope" as "delete nothing".
+"""
+
+from unittest.mock import AsyncMock
+
+from redis_sre_agent.pipelines.ingestion.processor import IngestionPipeline
+from redis_sre_agent.pipelines.scraper.base import ArtifactStorage
+
+
+class TestPathInScope:
+    def test_empty_string_scope_does_not_match_everything(self):
+        # The landmine: {""} must NOT authorize deleting an arbitrary path.
+        assert IngestionPipeline._path_in_scope("redis.io/docs/x", {""}) is False
+
+    def test_no_scope_prefixes_matches_nothing(self):
+        assert IngestionPipeline._path_in_scope("anything", set()) is False
+
+    def test_only_blank_scopes_match_nothing(self):
+        assert IngestionPipeline._path_in_scope("anything", {"", "   "}) is False
+
+    def test_real_prefix_matches(self):
+        assert IngestionPipeline._path_in_scope("shared/x.md", {"shared/"}) is True
+
+    def test_real_prefix_non_match(self):
+        assert IngestionPipeline._path_in_scope("other/x.md", {"shared/"}) is False
+
+    def test_empty_alongside_real_prefix_ignores_empty(self):
+        # "" must be ignored, not widen the match to everything.
+        assert IngestionPipeline._path_in_scope("shared/x.md", {"", "shared/"}) is True
+        assert IngestionPipeline._path_in_scope("other/x.md", {"", "shared/"}) is False
+
+
+class TestStaleSweepEmptyScopeDeletesNothing:
+    async def test_partial_ingest_with_empty_scope_deletes_nothing(self, tmp_path):
+        """The exact landmine scenario: tracked docs, empty scope, partial run."""
+        pipe = IngestionPipeline(ArtifactStorage(tmp_path / "artifacts"))
+
+        tracked_by_path = {
+            "redis.io/docs/page-a": [
+                {"deduplicator_key": "knowledge", "document_hash": "aaaa", "title": "A"}
+            ],
+            "redis.io/docs/page-b": [
+                {"deduplicator_key": "knowledge", "document_hash": "bbbb", "title": "B"}
+            ],
+        }
+        deleted = []
+        dedup = AsyncMock()
+
+        async def _rec(doc_hash, path, **kw):
+            deleted.append(path)
+
+        dedup.delete_tracked_source_document.side_effect = _rec
+        deduplicators = {"knowledge": dedup}
+
+        # Partial run saw only page-a; scope is the real-world empty value.
+        result = await pipe._delete_stale_source_documents(
+            deduplicators,
+            tracked_by_path,
+            {"redis.io/docs/page-a"},
+            {""},
+        )
+
+        assert deleted == []  # nothing deleted despite page-b being "unseen"
+        assert result == []
+
+    async def test_real_scope_still_deletes_unseen_in_that_scope(self, tmp_path):
+        """The fix must not disable legitimate, bounded deletion."""
+        pipe = IngestionPipeline(ArtifactStorage(tmp_path / "artifacts"))
+        tracked_by_path = {
+            "shared/keep.md": [
+                {"deduplicator_key": "knowledge", "document_hash": "k", "title": "Keep"}
+            ],
+            "shared/gone.md": [
+                {"deduplicator_key": "knowledge", "document_hash": "g", "title": "Gone"}
+            ],
+        }
+        deleted = []
+        dedup = AsyncMock()
+
+        async def _rec(doc_hash, path, **kw):
+            deleted.append(path)
+
+        dedup.delete_tracked_source_document.side_effect = _rec
+
+        result = await pipe._delete_stale_source_documents(
+            {"knowledge": dedup},
+            tracked_by_path,
+            {"shared/keep.md"},  # gone.md not seen this run
+            {"shared/"},  # real, bounded scope
+        )
+        assert deleted == ["shared/gone.md"]
+        assert [d["path"] for d in result] == ["shared/gone.md"]

--- a/tests/unit/pipelines/scraper/test_cloud_api_source_path.py
+++ b/tests/unit/pipelines/scraper/test_cloud_api_source_path.py
@@ -1,0 +1,60 @@
+"""Cloud API scraper assigns explicit, collision-free source_document_path values."""
+
+from redis_sre_agent.pipelines.scraper.base import ArtifactStorage
+from redis_sre_agent.pipelines.scraper.redis_cloud_api import RedisCloudAPIScraper
+
+SWAGGER = {
+    "info": {"title": "Redis Cloud API", "version": "v1", "description": "x"},
+    "host": "api.redislabs.com",
+    "basePath": "/v1",
+    "paths": {
+        "/subscriptions": {
+            "get": {"operationId": "getSubs", "summary": "List subscriptions"},
+            "post": {"operationId": "createSub", "summary": "Create subscription"},
+        },
+        "/subscriptions/{id}": {
+            "get": {"operationId": "getSub", "summary": "Get subscription"},
+            "delete": {"operationId": "deleteSub", "summary": "Delete subscription"},
+        },
+    },
+}
+
+
+def _scraper(tmp_path):
+    return RedisCloudAPIScraper(ArtifactStorage(tmp_path / "artifacts"))
+
+
+def test_endpoint_path_is_method_and_template(tmp_path):
+    scraper = _scraper(tmp_path)
+    doc = scraper._create_endpoint_document(
+        "/subscriptions/{id}", "get", SWAGGER["paths"]["/subscriptions/{id}"]["get"], SWAGGER
+    )
+    assert doc.metadata["source_document_path"] == "redis-cloud-api/GET /subscriptions/{id}"
+
+
+def test_endpoints_sharing_swagger_url_do_not_collide(tmp_path):
+    scraper = _scraper(tmp_path)
+    docs = []
+    for path, methods in SWAGGER["paths"].items():
+        for method, operation in methods.items():
+            docs.append(scraper._create_endpoint_document(path, method, operation, SWAGGER))
+
+    paths = [d.metadata["source_document_path"] for d in docs]
+    # All endpoints share the same swagger source_url; identities must be distinct.
+    assert len(paths) == 4
+    assert len(set(paths)) == 4
+    # And none of them collapsed onto the swagger URL host (the default would have).
+    assert all(p.startswith("redis-cloud-api/") for p in paths)
+
+
+def test_endpoint_identity_is_content_independent(tmp_path):
+    scraper = _scraper(tmp_path)
+    op = dict(SWAGGER["paths"]["/subscriptions"]["get"])
+    doc_a = scraper._create_endpoint_document("/subscriptions", "get", op, SWAGGER)
+    op2 = dict(op, summary="A completely different summary")
+    doc_b = scraper._create_endpoint_document("/subscriptions", "get", op2, SWAGGER)
+    assert (
+        doc_a.metadata["source_document_path"]
+        == doc_b.metadata["source_document_path"]
+        == "redis-cloud-api/GET /subscriptions"
+    )

--- a/tests/unit/pipelines/scraper/test_derive_stable_path.py
+++ b/tests/unit/pipelines/scraper/test_derive_stable_path.py
@@ -1,0 +1,137 @@
+"""Tests for derive_stable_path and the ScrapedDocument source_document_path default.
+
+derive_stable_path is the frozen, content-independent logical identity used to
+route scraped documents through the tracked dedup branch (replace-on-change).
+Changing its contract re-keys the entire corpus, so these tests pin the contract.
+"""
+
+import pytest
+
+from redis_sre_agent.pipelines.scraper.base import (
+    DocumentCategory,
+    DocumentType,
+    ScrapedDocument,
+    derive_stable_path,
+)
+
+
+class TestDeriveStablePath:
+    @pytest.mark.parametrize(
+        "source_url,expected",
+        [
+            # scheme stripped, host lowercased, query+fragment dropped, trailing slash stripped
+            ("HTTPS://Redis.IO/docs/foo/index.html?x=1#y", "redis.io/docs/foo/index.html"),
+            ("https://redis.io/docs/foo/", "redis.io/docs/foo"),
+            ("https://redis.io/docs/foo", "redis.io/docs/foo"),
+            ("http://redis.io/docs/foo", "redis.io/docs/foo"),
+            ("https://Redis.io/", "redis.io"),
+            ("https://redis.io", "redis.io"),
+            # query/fragment only
+            ("https://redis.io/a?b=c", "redis.io/a"),
+            ("https://redis.io/a#frag", "redis.io/a"),
+            # non-http(s) and empty -> "" (route to untracked branch; never machine-specific)
+            ("file:///Users/someone/repo/source_documents/shared/foo.md", ""),
+            ("mailto:someone@example.com", ""),
+            ("ftp://redis.io/x", ""),
+            ("", ""),
+            ("operate/rs/foo.md", ""),  # relative / unparseable -> no scheme
+        ],
+    )
+    def test_contract_table(self, source_url, expected):
+        assert derive_stable_path(source_url) == expected
+
+    def test_deterministic(self):
+        url = "https://redis.io/docs/Foo/Bar"
+        assert derive_stable_path(url) == derive_stable_path(url)
+
+    def test_cosmetic_variations_collapse_together(self):
+        """Same logical page via case / trailing slash / query must map to one identity."""
+        canonical = derive_stable_path("https://redis.io/docs/foo")
+        assert derive_stable_path("https://REDIS.io/docs/foo/") == canonical
+        assert derive_stable_path("https://redis.io/docs/foo?utm=1") == canonical
+        assert derive_stable_path("https://redis.io/docs/foo#section") == canonical
+
+    def test_does_not_fold_index_html(self):
+        """index.html is intentionally NOT folded (folding can manufacture collisions)."""
+        assert derive_stable_path("https://redis.io/docs/foo/index.html") != derive_stable_path(
+            "https://redis.io/docs/foo/"
+        )
+
+    def test_path_is_content_independent(self):
+        """The identity depends only on the URL, never on title/content."""
+        a = ScrapedDocument(
+            title="One",
+            content="alpha",
+            source_url="https://redis.io/docs/page",
+            category=DocumentCategory.OSS,
+            doc_type=DocumentType.DOCUMENTATION,
+        )
+        b = ScrapedDocument(
+            title="Two — totally different",
+            content="omega omega omega",
+            source_url="https://redis.io/docs/page",
+            category=DocumentCategory.OSS,
+            doc_type=DocumentType.DOCUMENTATION,
+        )
+        assert (
+            a.metadata["source_document_path"]
+            == b.metadata["source_document_path"]
+            == "redis.io/docs/page"
+        )
+        assert a.content_hash != b.content_hash  # content changed, identity did not
+
+
+class TestScrapedDocumentDefault:
+    def _doc(self, source_url, metadata=None):
+        return ScrapedDocument(
+            title="t",
+            content="c",
+            source_url=source_url,
+            category=DocumentCategory.OSS,
+            doc_type=DocumentType.DOCUMENTATION,
+            metadata=metadata,
+        )
+
+    def test_default_populated_for_http(self):
+        doc = self._doc("https://redis.io/docs/x")
+        assert doc.metadata["source_document_path"] == "redis.io/docs/x"
+
+    def test_default_empty_for_file_scheme(self):
+        """A file:// URL must NOT become a machine-specific identity (A2).
+
+        The default adds no key when derivation is empty, so downstream
+        (which reads ``.get(...) or ""``) routes the doc to the untracked
+        branch — identical to pre-change behavior.
+        """
+        doc = self._doc("file:///Users/me/checkout/source_documents/shared/x.md")
+        assert doc.metadata.get("source_document_path", "") == ""
+
+    def test_explicit_path_not_overwritten(self):
+        doc = self._doc(
+            "https://redis.io/docs/x",
+            metadata={"source_document_path": "redis-cloud-api/GET /foo"},
+        )
+        assert doc.metadata["source_document_path"] == "redis-cloud-api/GET /foo"
+
+    def test_explicit_empty_string_not_overwritten_when_url_nonhttp(self):
+        doc = self._doc("file://x", metadata={"source_document_path": ""})
+        assert doc.metadata["source_document_path"] == ""
+
+    def test_from_dict_synthesizes_for_legacy_http_artifact(self):
+        """Reingesting a legacy artifact (no source_document_path) auto-migrates http docs."""
+        legacy = {
+            "title": "t",
+            "content": "c",
+            "source_url": "https://redis.io/docs/legacy",
+            "category": "oss",
+            "doc_type": "documentation",
+            "severity": "medium",
+            "metadata": {},  # legacy artifact had no source_document_path
+        }
+        doc = ScrapedDocument.from_dict(legacy)
+        assert doc.metadata["source_document_path"] == "redis.io/docs/legacy"
+
+    def test_to_dict_from_dict_roundtrip_preserves_path(self):
+        doc = self._doc("https://redis.io/docs/x")
+        restored = ScrapedDocument.from_dict(doc.to_dict())
+        assert restored.metadata["source_document_path"] == "redis.io/docs/x"

--- a/tests/unit/pipelines/scraper/test_redis_docs_local.py
+++ b/tests/unit/pipelines/scraper/test_redis_docs_local.py
@@ -28,6 +28,24 @@ def test_extract_version_from_rel_path(tmp_path):
     )
 
 
+def test_source_document_path_is_relative_not_github_url(tmp_path):
+    """Local mirror keys docs by their relative path, not the github-URL default."""
+    docs_repo = tmp_path / "redis-docs"
+    content_dir = docs_repo / "content"
+    md = content_dir / "operate/rs/clustering.md"
+    _write_markdown(md, "Clustering")
+
+    storage = ArtifactStorage(tmp_path / "artifacts")
+    scraper = RedisDocsLocalScraper(storage, config={"docs_repo_path": str(docs_repo)})
+
+    doc = scraper._process_markdown_file(md, content_dir)
+
+    assert doc.metadata["source_document_path"] == "operate/rs/clustering.md"
+    # The github blob URL remains the human-facing source, but is NOT the identity.
+    assert doc.source_url.startswith("https://github.com/redis/docs/blob/")
+    assert "github.com" not in doc.metadata["source_document_path"]
+
+
 @pytest.mark.asyncio
 async def test_scrape_sets_version_metadata_from_path(tmp_path):
     """Test scraped docs include normalized version metadata."""


### PR DESCRIPTION
## Problem

Web- and API-scraped documents were ingested without a stable `source_document_path`, so reingestion took the *untracked* dedup branch (`replace_document_chunks`), keyed only on the new content hash. Because chunk keys embed a content-derived hash (`sha256(title||content||source_url)`), any content change produced a brand-new key set and the **old chunks were never deleted** — silent accumulation of stale, still-searchable versions. On the live index this showed as knowledge chunks with **0** source-tracking pointers (nothing was tracked for replace-on-change).

While fixing this, we also found a latent data-loss path: the stale-delete sweep treated an empty `source_document_scope` (`""`) as **match-everything**. No scraper sets a scope, so once documents became tracked, a partial or cross-source ingest could hard-`DEL` every tracked doc it didn't re-emit (deletion is irreversible).

## Fix

- Added `derive_stable_path(source_url)` — a standalone, content-independent identity (strip scheme, lowercase host, drop query/fragment, trailing slash; returns `""` for non-`http(s)`/empty so it never yields a machine-specific path).
- `ScrapedDocument.__init__` defaults `source_document_path` from the URL when unset; the Cloud API scraper sets explicit per-endpoint identities (`redis-cloud-api/{METHOD} {path}`); the local docs mirror uses its relative path. This routes scraped docs through the **tracked** branch (`replace_source_document_chunks`), which deletes the prior version before writing the new one. No changes to `deduplication.py`.
- Added a pre-indexing collision guard so two docs resolving to the same `source_document_path` can't silently clobber each other.
- Safety: `_path_in_scope` now ignores empty/blank scopes — the stale sweep can only delete within an explicitly declared, non-empty scope.

## How to test

```bash
# 1. Bring up the stack (agent Redis on :7843)
make local-services

# 2. Sync local docs + scrape + ingest (full pipeline)
make redis-docs-sync
uv run redis-sre-agent pipeline full --scrapers redis_docs_local --latest-only --docs-path ./redis-docs

# 3. View chunks + source pointers — pointers should now be > 0 (was 0 before this PR)
docker compose exec redis redis-cli --scan --pattern 'sre_knowledge:*:chunk:*' | wc -l         # N chunks
docker compose exec redis redis-cli --scan --pattern 'sre_knowledge_meta:source:*' | wc -l      # one per doc

# 4. Re-ingest the same batch (replace-on-change path)
uv run redis-sre-agent pipeline ingest --batch-date "$(date +%Y-%m-%d)" --latest-only

# 5. View chunks again — count is UNCHANGED (no orphans); deleted=0 in the summary.
docker compose exec redis redis-cli --scan --pattern 'sre_knowledge:*:chunk:*' | wc -l         # same N
```

Before this PR, step 5's chunk count would grow on any content change (old versions orphaned) and step 3's pointer count was 0. After it, the count is stable and every document is tracked.

`make test` and `make test-eval-pr` pass (one unrelated pre-existing `test_cluster_helpers` failure aside).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes ingestion identity, dedup routing, and stale-delete scope rules; a wrong `derive_stable_path` contract would re-key the corpus or leave orphans, and scope bugs can cause irreversible deletions.
> 
> **Overview**
> Routes scraped web/API docs through **tracked** replace-on-change indexing by assigning a stable `source_document_path`, so re-ingest deletes prior chunks instead of orphaning content-hash-keyed copies.
> 
> Adds `derive_stable_path` for http(s) URLs and defaults it in `ScrapedDocument` when metadata is unset; **Redis Cloud API** and **local docs** scrapers set explicit per-endpoint or relative-path identities to avoid collisions. A **pre-index collision guard** keeps the first file per path and logs errors for duplicates.
> 
> **Safety:** `_path_in_scope` no longer treats empty `source_document_scope` as match-everything, preventing partial ingests from sweeping unrelated tracked documents. Unit tests cover derivation, collisions, empty scope, and scraper paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4dc4b5d1236096accd924e75778a98c7d584714. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->