### PR TITLE
Add semantic answer cache (LangCache) for the knowledge agent

### DIFF
--- a/docs/design/semantic-cache-knowledge-agent.md
+++ b/docs/design/semantic-cache-knowledge-agent.md
@@ -1,0 +1,300 @@
+# Design: Semantic Answer Cache (LangCache) for the Knowledge Agent
+
+**Status:** Draft for review (revised after consensus review) · **Scope:** knowledge-only agent (`process_query`, `redis_sre_agent/agent/knowledge_agent.py:514`) · **Code changes:** none yet (design only)
+**Backend:** Redis **LangCache** (managed) + the project's existing Redis
+**Supersedes:** the prior redisvl `SemanticCache` draft.
+
+> **Revision note:** A Planner→Architect→Critic consensus review verified this doc against the codebase and the LangCache API spec (`redis-docs/.../langcache/api-reference/api.yaml`). This revision corrects the grounding defects it found: the `source_document_path` join-key gap, the fictional `process_query(version)` signature, the false "feedback eviction already implemented" claim, the nonexistent `is_case_specific`/PII router, the sliding-TTL contradiction, and the unverified "filter-before-similarity" guarantee. Items that depend on unbuilt work are now in **§0 Prerequisites**; unverified vendor behavior is in **§P Open spikes**.
+
+---
+
+## 0. Prerequisites & small pre-work
+
+**`source_document_path` is implemented** (verified). It is written to the document hash at ingestion (`document_processor.py:165`) and drives the existing source-tracking / `path_hash` machinery (`deduplication.py:64-66`, keyed `sre_knowledge_meta:source:{path_hash}` in `core/keys.py`). The `.omc/specs/deep-interview-source-document-path.md` spec is **completed work that simply hasn't been deleted — not a blocker.**
+
+One small cache-side change remains so the field reaches the agent at query time:
+
+1. **Add `source_document_path` to `_SEARCH_RETURN_FIELDS`** (`core/knowledge_helpers.py:42`) and include it in the serialized search-result dict (`:1419`). RediSearch `RETURN` can return a hash field that is **not** in the index schema, so **no schema change and no re-index are required** — the field already exists on the hashes. (Confirm the live corpus was ingested after the feature landed; re-ingest only any docs that predate it.)
+
+Once that lands, `path_hash = sha256(source_document_path)[:16]` is computable from `state["knowledge_search_results"]` (`knowledge_agent.py:410`) and the reverse index (§C.2/§G) works.
+
+**Version (fully supported — not a blocker).** The schema has a `version` field (`core/redis.py` `_build_document_schema`) and search filters on it (`_tag_equals_expression("version", version)` at `knowledge_helpers.py:333`, plus `_doc_matches_requested_version` at `:164`). v1 caches **both `latest` and pinned versions** (`7.8`, `7.4`, …). Storing a `version` attribute on the cache entry is trivial. The only design point: the cache lookup runs at the *top* of `process_query`, before retrieval, so the **request version is resolved at lookup time** — extract it from the query (the repo already has version helpers like `_extract_version_from_source`; a query-text version detector is a small add) and default to `latest`.
+
+---
+
+## A. Executive summary
+
+Put a single, global, flag-gated **semantic answer cache** in front of the knowledge agent. On a sufficiently-similar prior question it returns the previously synthesized answer and **short-circuits the entire LangGraph run** — skipping the LLM loop, the tools, and the forced turn-0 `knowledge_search` (`tool_choice="required"` at `knowledge_agent.py:248-249`).
+
+- **Backend is managed LangCache** — it owns embeddings, the vector index, similarity search, store-time TTL, and scalar attribute filters. Fan-out (one document → many entries) and rich provenance live in **our own Redis**.
+- **Provenance-based push invalidation** keyed on `source_document_path` (via a `path_hash` reverse index we maintain). Requires §0.
+- **Lookup via LangCache native `searchStrategies`** (`exact` then `semantic`) plus mid-conversation query rewriting; not a hand-rolled two-stage scheme (see §D).
+- **Tickets, skills, and docs are all cacheable.** There is **no tenant/user authorization model** today, so a global cache has no cross-tenant leak vector (§K). The only hard write exclusion is *ungrounded* answers.
+- **Identifier queries are scoped by an `entity_id` attribute** with a **post-filter safety net** (correct regardless of LangCache's internal filter ordering).
+- **Fixed store-time TTL** (no sliding/refresh-on-hit — LangCache exposes no read-extend op). Correctness comes from push invalidation; TTL is a bounded backstop.
+- **Async write** — fire-and-forget after the response returns; never adds user-facing latency. A tombstone recheck guards the write-vs-invalidate race (§H).
+
+Ships **default-OFF** behind `semantic_cache_enabled`, after §0, validated on the live local stack and the eval harness.
+
+---
+
+## B. Architecture: where things live
+
+```
+┌─────────────────────────── LangCache (managed) ───────────────────────────┐
+│  one entry per stored answer                                                │
+│  • prompt          canonical/rewritten question  (LangCache embeds this)    │
+│  • response        answer + inline source citations (JSON string)           │
+│  • attributes      version · cache_origin · entity_id   (≤ 5 attrs allowed) │
+│  • ttlMillis       fixed at store time (short for latest)                   │
+│  • entry_id        returned by the set call                                 │
+└─────────────────────────────────────────────────────────────────────────┘
+              │ entry_id                          ▲ path_hash → entry_ids
+              ▼                                    │
+┌──────────────────────── Our Redis (existing instance) ────────────────────┐
+│  cache_prov:{path_hash}   →  SET of entry_ids     (reverse index)          │
+│  cache_meta:{entry_id}    →  JSON  (full provenance + audit, debug only)   │
+│  cache_inval:{path_hash}  →  short-TTL tombstone  (write-vs-invalidate)    │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+`ToolCache` (exact-match memoization of individual tool calls within a run) is unchanged and complementary; the semantic cache sits above the graph and is checked first.
+
+**Invalidation primitives (verified in `api.yaml`):** LangCache supports `DELETE /entries/{entryId}` (`:243`), `deleteQuery` by attributes (`:168`), and `flush` (`:316`) — so per-entry, coarse, and full clears are all available.
+
+---
+
+## C. Data model
+
+### C.1 LangCache entry
+
+**Core:** `prompt` (canonical/rewritten question, embedded by LangCache), `response` (answer + source citations as JSON), `entry_id` (returned by the set call), `ttlMillis` (fixed at store time).
+
+**Attributes** (declared at cache creation, immutable; **max 5**, names `^[a-zA-Z0-9_-]{1,32}$`, values no-comma and ≤500 chars — `api.yaml:489-499`):
+
+| Attribute | Example | Role |
+|---|---|---|
+| `version` | `latest` / `7.8` | lookup filter — request version resolved from the query (§0); v1 caches latest + pinned. |
+| `cache_origin` | `dynamic` / `curated` | generated vs pre-warmed (warming is Phase 2). Declared now to avoid a rebuild. |
+| `entity_id` | `RET-4421` | exact identifier scope for identifier queries (§I). |
+
+3 of 5 attributes used; values must be comma-free (ticket IDs qualify). **Removed:** `embedding_model_version` (LangCache-managed), `source_ids` (→ reverse index — LangCache has no multi-value/`contains` filter), `index_origin` (reverse index does fine-grained invalidation strictly better; content-type observability comes from `cache_meta.provenance[].index`).
+
+### C.2 Reverse index (invalidation)
+
+```
+cache_prov:{path_hash}  →  SET { entry_id, … }
+```
+`path_hash = sha256(source_document_path)[:16]` — the **same hash ingestion uses** (`deduplication.py:66`, `knowledge_pack/loader.py:208`, keyed `sre_knowledge_meta:source:{path_hash}` in `core/keys.py`), so the invalidation signal and the cache speak one identifier with no translation. Written `SADD cache_prov:{path_hash} {entry_id}` per cited doc; read `SMEMBERS → DELETE /entries/{entry_id}` on change. **Depends on §0** (source_document_path must reach `knowledge_search_results`).
+
+### C.3 Side metadata (debug / audit)
+
+`cache_meta:{entry_id}` → JSON: `provenance[]` (`source_document_path`, `path_hash`, `index`, `title`, `doc_version`, `document_hash`, `chunk_indices`), plus `original_question`, `rewritten_question`, `tools_invoked`, `version`, `model`, `generated_at` (also answers "how long cached?"), `thread_id`, `num_sources`. Not on the serve path (sources for serving ride in the `response`).
+
+### C.4 Relationships
+
+`cache_meta.provenance[]` is the source of truth; `cache_prov` sets, `entity_id`, and `version` are projections computed at store time. **Three structures, three jobs:** LangCache = match + serve; reverse index = invalidate; side-blob = debug/audit.
+
+---
+
+## D. Read / lookup path
+
+```mermaid
+flowchart TD
+    A["Query arrives — process_query(query, session_id, user_id, context, …)"] --> B{"semantic_cache_enabled?"}
+    B -->|no| Z["Run full agent graph (miss path)"]
+    B -->|yes| C{"identifier query?<br/>(ticket-ID extractor)"}
+    C -->|yes| D["Extract entity_id → filter = entity_id + version"]
+    C -->|no| E["filter = version (resolved from query, default latest)"]
+    D --> G["First-turn? use raw query.<br/>Mid-conversation? rewrite → standalone (nano)"]
+    E --> G
+    G --> H["LangCache search<br/>searchStrategies:[exact, semantic]<br/>attributes filter · similarity ≥ 0.9 · num_results=1"]
+    H --> I{"LangCache / Redis error?"}
+    I -->|"yes → fail open + log"| Z
+    I -->|no| J{"Candidate hit ≥ 0.9?"}
+    J -->|no| Z
+    J -->|yes| PF{"Post-filter: returned entity_id == requested?<br/>(safety net, ordering-independent)"}
+    PF -->|"no → reject"| Z
+    PF -->|yes| SERVE["Serve cached answer"]
+    SERVE --> P["Reconstruct sources from response payload"]
+    P --> R["Emit metrics: cache_exact / cache_semantic · similarity · entity_id"]
+    R --> S["Return AgentResponse — short-circuit (skip LLM + tools + turn-0 search)"]
+```
+
+**Notes:**
+
+1. **Native `searchStrategies`.** LangCache accepts an ordered strategy array `[exact, semantic]` (`api.yaml:421-425,544-551`) in a single call — exact-match first, semantic fallback. We use that instead of a hand-rolled two-stage scheme. Verbatim repeats resolve via the `exact` strategy; paraphrases via `semantic`.
+2. **Rewriting is mid-conversation only.** First-turn queries use the raw text (no rewrite); mid-conversation queries are rewritten to standalone form via `nano` (§F). The rewrite is reused as the store key on a miss. (Note: `exact` strategy matches a *first-turn* raw repeat against a first-turn stored key; a mid-conversation repeat relies on `semantic` against the stored rewritten key.)
+3. **`version` filter** — the request version is resolved from the query at lookup time (default `latest`); both `latest` and pinned versions (`7.8`, …) are cached and filtered (§0).
+4. **Post-filter safety net.** After a candidate hit, verify the returned entry's `entity_id` equals the requested one before serving (treat mismatch as a miss). This makes identifier safety hold **regardless of whether LangCache pre- or post-filters** — see §P.
+5. **Threshold 0.9** (LangCache *similarity*, higher = stricter). Re-validate on LangCache's embedding model.
+6. **Fail open with logging** — any error → miss → full graph; structured log (never the raw prompt) + `cache_error_fallthrough` metric.
+7. **Trust-on-read freshness** — push invalidation (§G) prunes stale entries; the fixed TTL bounds the residual window (incl. the write-vs-invalidate race, §H).
+8. **No TTL refresh on hit** — LangCache has no read-extend op (§P); TTL is fixed at store time.
+
+---
+
+## E. TTL (fixed, no sliding window)
+
+LangCache `ttlMillis` is set **at store time only**; there is no read-extend/refresh operation (`api.yaml` — verified). So TTL is **fixed and absolute**, not a sliding window:
+
+- **`version="latest"`** → **short TTL** (e.g. 1h) — `latest` is a moving pointer; this bounds the in-flight-ingest + write-vs-invalidate-race window.
+- **pinned versions** (`7.8`, `7.4`, …) → **longer TTL** (e.g. 24h) — content is stable.
+
+TTL is a backstop only; correctness comes from push invalidation. A hard absolute max-age beyond this is unnecessary because TTL is already absolute. (The earlier "sliding window refreshed on hit" idea was dropped: faking it via re-store would mint a new `entry_id` and orphan the reverse index, making hot stale entries un-invalidatable.)
+
+---
+
+## F. Query rewriting (contextualization)
+
+Contextualization — resolving a context-dependent question into standalone form — not paraphrase-matching (LangCache handles paraphrases semantically).
+
+- **Model:** `openai_model_nano` (cheapest tier; `create_nano_llm` / `nano` tier, `llm_helpers.py:247,409,433`; `config.py:340`).
+- **When:** mid-conversation only; first-turn skips it (zero LLM cost on the common path). Computed once, reused as the store key.
+- **Must-keep tokens (preserve verbatim, never paraphrase):** versions (`7.8`, `latest`), config directives (`maxmemory`, `maxmemory-policy`, `appendonly`), commands (`CONFIG SET`, `BGREWRITEAOF`), error/log tokens (`MISCONF`, `OOM`), metric names, identifiers, paths, flags, quoted strings.
+- **Hard rule:** never introduce a version/environment/edition the user didn't state (a hallucinated version → silent wrong-version entry).
+- **Fallback:** already self-contained → unchanged; insufficient context → append terms or skip caching this turn.
+
+---
+
+## G. Invalidation
+
+**Primary — push, per-document (surgical).** At ingestion job completion, for each document **replaced or removed** (the dedup layer distinguishes this from a pure add — `deduplication.py:518-572`), emit its `path_hash` → `SMEMBERS cache_prov:{path_hash}` → `DELETE /entries/{entry_id}` each → clean the set, and write a short-TTL tombstone `cache_inval:{path_hash}` (for the write race, §H). Covers docs, runbooks, skills, tickets uniformly; automatically version-correct (the `7.8` and `latest` paths hash differently). **Depends on §0.**
+
+- **Pure adds do not invalidate.** A manual clear lever stays for "make new content live now."
+- **Coarse / break-glass:** `deleteQuery` by attribute (e.g. `entity_id` for a single changed ticket); `flush` for a full clear (all API-supported).
+- **TTL** is the passive backstop (§E).
+- **Feedback-driven eviction is Phase 2** (§J) — not in v1. (The feedback signal exists at `core/feedback.py`, but no cache eviction is wired, and the cache doesn't exist yet.)
+
+---
+
+## H. Write / miss path
+
+```mermaid
+flowchart TD
+    START["Cache miss"] --> LOOP["Run full agent graph"]
+    LOOP --> ERR{"Valid grounded answer?"}
+    ERR -->|"no / error"| RESPERR["Return to user · NO write"]
+    ERR -->|yes| RESP["Return AgentResponse to user IMMEDIATELY"]
+    RESP --> ASYNC["⎇ Fire-and-forget background task"]
+    ASYNC --> GATE{"decide_cacheability()"}
+    GATE -->|"ungrounded (empty knowledge_search_results)"| SKIP["do_not_cache → no-op + emit reason"]
+    GATE -->|"grounded"| TOMB{"any cited path_hash has a fresh<br/>cache_inval tombstone?"}
+    TOMB -->|"yes → content just changed"| SKIP
+    TOMB -->|no| PROV["Build provenance[] from knowledge_search_results"]
+    PROV --> KEY["Canonical key = rewritten form (mid-conv) else raw"]
+    KEY --> STORE["set(prompt=key, response=answer+sources, attributes={version, cache_origin=dynamic, entity_id?}, ttlMillis) → entry_id"]
+    STORE --> RINDEX["SADD cache_prov:{path_hash} entry_id (per cited doc)"]
+    RINDEX --> RECHECK{"tombstone appeared during write?"}
+    RECHECK -->|yes| UNDO["DELETE /entries/{entry_id} + clean sets"]
+    RECHECK -->|no| META["SET cache_meta:{entry_id} = provenance + audit"]
+    META --> OBS["Emit metrics: store · cacheable · num_sources"]
+```
+
+**Notes:**
+
+1. **Error/ungrounded → no write.** Only successful **grounded** answers are stored. Ungrounded (empty `knowledge_search_results`) is the **only** hard exclusion — verified as a valid signal (`knowledge_agent.py:410`).
+2. **Async, fire-and-forget.** Returns before writing; fails silently + logs (`cache_store_error`).
+3. **Write-vs-invalidate race mitigation.** Invalidation writes a short-TTL `cache_inval:{path_hash}` tombstone. The write checks for a fresh tombstone **before** storing (skip if the content just changed) and **rechecks after** `SADD` (undo if a tombstone appeared during the write window). This closes the race the async write would otherwise open; residual exposure is bounded by the TTL regardless.
+4. **`entity_id` extraction is NET-NEW work** — see §I; the existing predicates are inadequate.
+5. **Canonical-key invariant** — store under the same form the lookup uses.
+
+---
+
+## I. Identifier handling (`entity_id`)
+
+Identifier queries need an **exact** identifier match (`RET-4421` ≠ `RET-4422`) but **paraphrase** reuse for the same ID. Approach: semantic match **scoped by an `entity_id` attribute filter**, plus a **post-filter safety net** (§D note 4) so correctness does not depend on LangCache's internal filter ordering (§P).
+
+**The only entity type for this cache is the support-ticket ID.** Instance/cluster IDs are a diagnostic-agent (live-targeting) concept and are **not extracted anywhere in the knowledge path** (no instance/cluster patterns in `knowledge_helpers.py` or `knowledge_agent.py`) — so they are **out of scope** for the knowledge cache. Add a typed pattern later only if knowledge queries are found to carry them.
+
+**Why extraction is net-new (can't reuse the existing gate).** The only identifier detector is `_looks_like_support_ticket_identifier` (`knowledge_helpers.py:833`), which is **shape-only**: no spaces, matches the catch-all `_SUPPORT_TICKET_ID_RE` (`^[A-Za-z0-9][A-Za-z0-9._:-]{1,127}$`), and contains a digit. That shape cannot distinguish a version from a ticket ID, so `7.8` is classified as an identifier (verified). Reusing it would write `7.8` into `entity_id` — wrong, because **version is a separate axis** (the `version` lookup filter, not an entity).
+
+**v1 extraction = three pieces, version-first precedence:**
+
+1. **Query-text version detector (new).** Match version mentions in the query — `7.8`, `v7.8`, "version 7.2", "in 7.4" — and route them to the **`version` attribute** (§0). (`_SOURCE_VERSION_RE = /(\d+\.\d+)/` only reads version from doc *source paths* today, not query text, so this is new.) These tokens are **claimed by the version axis and removed from entity consideration.**
+2. **Tight ticket-ID pattern (new).** Replace the catch-all regex with the real ticket format (e.g. `[A-Z]{2,}-\d+` → `RET-4421`) → `entity_id`. This alone excludes `7.8`, `maxmemory`, `OOM`, and any bare digit-bearing token.
+3. **Precedence rule.** Version is matched first; a token becomes `entity_id` **only if** it matches the specific ticket-ID format **and** is not a version. Non-identifier queries take the general semantic path (no `entity_id` filter; version filter only).
+
+No PII detection exists and none is required (no authz/privacy model today, §K) — there is no PII `do_not_cache` gate in v1.
+
+---
+
+## J. Deferred to Phase 2 / later
+
+- **Feedback-driven eviction** — wire `evict_cache(query)` into the existing `core/feedback.py` signal. Net-new; not v1.
+- **Multi-version support** — plumb a per-query `version` into `process_query` (it has none today); then activate per-version filtering + latest-vs-pinned TTL tiering.
+- **Curated warming / pre-warm** — **Phase 2, not designed yet.** Only v1 obligation: `cache_origin` declared up front so warming needs no rebuild.
+- **Multi-entity queries** — one holistic answer can't be represented by a single-valued `entity_id`. v1: not served, not stored. Phase 2: decompose into per-entity sub-queries + partial-hit synthesis.
+- **Concurrent first-askers (stampede)** — two simultaneous misses both run the loop and store. v1: accept (cost, not correctness). Phase 2: single-flight lock (`SET cache_lock:{prompt_hash} NX EX 30`) with run-anyway fallback.
+- **Multi-value `entity_id`** — blocked on both LangCache multi-value support (unconfirmed) and the no-comma value rule. Until then, decomposition handles multi-entity.
+- **Chunk-level invalidation** — finer than per-document; `chunk_content_hashes` captured in `cache_meta` from day one so it's a pure add later.
+
+---
+
+## K. Configuration & authorization
+
+Env-agnostic single config set (deploy injects per-environment values); fits the project's pydantic-settings style (no env prefix, `SecretStr` for secrets — `config.py:263,284`):
+
+```python
+semantic_cache_enabled: bool = Field(default=False)              # default OFF (and gated on §0)
+semantic_cache_similarity_threshold: float = Field(default=0.9)  # LangCache similarity
+semantic_cache_ttl_latest_ms: int = Field(default=60 * 60 * 1000)        # 1h (v1 default)
+semantic_cache_ttl_pinned_ms: int = Field(default=24 * 60 * 60 * 1000)   # 24h (multi-version, later)
+langcache_api_url: str = Field(...)
+langcache_cache_id: SecretStr = Field(...)
+langcache_api_key: SecretStr = Field(...)
+langcache_server_url: str = Field(default="https://aws-us-east-1.langcache.redis.io")
+```
+
+**Authorization:** there is **no tenant/user/role authorization model** in the knowledge path today. A global, ACL-free answer cache therefore has **no cross-tenant leak vector** — tickets and skills are cacheable globally. If an authz/tenancy model is ever introduced, this design must be revisited (a per-tenant scope or a separate cache).
+
+**Ops prerequisites:** create the attributes (`version`, `cache_origin`, `entity_id`) on each LangCache service **before first deploy** (immutable after creation); confirm the 5-attribute / no-comma-value constraints.
+
+---
+
+## L. Observability & kill switch
+
+- **Tiered metrics:** `cache_exact`, `cache_semantic`, `cache_miss`; store rate, `do_not_cache` reason counts, tokens/latency saved, `cache_error_fallthrough`, `cache_store_error`, post-filter-reject count.
+- **Content-type mix** derived from `cache_meta.provenance[].index`.
+- **Never log raw prompts** (hash them — mirror the existing `query.sha1` pattern).
+- **Fail open, loudly** — every error path treats the cache as absent and logs structurally.
+- **Kill switch:** `semantic_cache_enabled=false` disables **serve and store**; **push invalidation still runs** so stale entries are cleaned while serving is off.
+
+---
+
+## M. Decisions log
+
+1. ✅ Backend = managed LangCache.
+2. ✅ Lookup via native `searchStrategies:[exact, semantic]` + mid-conversation rewriting (not a hand-rolled two-stage scheme).
+3. ✅ Provenance push invalidation via a `path_hash → {entry_id}` reverse index. **Gated on §0.**
+4. ✅ Tickets + skills + docs cacheable; only *ungrounded* answers are `do_not_cache`. **No authz model exists**, so no cross-tenant vector (§K).
+5. ✅ Identifier queries scoped by `entity_id` (support-ticket IDs only; instance/cluster out of scope) + a post-filter safety net. Extractor is **net-new**: tight ticket-ID pattern + separate query-version detector, **version-first precedence** (§I).
+6. ✅ **Fixed store-time TTL** (no sliding/refresh — no LangCache read-extend op). `latest` short TTL; pinned versions longer.
+7. ✅ Similarity threshold 0.9 (re-validate on LangCache).
+8. ✅ Rewrite via `nano`, mid-conversation only; constrained rewriting.
+9. ✅ Async write; error/ungrounded skip the write; tombstone recheck for the write-vs-invalidate race.
+10. ✅ Kill switch disables serve/store, keeps push invalidation.
+11. ✅ Removed `index_origin`, `source_ids` (→ reverse index), `embedding_model_version`.
+
+**Deferred to Phase 2:** feedback eviction, multi-version, warming, multi-entity, concurrent-first-asker single-flight, multi-value `entity_id`, chunk-level invalidation (§J).
+
+---
+
+## N. Testing & rollout
+
+**Prerequisite gate:** the live-stack/invalidation tests require the §0 return-field change (so `source_document_path` reaches search results); version supports `latest` + pinned. State this in the test plan.
+
+- **Unit:** `decide_cacheability` truth table (ungrounded → skip; grounded doc/skill/ticket → cache); tombstone-skip and post-`SADD` undo on the write race; `entity_id` extractor (rejects `7.8`, accepts `RET-4421`); post-filter rejects an `entity_id` mismatch; canonical-key consistency between store and lookup; fail-open on simulated LangCache error.
+- **Spike tests (§P) before relying on the guarantees:** (a) does an `entity_id` attribute filter actually prevent cross-serving `RET-4421`/`RET-4422` (pre- vs post-filter)? — the post-filter net should make the answer "safe either way"; (b) confirm `searchStrategies:[exact, semantic]` semantics on the literal prompt.
+- **Live stack (post-§0):** ask a question twice → 2nd is a hit, no LLM/tool spans; change a doc → reingest → confirm citing entries dropped (reverse index); two different tickets → confirm no cross-serve.
+- **Eval:** `make test` then `make test-eval-pr`; tune the threshold against **numeric targets** — record hit-rate and false-hit-rate; gate "loosen threshold" on false-hit-rate ≈ 0.
+- **Phased:** complete §0 → land wrapper + hooks flag-OFF → spikes (§P) → enable in dev, validate on live stack + evals → default-ON after sign-off.
+
+---
+
+## P. Open spikes (unverified vendor behavior — confirm before relying)
+
+1. **Attribute filter ordering.** `api.yaml` says attributes "can be used for filtering when searching" but does **not** state whether filtering is a hard pre-filter (before vector scoring) or a post-filter on top-k. The §D **post-filter safety net** makes identifier correctness hold either way, but confirm the performance/recall implication.
+2. **`searchStrategies` semantics.** Confirm `exact` operates on the literal prompt string and that `[exact, semantic]` priority behaves as expected in one call.
+3. **TTL.** Confirmed no read-extend op exists; confirm default-cache-TTL behavior when `ttlMillis` is omitted.
+4. **Attribute constraints.** Confirmed max 5 / name pattern / no-comma values (`api.yaml:489-499`); confirm at cache-provisioning time.

--- a/redis_sre_agent/core/config.py
+++ b/redis_sre_agent/core/config.py
@@ -341,6 +341,40 @@ class Settings(BaseSettings):
         default="gpt-5-nano", description="OpenAI model for very simple classification/triage"
     )
 
+    # Semantic Answer Cache (LangCache) — default OFF; see docs/design/semantic-cache-knowledge-agent.md
+    semantic_cache_enabled: bool = Field(
+        default=False,
+        description="Enable the semantic answer cache in front of the knowledge agent (serve + store).",
+    )
+    semantic_cache_similarity_threshold: float = Field(
+        default=0.9,
+        description="LangCache similarity threshold for a cache hit (higher = stricter).",
+    )
+    semantic_cache_ttl_latest_ms: int = Field(
+        default=60 * 60 * 1000,
+        description="Store-time TTL (ms) for version='latest' entries (moving pointer => short).",
+    )
+    semantic_cache_ttl_pinned_ms: int = Field(
+        default=24 * 60 * 60 * 1000,
+        description="Store-time TTL (ms) for pinned-version entries (stable => longer).",
+    )
+    semantic_cache_inval_tombstone_ttl_seconds: int = Field(
+        default=120,
+        description="TTL (s) for cache_inval write-vs-invalidate tombstones in our Redis.",
+    )
+    langcache_server_url: str = Field(
+        default="https://aws-us-east-1.langcache.redis.io",
+        description="Base URL for the managed LangCache service.",
+    )
+    langcache_cache_id: Optional[SecretStr] = Field(
+        default=None,
+        description="LangCache cache identifier (required when semantic_cache_enabled).",
+    )
+    langcache_api_key: Optional[SecretStr] = Field(
+        default=None,
+        description="LangCache API key (required when semantic_cache_enabled).",
+    )
+
     # Vector Search / Embeddings
     embedding_provider: str = Field(
         default="openai",

--- a/redis_sre_agent/core/docket_tasks.py
+++ b/redis_sre_agent/core/docket_tasks.py
@@ -2481,15 +2481,42 @@ async def _process_agent_turn_impl(
             else:
                 max_iterations = min(int(settings.max_iterations or 15), 10)
 
-            chat_agent_response = await agent.process_query(
-                query=message,
-                user_id=thread.metadata.user_id,
-                session_id=thread.metadata.session_id or thread_id,
-                max_iterations=max_iterations,
-                context=routing_context,
-                progress_emitter=progress_emitter,
-                conversation_history=lc_history if lc_history else None,
-            )
+            # Semantic answer cache: only the knowledge-only turn is instance-
+            # independent and therefore safe to serve globally (chat/triage turns
+            # depend on a specific instance's live state). Default OFF; fail-open.
+            cache_history = lc_history if lc_history else None
+            cached_response = None
+            cache_key = None
+            if is_knowledge_only and settings.semantic_cache_enabled:
+                from redis_sre_agent.core.semantic_cache.service import lookup_cached_answer
+
+                cached_response, cache_key = await lookup_cached_answer(message, cache_history)
+
+            if cached_response is not None:
+                await task_manager.add_task_update(
+                    task_id, "Served answer from semantic cache", "agent_processing"
+                )
+                chat_agent_response = cached_response
+            else:
+                chat_agent_response = await agent.process_query(
+                    query=message,
+                    user_id=thread.metadata.user_id,
+                    session_id=thread.metadata.session_id or thread_id,
+                    max_iterations=max_iterations,
+                    context=routing_context,
+                    progress_emitter=progress_emitter,
+                    conversation_history=cache_history,
+                )
+                if is_knowledge_only and settings.semantic_cache_enabled:
+                    from redis_sre_agent.core.semantic_cache.service import schedule_store
+
+                    schedule_store(
+                        message,
+                        chat_agent_response.response,
+                        chat_agent_response.search_results,
+                        cache_history,
+                        rewritten_query=cache_key,
+                    )
 
             # chat_agent_response is an AgentResponse with .response, .search_results, .tool_envelopes
             agent_response = {

--- a/redis_sre_agent/core/keys.py
+++ b/redis_sre_agent/core/keys.py
@@ -100,6 +100,26 @@ class RedisKeys:
         return "sre:knowledge_pack:active"
 
     # ============================================================================
+    # Semantic answer cache (LangCache) provenance — see
+    # docs/design/semantic-cache-knowledge-agent.md §B
+    # ============================================================================
+
+    @staticmethod
+    def semantic_cache_provenance(path_hash: str) -> str:
+        """Reverse index: source path_hash -> SET of LangCache entry_ids."""
+        return f"cache_prov:{path_hash}"
+
+    @staticmethod
+    def semantic_cache_meta(entry_id: str) -> str:
+        """Side metadata (provenance + audit) for one LangCache entry."""
+        return f"cache_meta:{entry_id}"
+
+    @staticmethod
+    def semantic_cache_invalidation(path_hash: str) -> str:
+        """Short-TTL tombstone guarding the write-vs-invalidate race."""
+        return f"cache_inval:{path_hash}"
+
+    # ============================================================================
     # Task result keys
     # ============================================================================
 

--- a/redis_sre_agent/core/knowledge_helpers.py
+++ b/redis_sre_agent/core/knowledge_helpers.py
@@ -58,6 +58,7 @@ _SEARCH_RETURN_FIELDS = [
     "meta_pinned",
     "severity",
     "version",
+    "source_document_path",
 ]
 _EXACT_MATCH_TAG_FIELDS = ("name", "document_hash", "source")
 _SUPPORT_TICKET_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{1,127}$")
@@ -1432,6 +1433,7 @@ async def search_knowledge_base_helper(
                 "priority": _doc_priority(doc),
                 "pinned": _doc_is_pinned(doc),
                 "version": _normalized_doc_version(doc),
+                "source_document_path": doc.get("source_document_path", ""),
                 # RedisVL returns distance when return_score=True (default). Some versions
                 # expose it as 'score' and others as 'vector_distance' or 'distance'.
                 # Normalize to float.

--- a/redis_sre_agent/core/semantic_cache/__init__.py
+++ b/redis_sre_agent/core/semantic_cache/__init__.py
@@ -1,0 +1,19 @@
+"""Semantic answer cache (LangCache) for the knowledge agent.
+
+A flag-gated (``settings.semantic_cache_enabled``, default OFF) semantic answer
+cache that sits above the knowledge-agent LangGraph run. On a sufficiently
+similar prior question it serves the previously synthesized answer and
+short-circuits the entire graph.
+
+Backend split (see ``docs/design/semantic-cache-knowledge-agent.md``): LangCache
+(managed) owns embeddings/index/similarity/TTL/attribute filters; our Redis owns
+provenance (``path_hash -> {entry_id}`` reverse index, side metadata, tombstones).
+
+``SemanticCache`` is the only entry point callers need; the submodules
+(extraction, cacheability, provenance, client, rewrite, service) are imported
+directly where used.
+"""
+
+from redis_sre_agent.core.semantic_cache.service import SemanticCache
+
+__all__ = ["SemanticCache"]

--- a/redis_sre_agent/core/semantic_cache/cacheability.py
+++ b/redis_sre_agent/core/semantic_cache/cacheability.py
@@ -1,0 +1,43 @@
+"""Cacheability gate for the semantic answer cache write path.
+
+Only successful **grounded** answers are stored. An *ungrounded* answer — one
+produced with no knowledge-base search results — is the only hard write
+exclusion (there is no authz/PII model, so nothing else gates storage). See
+``docs/design/semantic-cache-knowledge-agent.md`` §H/§I.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+
+@dataclass(frozen=True)
+class CacheDecision:
+    """Outcome of the cacheability gate."""
+
+    cacheable: bool
+    reason: str
+
+
+def decide_cacheability(
+    knowledge_search_results: Optional[List[Dict[str, Any]]],
+    *,
+    response: Optional[str] = None,
+) -> CacheDecision:
+    """Decide whether a freshly generated answer may be stored.
+
+    Args:
+        knowledge_search_results: The accumulated ``knowledge_search_results``
+            from the agent run. Empty/None means the answer is *ungrounded*.
+        response: The generated answer text; an empty answer is never stored.
+
+    Returns:
+        A :class:`CacheDecision`. ``cacheable`` is True only for a non-empty
+        answer backed by at least one knowledge-search result.
+    """
+    if response is not None and not str(response).strip():
+        return CacheDecision(False, "empty_response")
+    if not knowledge_search_results:
+        return CacheDecision(False, "ungrounded")
+    return CacheDecision(True, "grounded")

--- a/redis_sre_agent/core/semantic_cache/client.py
+++ b/redis_sre_agent/core/semantic_cache/client.py
@@ -1,0 +1,158 @@
+"""Async HTTP client for the managed Redis LangCache service.
+
+Wraps the REST endpoints verified in
+``redis-docs/content/develop/ai/langcache/api-reference/api.yaml``:
+
+* ``POST /v1/caches/{cacheId}/entries/search`` — search (exact then semantic)
+* ``POST /v1/caches/{cacheId}/entries``        — set (returns ``entryId``)
+* ``DELETE /v1/caches/{cacheId}/entries/{id}`` — delete a single entry
+* ``DELETE /v1/caches/{cacheId}/entries``      — delete by attributes (deleteQuery)
+* ``POST /v1/caches/{cacheId}/flush``          — flush all entries
+
+Every method **fails open**: transport/HTTP errors are logged and converted to a
+miss/no-op return value so the cache is transparent to the agent.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Sequence
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+# LangCache search strategies (api.yaml SearchStrategy enum), ordered by priority.
+DEFAULT_SEARCH_STRATEGIES: Sequence[str] = ("exact", "semantic")
+
+
+@dataclass(frozen=True)
+class LangCacheEntry:
+    """A single cache entry returned by a search (api.yaml ``CacheEntry``)."""
+
+    id: str
+    prompt: str
+    response: str
+    similarity: float
+    attributes: Dict[str, str]
+    search_strategy: str
+
+    @classmethod
+    def from_payload(cls, payload: Dict[str, Any]) -> "LangCacheEntry":
+        return cls(
+            id=str(payload.get("id", "")),
+            prompt=str(payload.get("prompt", "")),
+            response=str(payload.get("response", "")),
+            similarity=float(payload.get("similarity", 0.0) or 0.0),
+            attributes=dict(payload.get("attributes") or {}),
+            search_strategy=str(payload.get("searchStrategy", "")),
+        )
+
+
+class LangCacheClient:
+    """Thin async wrapper around the LangCache REST API.
+
+    Args:
+        server_url: Base URL of the LangCache service.
+        cache_id: The cache identifier (path segment).
+        api_key: Bearer token for the ``Authorization`` header.
+        timeout: Per-request timeout in seconds.
+        client: Optional injected ``httpx.AsyncClient`` (for tests).
+    """
+
+    def __init__(
+        self,
+        *,
+        server_url: str,
+        cache_id: str,
+        api_key: str,
+        timeout: float = 5.0,
+        client: Optional[httpx.AsyncClient] = None,
+    ):
+        self._base = server_url.rstrip("/")
+        self._cache_id = cache_id
+        self._timeout = timeout
+        self._headers = {
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        }
+        self._client = client
+        self._owns_client = client is None
+
+    async def _get_client(self) -> httpx.AsyncClient:
+        if self._client is None:
+            self._client = httpx.AsyncClient(timeout=self._timeout)
+        return self._client
+
+    async def aclose(self) -> None:
+        if self._client is not None and self._owns_client:
+            await self._client.aclose()
+            self._client = None
+
+    def _url(self, suffix: str) -> str:
+        return f"{self._base}/v1/caches/{self._cache_id}{suffix}"
+
+    async def search(
+        self,
+        prompt: str,
+        *,
+        similarity_threshold: float,
+        attributes: Optional[Dict[str, str]] = None,
+        search_strategies: Sequence[str] = DEFAULT_SEARCH_STRATEGIES,
+    ) -> List[LangCacheEntry]:
+        """Search the cache. Returns matching entries (possibly empty) or [] on error."""
+        body: Dict[str, Any] = {
+            "prompt": prompt,
+            "similarityThreshold": similarity_threshold,
+            "searchStrategies": list(search_strategies),
+        }
+        if attributes:
+            body["attributes"] = attributes
+        try:
+            client = await self._get_client()
+            resp = await client.post(self._url("/entries/search"), json=body, headers=self._headers)
+            resp.raise_for_status()
+            data = resp.json().get("data") or []
+            return [LangCacheEntry.from_payload(item) for item in data]
+        except Exception as exc:
+            logger.warning("LangCache search failed (fail-open miss): %s", exc)
+            return []
+
+    async def set_entry(
+        self,
+        prompt: str,
+        response: str,
+        *,
+        attributes: Optional[Dict[str, str]] = None,
+        ttl_millis: Optional[int] = None,
+    ) -> Optional[str]:
+        """Store an entry. Returns the new ``entry_id`` or None on error."""
+        body: Dict[str, Any] = {"prompt": prompt, "response": response}
+        if attributes:
+            body["attributes"] = attributes
+        if ttl_millis is not None:
+            body["ttlMillis"] = ttl_millis
+        try:
+            client = await self._get_client()
+            resp = await client.post(self._url("/entries"), json=body, headers=self._headers)
+            resp.raise_for_status()
+            return resp.json().get("entryId")
+        except Exception as exc:
+            logger.warning("LangCache set failed (fail-open no-op): %s", exc)
+            return None
+
+    async def delete_entry(self, entry_id: str) -> bool:
+        """Delete a single entry by id. Returns True on success, False on error."""
+        try:
+            client = await self._get_client()
+            resp = await client.delete(self._url(f"/entries/{entry_id}"), headers=self._headers)
+            resp.raise_for_status()
+            return True
+        except Exception as exc:
+            logger.warning("LangCache delete_entry failed: %s", exc)
+            return False
+
+    # Only per-entry delete is wired (the sole v1 caller is push invalidation).
+    # LangCache also exposes deleteQuery (by attributes) and flush (full clear) —
+    # add those wrappers if/when a break-glass caller needs them.

--- a/redis_sre_agent/core/semantic_cache/extraction.py
+++ b/redis_sre_agent/core/semantic_cache/extraction.py
@@ -1,0 +1,88 @@
+"""Entity-ID and query-version extraction for the semantic cache.
+
+Identifier queries need an *exact* identifier match (``RET-4421`` != ``RET-4422``)
+but *paraphrase* reuse for the same ID. We scope those by an ``entity_id``
+attribute. Versions are a *separate axis* (the ``version`` lookup filter), so a
+token must never be classified as both.
+
+This is net-new work: the existing ``_looks_like_support_ticket_identifier`` is
+shape-only and classifies ``7.8`` as an identifier, and the existing
+``_SOURCE_VERSION_RE`` only reads versions from doc *source paths*, not query
+text. See ``docs/design/semantic-cache-knowledge-agent.md`` §I.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Optional
+
+# Default version axis value when the query pins no version.
+DEFAULT_VERSION = "latest"
+
+# Query-text version detector (NEW — there is no query-text version detector in
+# the codebase today). Matches: "7.8", "v7.8", "version 7.2", "in 7.4". The
+# optional "v"/"version" prefix is consumed before the digits so that the
+# anchoring word boundary sits before the (optional) prefix, not between "v" and
+# the digit (where there is none in "v7.8").
+_QUERY_VERSION_RE = re.compile(
+    r"\bv?(?:ersion)?\s*(\d+\.\d+)\b",
+    re.IGNORECASE,
+)
+
+# Tight ticket-ID pattern (NEW — replaces the catch-all shape regex). Real ticket
+# format like ``RET-4421``. Excludes ``7.8``, ``maxmemory``, ``OOM``, bare digits.
+_TICKET_ID_RE = re.compile(r"\b([A-Z]{2,}-\d+)\b")
+
+
+@dataclass(frozen=True)
+class CacheScope:
+    """The lookup scope resolved from a query.
+
+    ``version`` always resolves (defaults to ``latest``). ``entity_id`` is set
+    only for identifier queries that match the tight ticket-ID format.
+    """
+
+    version: str = DEFAULT_VERSION
+    entity_id: Optional[str] = None
+
+
+def extract_query_version(query: str) -> str:
+    """Resolve the requested version from query text, defaulting to ``latest``.
+
+    Returns the first ``major.minor`` mention (e.g. ``7.8``) or ``latest``.
+    """
+    if not query:
+        return DEFAULT_VERSION
+    match = _QUERY_VERSION_RE.search(query)
+    if match:
+        return match.group(1)
+    return DEFAULT_VERSION
+
+
+def extract_entity_id(query: str, *, version: Optional[str] = None) -> Optional[str]:
+    """Extract a support-ticket ``entity_id`` from query text, version-first.
+
+    A token becomes ``entity_id`` only if it matches the tight ticket-ID format
+    *and* is not the resolved version token. Bare version tokens (``7.8``) and
+    non-identifier tokens (``maxmemory``, ``OOM``) never match.
+    """
+    if not query:
+        return None
+    resolved_version = version if version is not None else extract_query_version(query)
+    match = _TICKET_ID_RE.search(query)
+    if not match:
+        return None
+    candidate = match.group(1)
+    # Version-first precedence: a token claimed by the version axis is never an
+    # entity. (Ticket IDs contain a hyphen and no dot, so this is belt-and-braces.)
+    if candidate == resolved_version:
+        return None
+    return candidate
+
+
+def extract_cache_scope(query: str) -> CacheScope:
+    """Resolve the full cache lookup scope (version + optional entity_id)."""
+    version = extract_query_version(query)
+    entity_id = extract_entity_id(query, version=version)
+    return CacheScope(version=version, entity_id=entity_id)

--- a/redis_sre_agent/core/semantic_cache/extraction.py
+++ b/redis_sre_agent/core/semantic_cache/extraction.py
@@ -45,6 +45,10 @@ class CacheScope:
 
     version: str = DEFAULT_VERSION
     entity_id: Optional[str] = None
+    # True when the query names more than one distinct ticket ID. Multi-entity
+    # questions are deferred (§J): v1 neither serves nor stores them, since a
+    # single-valued entity_id can't represent a multi-ticket answer.
+    multi_entity: bool = False
 
 
 def extract_query_version(query: str) -> str:
@@ -82,7 +86,15 @@ def extract_entity_id(query: str, *, version: Optional[str] = None) -> Optional[
 
 
 def extract_cache_scope(query: str) -> CacheScope:
-    """Resolve the full cache lookup scope (version + optional entity_id)."""
+    """Resolve the full cache lookup scope (version + optional entity_id).
+
+    If the query names more than one distinct ticket ID it is flagged
+    ``multi_entity`` (deferred per §J) so the caller can skip serving/storing it,
+    rather than silently caching under whichever ticket happened to match first.
+    """
     version = extract_query_version(query)
-    entity_id = extract_entity_id(query, version=version)
+    ticket_ids = [tid for tid in _TICKET_ID_RE.findall(query or "") if tid != version]
+    if len(set(ticket_ids)) > 1:
+        return CacheScope(version=version, entity_id=None, multi_entity=True)
+    entity_id = ticket_ids[0] if ticket_ids else None
     return CacheScope(version=version, entity_id=entity_id)

--- a/redis_sre_agent/core/semantic_cache/provenance.py
+++ b/redis_sre_agent/core/semantic_cache/provenance.py
@@ -83,10 +83,16 @@ class ProvenanceStore:
             return []
 
     async def clear_path(self, path_hash: str, entry_ids: Iterable[str]) -> None:
-        """Drop the reverse-index set and side metadata for invalidated entries."""
+        """Remove reverse-index links + side metadata for the given entries only.
+
+        Uses SREM per entry (not a full-set delete) so entries whose LangCache
+        delete failed keep their link and can be retried on a later invalidation.
+        Redis drops the set automatically once its last member is removed.
+        """
         try:
-            await self._redis.delete(RedisKeys.semantic_cache_provenance(path_hash))
+            prov_key = RedisKeys.semantic_cache_provenance(path_hash)
             for entry_id in entry_ids:
+                await self._redis.srem(prov_key, entry_id)
                 await self._redis.delete(RedisKeys.semantic_cache_meta(entry_id))
         except Exception as exc:  # pragma: no cover - defensive
             logger.warning("semantic-cache provenance clear failed: %s", exc)

--- a/redis_sre_agent/core/semantic_cache/provenance.py
+++ b/redis_sre_agent/core/semantic_cache/provenance.py
@@ -1,0 +1,115 @@
+"""Provenance reverse index for the semantic cache (stored in *our* Redis).
+
+Three structures, three jobs (design §C):
+
+* ``cache_prov:{path_hash}``  → SET of LangCache ``entry_id`` s (invalidation).
+* ``cache_meta:{entry_id}``   → JSON side metadata (debug/audit; off the serve path).
+* ``cache_inval:{path_hash}`` → short-TTL tombstone (write-vs-invalidate race).
+
+``path_hash`` is ``sha256(source_document_path)[:16]`` — the *same* hash
+ingestion uses (``deduplication.py:66``), so the invalidation signal and the
+cache speak one identifier with no translation.
+
+Every method fails open: any Redis error is logged and swallowed so the cache
+never raises into the agent path.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+from typing import Any, Dict, Iterable, List, Optional
+
+from redis.asyncio import Redis
+
+from redis_sre_agent.core.keys import RedisKeys
+
+logger = logging.getLogger(__name__)
+
+
+def path_hash_for_source(source_document_path: str) -> str:
+    """Compute the path hash exactly as ingestion does (``deduplication.py:66``)."""
+    return hashlib.sha256(source_document_path.encode("utf-8")).hexdigest()[:16]
+
+
+class ProvenanceStore:
+    """Reverse-index + side-metadata + tombstone operations in our Redis."""
+
+    def __init__(self, redis_client: Redis, *, tombstone_ttl_seconds: int = 120):
+        self._redis = redis_client
+        self._tombstone_ttl = max(int(tombstone_ttl_seconds), 1)
+
+    async def record_entry(
+        self,
+        entry_id: str,
+        path_hashes: Iterable[str],
+        *,
+        meta: Optional[Dict[str, Any]] = None,
+    ) -> bool:
+        """Index a stored entry: SADD per cited path_hash + persist side metadata.
+
+        Returns True on success, False on any error (fail open).
+        """
+        try:
+            for path_hash in {h for h in path_hashes if h}:
+                await self._redis.sadd(RedisKeys.semantic_cache_provenance(path_hash), entry_id)
+            if meta is not None:
+                await self._redis.set(
+                    RedisKeys.semantic_cache_meta(entry_id),
+                    json.dumps(meta, default=str),
+                )
+            return True
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.warning("semantic-cache provenance record failed: %s", exc)
+            return False
+
+    async def remove_entry(self, entry_id: str, path_hashes: Iterable[str]) -> None:
+        """Undo a recorded entry (used by the post-SADD write-race recheck)."""
+        try:
+            for path_hash in {h for h in path_hashes if h}:
+                await self._redis.srem(RedisKeys.semantic_cache_provenance(path_hash), entry_id)
+            await self._redis.delete(RedisKeys.semantic_cache_meta(entry_id))
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.warning("semantic-cache provenance remove failed: %s", exc)
+
+    async def entries_for_path(self, path_hash: str) -> List[str]:
+        """Return the entry_ids cited by a source path (SMEMBERS), or [] on error."""
+        try:
+            members = await self._redis.smembers(RedisKeys.semantic_cache_provenance(path_hash))
+            return [m.decode() if isinstance(m, bytes) else str(m) for m in (members or [])]
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.warning("semantic-cache provenance read failed: %s", exc)
+            return []
+
+    async def clear_path(self, path_hash: str, entry_ids: Iterable[str]) -> None:
+        """Drop the reverse-index set and side metadata for invalidated entries."""
+        try:
+            await self._redis.delete(RedisKeys.semantic_cache_provenance(path_hash))
+            for entry_id in entry_ids:
+                await self._redis.delete(RedisKeys.semantic_cache_meta(entry_id))
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.warning("semantic-cache provenance clear failed: %s", exc)
+
+    async def write_tombstone(self, path_hash: str) -> None:
+        """Write a short-TTL tombstone marking that this path just changed."""
+        try:
+            await self._redis.set(
+                RedisKeys.semantic_cache_invalidation(path_hash),
+                "1",
+                ex=self._tombstone_ttl,
+            )
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.warning("semantic-cache tombstone write failed: %s", exc)
+
+    async def has_fresh_tombstone(self, path_hashes: Iterable[str]) -> bool:
+        """True if any cited path has a fresh tombstone (content just changed)."""
+        try:
+            for path_hash in {h for h in path_hashes if h}:
+                if await self._redis.exists(RedisKeys.semantic_cache_invalidation(path_hash)):
+                    return True
+            return False
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.warning("semantic-cache tombstone check failed: %s", exc)
+            # Fail safe: if we cannot confirm freshness, assume changed (skip write).
+            return True

--- a/redis_sre_agent/core/semantic_cache/rewrite.py
+++ b/redis_sre_agent/core/semantic_cache/rewrite.py
@@ -1,0 +1,79 @@
+"""Mid-conversation query rewriting (contextualization) for the cache key.
+
+Resolves a context-dependent follow-up ("what about for 7.2?") into a standalone
+question so it can be matched/stored on its own. This is *contextualization*, not
+paraphrase-matching — LangCache handles paraphrases semantically (design §F).
+
+* **First-turn** queries (no conversation history) are used verbatim — zero LLM
+  cost on the common path.
+* **Mid-conversation** queries are rewritten via the cheapest ``nano`` tier.
+* **Fail open**: any error returns the raw query unchanged.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import List, Optional
+
+from langchain_core.messages import BaseMessage, HumanMessage, SystemMessage
+
+from redis_sre_agent.core.llm_helpers import create_nano_llm
+
+logger = logging.getLogger(__name__)
+
+_REWRITE_SYSTEM_PROMPT = (
+    "You rewrite a user's latest question into a fully standalone question using "
+    "the prior conversation for context. Output ONLY the rewritten question, no "
+    "preamble.\n"
+    "Hard rules:\n"
+    "- Preserve verbatim, never paraphrase: version numbers (7.8, latest), config "
+    "directives (maxmemory, maxmemory-policy, appendonly), commands (CONFIG SET, "
+    "BGREWRITEAOF), error/log tokens (MISCONF, OOM), metric names, identifiers, "
+    "paths, flags, and quoted strings.\n"
+    "- NEVER introduce a version, environment, or edition the user did not state.\n"
+    "- If the question is already self-contained, return it unchanged."
+)
+
+
+def _conversation_to_text(conversation_history: List[BaseMessage]) -> str:
+    lines: List[str] = []
+    for message in conversation_history:
+        role = getattr(message, "type", "message")
+        content = getattr(message, "content", "")
+        if isinstance(content, str) and content.strip():
+            lines.append(f"{role}: {content.strip()}")
+    return "\n".join(lines)
+
+
+async def rewrite_query(
+    query: str,
+    conversation_history: Optional[List[BaseMessage]] = None,
+) -> str:
+    """Return a standalone form of ``query`` for use as the cache key.
+
+    First-turn queries (no history) are returned unchanged. Mid-conversation
+    queries are rewritten via the nano LLM; on any error the raw query is
+    returned (fail open).
+    """
+    if not conversation_history:
+        return query
+
+    try:
+        llm = create_nano_llm()
+        messages = [
+            SystemMessage(content=_REWRITE_SYSTEM_PROMPT),
+            HumanMessage(
+                content=(
+                    f"Conversation so far:\n{_conversation_to_text(conversation_history)}\n\n"
+                    f"Latest question: {query}\n\nStandalone question:"
+                )
+            ),
+        ]
+        result = await llm.ainvoke(messages)
+        rewritten = getattr(result, "content", "")
+        if isinstance(rewritten, str) and rewritten.strip():
+            return rewritten.strip()
+        return query
+    except Exception as exc:
+        logger.warning("semantic-cache query rewrite failed (using raw query): %s", exc)
+        return query

--- a/redis_sre_agent/core/semantic_cache/service.py
+++ b/redis_sre_agent/core/semantic_cache/service.py
@@ -98,7 +98,12 @@ class SemanticCache:
         )
 
     async def aclose(self) -> None:
-        await self._client.aclose()
+        # Cleanup must never raise — a failed close in a `finally` must not
+        # discard an already-computed lookup result/key (§F).
+        try:
+            await self._client.aclose()
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.debug("semantic-cache client close failed: %s", exc)
 
     # -- helpers --------------------------------------------------------------
 
@@ -429,20 +434,25 @@ async def lookup_cached_answer(
     cache is disabled or misconfigured. The returned key can be reused for a
     later store so the rewrite is computed once (§F). Fails open on any error.
     """
-    try:
-        from redis_sre_agent.core.redis import get_redis_client
+    from redis_sre_agent.core.redis import get_redis_client
 
+    cache = None
+    key: Optional[str] = None
+    try:
         cache = SemanticCache.from_settings(get_redis_client())
         if cache is None:
             return None, None
-        try:
-            key = await cache.canonical_key(query, conversation_history)
-            return await cache.lookup(query, conversation_history, rewritten_query=key), key
-        finally:
-            await cache.aclose()
+        key = await cache.canonical_key(query, conversation_history)
+        result = await cache.lookup(query, conversation_history, rewritten_query=key)
+        return result, key
     except Exception as exc:
+        # Preserve the key if it was already computed, so the miss-path store can
+        # still reuse it instead of paying a second nano rewrite (§F).
         logger.warning("semantic-cache lookup failed (fail-open miss): %s", exc)
-        return None, None
+        return None, key
+    finally:
+        if cache is not None:
+            await cache.aclose()
 
 
 async def _run_store(

--- a/redis_sre_agent/core/semantic_cache/service.py
+++ b/redis_sre_agent/core/semantic_cache/service.py
@@ -336,10 +336,16 @@ class SemanticCache:
                 # the reverse index (§H).
                 await self._provenance.write_tombstone(path_hash)
                 entry_ids = await self._provenance.entries_for_path(path_hash)
+                # Only clear reverse-index links for entries we actually deleted.
+                # A failed delete means the LangCache row may still exist, so we
+                # keep its link so a later invalidation can retry — dropping it
+                # would strand the row (reachable only by TTL) (§G).
+                succeeded = []
                 for entry_id in entry_ids:
                     if await self._client.delete_entry(entry_id):
                         deleted += 1
-                await self._provenance.clear_path(path_hash, entry_ids)
+                        succeeded.append(entry_id)
+                await self._provenance.clear_path(path_hash, succeeded)
         except Exception as exc:
             logger.warning("semantic-cache invalidate failed: %s", exc)
         return deleted

--- a/redis_sre_agent/core/semantic_cache/service.py
+++ b/redis_sre_agent/core/semantic_cache/service.py
@@ -108,9 +108,14 @@ class SemanticCache:
 
     @staticmethod
     def _path_hashes(search_results: Sequence[Dict[str, Any]]) -> List[str]:
+        # Key strictly on source_document_path — the exact field ingestion hashes
+        # for its tombstones (deduplication.py). A `source` fallback would mint a
+        # hash ingestion never emits, so those reverse-index entries could never be
+        # push-invalidated; such results simply get no reverse-index entry (the
+        # fixed TTL is their only backstop).
         hashes: List[str] = []
         for result in search_results or []:
-            source = str(result.get("source_document_path") or result.get("source") or "").strip()
+            source = str(result.get("source_document_path") or "").strip()
             if source:
                 hashes.append(path_hash_for_source(source))
         return hashes
@@ -148,12 +153,16 @@ class SemanticCache:
         Fails open: any error is logged and treated as a miss.
         """
         try:
-            scope = extract_cache_scope(query)
             key = (
                 rewritten_query
                 if rewritten_query is not None
                 else await self.canonical_key(query, conversation_history)
             )
+            # Resolve version/entity from the canonical key (the rewritten,
+            # standalone question) — not the raw query — so a context-resolved
+            # version (e.g. a mid-conversation "what about for 7.2?") tags and
+            # filters the entry correctly (§D/§F).
+            scope = extract_cache_scope(key)
             attributes: Dict[str, str] = {"version": scope.version}
             if scope.entity_id:
                 attributes["entity_id"] = scope.entity_id
@@ -171,9 +180,11 @@ class SemanticCache:
             if candidate.similarity < self._threshold:
                 return None
 
-            # Post-filter safety net (§D note 4): identifier correctness must hold
+            # Post-filter safety net (§D note 4): the served entry's entity_id must
+            # EQUAL the requested one — symmetrically. A general query (no entity_id)
+            # must not receive a ticket-scoped entry, and vice versa. Holds
             # regardless of whether LangCache pre- or post-filters on attributes.
-            if scope.entity_id and candidate.attributes.get("entity_id") != scope.entity_id:
+            if (candidate.attributes.get("entity_id") or None) != scope.entity_id:
                 logger.debug("semantic-cache post-filter reject: entity_id mismatch")
                 return None
 
@@ -228,12 +239,14 @@ class SemanticCache:
                 logger.debug("semantic-cache store skipped: fresh invalidation tombstone")
                 return None
 
-            scope = extract_cache_scope(query)
             key = (
                 rewritten_query
                 if rewritten_query is not None
                 else await self.canonical_key(query, conversation_history)
             )
+            # Scope from the canonical key so the stored version/entity match the
+            # form the lookup filters on (§D/§F).
+            scope = extract_cache_scope(key)
             attributes: Dict[str, str] = {
                 "version": scope.version,
                 "cache_origin": _CACHE_ORIGIN_DYNAMIC,

--- a/redis_sre_agent/core/semantic_cache/service.py
+++ b/redis_sre_agent/core/semantic_cache/service.py
@@ -168,6 +168,11 @@ class SemanticCache:
             # version (e.g. a mid-conversation "what about for 7.2?") tags and
             # filters the entry correctly (§D/§F).
             scope = extract_cache_scope(key)
+            if scope.multi_entity:
+                # Multi-ticket queries are deferred (§J): don't serve one under a
+                # single entity_id.
+                logger.debug("semantic-cache lookup skipped: multi-entity query")
+                return None
             attributes: Dict[str, str] = {"version": scope.version}
             if scope.entity_id:
                 attributes["entity_id"] = scope.entity_id
@@ -252,6 +257,11 @@ class SemanticCache:
             # Scope from the canonical key so the stored version/entity match the
             # form the lookup filters on (§D/§F).
             scope = extract_cache_scope(key)
+            if scope.multi_entity:
+                # Multi-ticket answers can't be represented by a single entity_id
+                # scope — deferred per §J, so don't store them under one ticket.
+                logger.debug("semantic-cache store skipped: multi-entity query")
+                return None
             attributes: Dict[str, str] = {
                 "version": scope.version,
                 "cache_origin": _CACHE_ORIGIN_DYNAMIC,

--- a/redis_sre_agent/core/semantic_cache/service.py
+++ b/redis_sre_agent/core/semantic_cache/service.py
@@ -1,0 +1,451 @@
+"""SemanticCache orchestrator: read (lookup) and write (store) + invalidation.
+
+This ties together the LangCache client (match + serve), the provenance store
+(invalidate), and the extraction/rewrite/cacheability helpers. It is the only
+object the agent and ingestion paths interact with.
+
+Design references: read path §D, write path §H, invalidation §G, identifiers §I.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Tuple
+
+from langchain_core.messages import BaseMessage
+from redis.asyncio import Redis
+
+if TYPE_CHECKING:
+    from redis_sre_agent.agent.models import AgentResponse
+
+from redis_sre_agent.core.config import Settings
+from redis_sre_agent.core.config import settings as global_settings
+from redis_sre_agent.core.semantic_cache.cacheability import decide_cacheability
+from redis_sre_agent.core.semantic_cache.client import LangCacheClient
+from redis_sre_agent.core.semantic_cache.extraction import DEFAULT_VERSION, extract_cache_scope
+from redis_sre_agent.core.semantic_cache.provenance import ProvenanceStore, path_hash_for_source
+from redis_sre_agent.core.semantic_cache.rewrite import rewrite_query
+
+logger = logging.getLogger(__name__)
+
+# LangCache prompt field max length (api.yaml SearchEntriesRequest/SetEntryRequest).
+_MAX_PROMPT_LEN = 1024
+_CACHE_ORIGIN_DYNAMIC = "dynamic"
+
+
+class SemanticCache:
+    """Semantic answer cache sitting above the knowledge-agent graph."""
+
+    def __init__(
+        self,
+        *,
+        client: LangCacheClient,
+        provenance: ProvenanceStore,
+        similarity_threshold: float,
+        ttl_latest_ms: int,
+        ttl_pinned_ms: int,
+    ):
+        self._client = client
+        self._provenance = provenance
+        self._threshold = similarity_threshold
+        self._ttl_latest_ms = ttl_latest_ms
+        self._ttl_pinned_ms = ttl_pinned_ms
+
+    # -- construction ---------------------------------------------------------
+
+    @classmethod
+    def from_settings(
+        cls,
+        redis_client: Redis,
+        *,
+        settings: Optional[Settings] = None,
+        require_enabled: bool = True,
+    ) -> Optional["SemanticCache"]:
+        """Build a SemanticCache from settings, or None if it cannot/should not run.
+
+        Returns None when LangCache credentials are missing. When
+        ``require_enabled`` is True (serve/store paths) it also returns None
+        while ``semantic_cache_enabled`` is False. Invalidation passes
+        ``require_enabled=False`` so push invalidation keeps running even with
+        the kill switch off (design §L). Callers treat None as "cache absent".
+        """
+        cfg = settings or global_settings
+        if require_enabled and not cfg.semantic_cache_enabled:
+            return None
+        if not cfg.langcache_cache_id or not cfg.langcache_api_key:
+            if cfg.semantic_cache_enabled:
+                logger.warning(
+                    "semantic_cache_enabled but LangCache credentials missing; disabling."
+                )
+            return None
+        client = LangCacheClient(
+            server_url=cfg.langcache_server_url,
+            cache_id=cfg.langcache_cache_id.get_secret_value(),
+            api_key=cfg.langcache_api_key.get_secret_value(),
+        )
+        provenance = ProvenanceStore(
+            redis_client,
+            tombstone_ttl_seconds=cfg.semantic_cache_inval_tombstone_ttl_seconds,
+        )
+        return cls(
+            client=client,
+            provenance=provenance,
+            similarity_threshold=cfg.semantic_cache_similarity_threshold,
+            ttl_latest_ms=cfg.semantic_cache_ttl_latest_ms,
+            ttl_pinned_ms=cfg.semantic_cache_ttl_pinned_ms,
+        )
+
+    async def aclose(self) -> None:
+        await self._client.aclose()
+
+    # -- helpers --------------------------------------------------------------
+
+    @staticmethod
+    def _canonical_key(rewritten_query: str) -> str:
+        return rewritten_query[:_MAX_PROMPT_LEN]
+
+    @staticmethod
+    def _path_hashes(search_results: Sequence[Dict[str, Any]]) -> List[str]:
+        hashes: List[str] = []
+        for result in search_results or []:
+            source = str(result.get("source_document_path") or result.get("source") or "").strip()
+            if source:
+                hashes.append(path_hash_for_source(source))
+        return hashes
+
+    def _ttl_for_version(self, version: str) -> int:
+        return self._ttl_latest_ms if version == DEFAULT_VERSION else self._ttl_pinned_ms
+
+    # -- read path (§D) -------------------------------------------------------
+
+    async def canonical_key(
+        self,
+        query: str,
+        conversation_history: Optional[List[BaseMessage]] = None,
+    ) -> str:
+        """Compute the canonical cache key for a query (rewrite + truncate).
+
+        Exposed so a caller can compute the key once and reuse it for both
+        ``lookup`` and ``store`` in the same turn (design §F: "computed once,
+        reused as the store key"), avoiding a second nano call and guaranteeing
+        the store and lookup keys match for a rewritten mid-conversation query.
+        """
+        return self._canonical_key(await rewrite_query(query, conversation_history))
+
+    async def lookup(
+        self,
+        query: str,
+        conversation_history: Optional[List[BaseMessage]] = None,
+        *,
+        rewritten_query: Optional[str] = None,
+    ) -> Optional["AgentResponse"]:
+        """Return a cached ``AgentResponse`` on a sufficiently-similar hit, else None.
+
+        ``rewritten_query`` lets the caller supply a pre-computed canonical key
+        (see :meth:`canonical_key`); when omitted it is computed here.
+        Fails open: any error is logged and treated as a miss.
+        """
+        try:
+            scope = extract_cache_scope(query)
+            key = (
+                rewritten_query
+                if rewritten_query is not None
+                else await self.canonical_key(query, conversation_history)
+            )
+            attributes: Dict[str, str] = {"version": scope.version}
+            if scope.entity_id:
+                attributes["entity_id"] = scope.entity_id
+
+            entries = await self._client.search(
+                key,
+                similarity_threshold=self._threshold,
+                attributes=attributes,
+            )
+            if not entries:
+                logger.debug("semantic-cache miss")
+                return None
+
+            candidate = entries[0]
+            if candidate.similarity < self._threshold:
+                return None
+
+            # Post-filter safety net (§D note 4): identifier correctness must hold
+            # regardless of whether LangCache pre- or post-filters on attributes.
+            if scope.entity_id and candidate.attributes.get("entity_id") != scope.entity_id:
+                logger.debug("semantic-cache post-filter reject: entity_id mismatch")
+                return None
+
+            response = self._reconstruct_response(candidate.response)
+            logger.info(
+                "semantic-cache hit via %s (similarity=%.3f)",
+                candidate.search_strategy or "?",
+                candidate.similarity,
+            )
+            return response
+        except Exception as exc:
+            logger.warning("semantic-cache lookup failed (fail-open miss): %s", exc)
+            return None
+
+    @staticmethod
+    def _reconstruct_response(stored_response: str) -> "AgentResponse":
+        from redis_sre_agent.agent.models import AgentResponse
+
+        try:
+            payload = json.loads(stored_response)
+            text = str(payload.get("response", ""))
+            search_results = list(payload.get("search_results") or [])
+        except (ValueError, TypeError):
+            text, search_results = stored_response, []
+        return AgentResponse(response=text, search_results=search_results, tool_envelopes=[])
+
+    # -- write path (§H) ------------------------------------------------------
+
+    async def store(
+        self,
+        query: str,
+        response: str,
+        search_results: Sequence[Dict[str, Any]],
+        conversation_history: Optional[List[BaseMessage]] = None,
+        *,
+        rewritten_query: Optional[str] = None,
+    ) -> Optional[str]:
+        """Store a grounded answer. Fire-and-forget safe; returns entry_id or None.
+
+        ``rewritten_query`` lets the caller reuse the key already computed for the
+        lookup (design §F). Skips ungrounded answers and skips/undoes around fresh
+        invalidation tombstones to close the write-vs-invalidate race (§H).
+        """
+        try:
+            decision = decide_cacheability(list(search_results), response=response)
+            if not decision.cacheable:
+                logger.debug("semantic-cache store skipped: %s", decision.reason)
+                return None
+
+            path_hashes = self._path_hashes(search_results)
+            if await self._provenance.has_fresh_tombstone(path_hashes):
+                logger.debug("semantic-cache store skipped: fresh invalidation tombstone")
+                return None
+
+            scope = extract_cache_scope(query)
+            key = (
+                rewritten_query
+                if rewritten_query is not None
+                else await self.canonical_key(query, conversation_history)
+            )
+            attributes: Dict[str, str] = {
+                "version": scope.version,
+                "cache_origin": _CACHE_ORIGIN_DYNAMIC,
+            }
+            if scope.entity_id:
+                attributes["entity_id"] = scope.entity_id
+
+            payload = json.dumps(
+                {"response": response, "search_results": list(search_results)}, default=str
+            )
+            entry_id = await self._client.set_entry(
+                key,
+                payload,
+                attributes=attributes,
+                ttl_millis=self._ttl_for_version(scope.version),
+            )
+            if not entry_id:
+                return None
+
+            meta = {
+                "original_question": query,
+                "rewritten_question": key,
+                "version": scope.version,
+                "entity_id": scope.entity_id,
+                "num_sources": len(search_results),
+                "provenance": [
+                    {
+                        "source_document_path": r.get("source_document_path") or r.get("source"),
+                        "path_hash": ph,
+                        "index_type": r.get("index_type"),
+                        "title": r.get("title"),
+                        "doc_version": r.get("version"),
+                        "document_hash": r.get("document_hash"),
+                    }
+                    for r, ph in zip(search_results, path_hashes)
+                ],
+            }
+            await self._provenance.record_entry(entry_id, path_hashes, meta=meta)
+
+            # Recheck for a tombstone that appeared during the write window (§H).
+            if await self._provenance.has_fresh_tombstone(path_hashes):
+                logger.debug("semantic-cache store undone: tombstone appeared during write")
+                await self._client.delete_entry(entry_id)
+                await self._provenance.remove_entry(entry_id, path_hashes)
+                return None
+
+            logger.info("semantic-cache stored entry (sources=%d)", len(search_results))
+            return entry_id
+        except Exception as exc:
+            logger.warning("semantic-cache store failed (no-op): %s", exc)
+            return None
+
+    # -- invalidation (§G) ----------------------------------------------------
+
+    async def invalidate(self, source_document_paths: Sequence[str]) -> int:
+        """Push-invalidate all cache entries citing the given changed source docs.
+
+        Runs even when serving is disabled (kill-switch semantics) and fails
+        open. Returns the number of LangCache entries deleted.
+        """
+        deleted = 0
+        try:
+            for source in source_document_paths or []:
+                source = str(source or "").strip()
+                if not source:
+                    continue
+                path_hash = path_hash_for_source(source)
+                # Write the tombstone FIRST so a concurrent store that completes
+                # mid-invalidation observes it (on its pre-store check or post-SADD
+                # recheck) and undoes itself — closing the window before we clear
+                # the reverse index (§H).
+                await self._provenance.write_tombstone(path_hash)
+                entry_ids = await self._provenance.entries_for_path(path_hash)
+                for entry_id in entry_ids:
+                    if await self._client.delete_entry(entry_id):
+                        deleted += 1
+                await self._provenance.clear_path(path_hash, entry_ids)
+        except Exception as exc:
+            logger.warning("semantic-cache invalidate failed: %s", exc)
+        return deleted
+
+
+# Actions that mean a source document was replaced or removed (not a pure add).
+_INVALIDATING_ACTIONS = {"update", "updated", "delete", "deleted", "remove", "removed"}
+
+
+def _changed_source_paths(source_document_changes: Any) -> List[str]:
+    """Extract replaced/removed source paths from an ingestion change summary.
+
+    Accepts the summary dict (with a ``files`` list of ``{path, action}``) or a
+    plain list of such file dicts. Pure adds and unchanged docs are ignored.
+    """
+    if isinstance(source_document_changes, dict):
+        files = source_document_changes.get("files") or []
+    elif isinstance(source_document_changes, list):
+        files = source_document_changes
+    else:
+        return []
+    paths: List[str] = []
+    for entry in files:
+        if not isinstance(entry, dict):
+            continue
+        action = str(entry.get("action") or "").strip().lower()
+        path = str(entry.get("path") or entry.get("file") or "").strip()
+        if path and action in _INVALIDATING_ACTIONS:
+            paths.append(path)
+    return paths
+
+
+async def invalidate_changed_sources(
+    source_document_changes: Any,
+    *,
+    redis_client: Optional[Redis] = None,
+    settings: Optional[Settings] = None,
+) -> int:
+    """Push-invalidate cache entries for docs replaced/removed during ingestion.
+
+    Runs regardless of ``semantic_cache_enabled`` (kill-switch semantics, §L);
+    no-op when LangCache credentials are absent. Fails open. Returns the number
+    of LangCache entries deleted.
+    """
+    paths = _changed_source_paths(source_document_changes)
+    if not paths:
+        return 0
+    try:
+        from redis_sre_agent.core.redis import get_redis_client
+
+        client = redis_client if redis_client is not None else get_redis_client()
+        cache = SemanticCache.from_settings(client, settings=settings, require_enabled=False)
+        if cache is None:
+            return 0
+        try:
+            return await cache.invalidate(paths)
+        finally:
+            await cache.aclose()
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.warning("semantic-cache ingestion invalidation failed: %s", exc)
+        return 0
+
+
+# -- request-path helpers (build-from-settings + fail-open + fire-and-forget) --
+#
+# Used by the knowledge-only turn in the worker (docket_tasks). Kept here so the
+# serve/store wiring lives in one place regardless of which caller uses it.
+
+# Retain references to in-flight fire-and-forget writes so they are not
+# garbage-collected before they run (see asyncio.create_task docs).
+_STORE_TASKS: "set[asyncio.Task[Any]]" = set()
+
+
+async def lookup_cached_answer(
+    query: str,
+    conversation_history: Optional[List[BaseMessage]] = None,
+) -> Tuple[Optional["AgentResponse"], Optional[str]]:
+    """Look up a cached answer. Returns ``(response_or_None, canonical_key_or_None)``.
+
+    Builds a short-lived cache from settings; returns ``(None, None)`` when the
+    cache is disabled or misconfigured. The returned key can be reused for a
+    later store so the rewrite is computed once (§F). Fails open on any error.
+    """
+    try:
+        from redis_sre_agent.core.redis import get_redis_client
+
+        cache = SemanticCache.from_settings(get_redis_client())
+        if cache is None:
+            return None, None
+        try:
+            key = await cache.canonical_key(query, conversation_history)
+            return await cache.lookup(query, conversation_history, rewritten_query=key), key
+        finally:
+            await cache.aclose()
+    except Exception as exc:
+        logger.warning("semantic-cache lookup failed (fail-open miss): %s", exc)
+        return None, None
+
+
+async def _run_store(
+    query: str,
+    response: str,
+    search_results: Sequence[Dict[str, Any]],
+    conversation_history: Optional[List[BaseMessage]],
+    rewritten_query: Optional[str],
+) -> None:
+    from redis_sre_agent.core.redis import get_redis_client
+
+    cache = SemanticCache.from_settings(get_redis_client())
+    if cache is None:
+        return
+    try:
+        await cache.store(
+            query, response, search_results, conversation_history, rewritten_query=rewritten_query
+        )
+    except Exception as exc:  # pragma: no cover - store() already fails open
+        logger.warning("semantic-cache background store failed: %s", exc)
+    finally:
+        await cache.aclose()
+
+
+def schedule_store(
+    query: str,
+    response: str,
+    search_results: Sequence[Dict[str, Any]],
+    conversation_history: Optional[List[BaseMessage]] = None,
+    rewritten_query: Optional[str] = None,
+) -> None:
+    """Fire-and-forget store; never adds user-facing latency, never raises.
+
+    Cacheability (grounded vs ungrounded) and the write-vs-invalidate race are
+    handled inside ``store``; a no-op when the cache is disabled/misconfigured.
+    """
+    task = asyncio.create_task(
+        _run_store(query, response, search_results, conversation_history, rewritten_query)
+    )
+    _STORE_TASKS.add(task)
+    task.add_done_callback(_STORE_TASKS.discard)

--- a/redis_sre_agent/core/semantic_cache/service.py
+++ b/redis_sre_agent/core/semantic_cache/service.py
@@ -329,6 +329,11 @@ class SemanticCache:
         open. Returns the number of LangCache entries deleted.
         """
         deleted = 0
+        # Track entries deleted earlier in THIS call: an entry cited by several
+        # changed paths is deleted on the first path, and a repeat delete of the
+        # now-gone row would "fail" — we must still clear its link on later paths
+        # rather than orphan it in their reverse-index sets.
+        deleted_ids: set[str] = set()
         try:
             for source in source_document_paths or []:
                 source = str(source or "").strip()
@@ -341,16 +346,20 @@ class SemanticCache:
                 # the reverse index (§H).
                 await self._provenance.write_tombstone(path_hash)
                 entry_ids = await self._provenance.entries_for_path(path_hash)
-                # Only clear reverse-index links for entries we actually deleted.
-                # A failed delete means the LangCache row may still exist, so we
-                # keep its link so a later invalidation can retry — dropping it
-                # would strand the row (reachable only by TTL) (§G).
-                succeeded = []
+                # Clear reverse-index links only for entries confirmed gone (deleted
+                # now or earlier in this call). A genuinely failed delete keeps its
+                # link so a later invalidation can retry — dropping it would strand
+                # the row (reachable only by TTL) (§G).
+                to_clear = []
                 for entry_id in entry_ids:
+                    if entry_id in deleted_ids:
+                        to_clear.append(entry_id)
+                        continue
                     if await self._client.delete_entry(entry_id):
                         deleted += 1
-                        succeeded.append(entry_id)
-                await self._provenance.clear_path(path_hash, succeeded)
+                        deleted_ids.add(entry_id)
+                        to_clear.append(entry_id)
+                await self._provenance.clear_path(path_hash, to_clear)
         except Exception as exc:
             logger.warning("semantic-cache invalidate failed: %s", exc)
         return deleted

--- a/redis_sre_agent/core/semantic_cache/service.py
+++ b/redis_sre_agent/core/semantic_cache/service.py
@@ -292,7 +292,15 @@ class SemanticCache:
                     for r in search_results
                 ],
             }
-            await self._provenance.record_entry(entry_id, path_hashes, meta=meta)
+            recorded = await self._provenance.record_entry(entry_id, path_hashes, meta=meta)
+            if path_hashes and not recorded:
+                # The reverse-index links failed to write, so this entry could not
+                # be push-invalidated (only TTL would reach it). Roll the LangCache
+                # write back rather than leave an un-invalidatable orphan (§G/§H).
+                logger.warning("semantic-cache store undone: provenance recording failed")
+                await self._client.delete_entry(entry_id)
+                await self._provenance.remove_entry(entry_id, path_hashes)
+                return None
 
             # Recheck for a tombstone that appeared during the write window (§H).
             if await self._provenance.has_fresh_tombstone(path_hashes):

--- a/redis_sre_agent/core/semantic_cache/service.py
+++ b/redis_sre_agent/core/semantic_cache/service.py
@@ -272,16 +272,24 @@ class SemanticCache:
                 "version": scope.version,
                 "entity_id": scope.entity_id,
                 "num_sources": len(search_results),
+                # Compute each row's path_hash inline (aligned per-result). Do NOT
+                # zip against path_hashes: that list omits rows without
+                # source_document_path, which would shift pairings for mixed
+                # citations and attach the wrong hash to a result.
                 "provenance": [
                     {
-                        "source_document_path": r.get("source_document_path") or r.get("source"),
-                        "path_hash": ph,
+                        "source_document_path": r.get("source_document_path"),
+                        "path_hash": (
+                            path_hash_for_source(sp)
+                            if (sp := str(r.get("source_document_path") or "").strip())
+                            else None
+                        ),
                         "index_type": r.get("index_type"),
                         "title": r.get("title"),
                         "doc_version": r.get("version"),
                         "document_hash": r.get("document_hash"),
                     }
-                    for r, ph in zip(search_results, path_hashes)
+                    for r in search_results
                 ],
             }
             await self._provenance.record_entry(entry_id, path_hashes, meta=meta)

--- a/redis_sre_agent/pipelines/ingestion/_processor_impl.py
+++ b/redis_sre_agent/pipelines/ingestion/_processor_impl.py
@@ -259,13 +259,6 @@ class IngestionPipeline(PipelineWorkflowMixin):
             ingestion_stats["completed_at"] = datetime.now(timezone.utc).isoformat()
             ingestion_stats["success"] = True
 
-            # Push-invalidate the semantic answer cache for replaced/removed docs.
-            # Runs regardless of the serve/store kill switch (design §G/§L) and
-            # fails open so ingestion is never blocked by cache issues.
-            from redis_sre_agent.core.semantic_cache.service import invalidate_changed_sources
-
-            await invalidate_changed_sources(ingestion_stats["source_document_changes"])
-
             # Save ingestion manifest
             await self._save_ingestion_manifest(batch_date, ingestion_stats)
 
@@ -276,6 +269,16 @@ class IngestionPipeline(PipelineWorkflowMixin):
             ingestion_stats["error"] = str(e)
             ingestion_stats["completed_at"] = datetime.now(timezone.utc).isoformat()
             raise
+        finally:
+            # Push-invalidate the semantic answer cache for docs already
+            # replaced/removed — in `finally` so a PARTIAL ingestion (some
+            # categories changed docs, then a later failure) still invalidates
+            # the cache entries citing those now-stale docs (§G). Runs regardless
+            # of the serve/store kill switch (§L) and fails open, so it never
+            # masks the original error or blocks ingestion.
+            from redis_sre_agent.core.semantic_cache.service import invalidate_changed_sources
+
+            await invalidate_changed_sources(ingestion_stats["source_document_changes"])
 
         return ingestion_stats
 

--- a/redis_sre_agent/pipelines/ingestion/_processor_impl.py
+++ b/redis_sre_agent/pipelines/ingestion/_processor_impl.py
@@ -259,6 +259,13 @@ class IngestionPipeline(PipelineWorkflowMixin):
             ingestion_stats["completed_at"] = datetime.now(timezone.utc).isoformat()
             ingestion_stats["success"] = True
 
+            # Push-invalidate the semantic answer cache for replaced/removed docs.
+            # Runs regardless of the serve/store kill switch (design §G/§L) and
+            # fails open so ingestion is never blocked by cache issues.
+            from redis_sre_agent.core.semantic_cache.service import invalidate_changed_sources
+
+            await invalidate_changed_sources(ingestion_stats["source_document_changes"])
+
             # Save ingestion manifest
             await self._save_ingestion_manifest(batch_date, ingestion_stats)
 

--- a/redis_sre_agent/pipelines/ingestion/pipeline_workflow_mixin.py
+++ b/redis_sre_agent/pipelines/ingestion/pipeline_workflow_mixin.py
@@ -215,6 +215,12 @@ class PipelineWorkflowMixin:
                 }
             )
 
+        # Push-invalidate the semantic answer cache for replaced/removed docs
+        # (design §G/§L); fails open and runs regardless of the kill switch.
+        from redis_sre_agent.core.semantic_cache.service import invalidate_changed_sources
+
+        await invalidate_changed_sources(results)
+
         return results
 
     async def prepare_source_artifacts(self, source_dir: Path, batch_date: str) -> int:

--- a/redis_sre_agent/pipelines/ingestion/pipeline_workflow_mixin.py
+++ b/redis_sre_agent/pipelines/ingestion/pipeline_workflow_mixin.py
@@ -195,31 +195,35 @@ class PipelineWorkflowMixin:
                     }
                 )
 
-        stale_source_documents = await self._delete_stale_source_documents(
-            deduplicators,
-            tracked_source_documents,
-            current_source_paths,
-            scope_prefixes,
-        )
-        for deletion in stale_source_documents:
-            results.append(
-                {
-                    "file": deletion["path"],
-                    "title": deletion.get("title", ""),
-                    "category": deletion.get("category", ""),
-                    "severity": deletion.get("severity", ""),
-                    "status": "success",
-                    "action": "delete",
-                    "chunks_created": 0,
-                    "chunks_indexed": 0,
-                }
+        try:
+            stale_source_documents = await self._delete_stale_source_documents(
+                deduplicators,
+                tracked_source_documents,
+                current_source_paths,
+                scope_prefixes,
             )
+            for deletion in stale_source_documents:
+                results.append(
+                    {
+                        "file": deletion["path"],
+                        "title": deletion.get("title", ""),
+                        "category": deletion.get("category", ""),
+                        "severity": deletion.get("severity", ""),
+                        "status": "success",
+                        "action": "delete",
+                        "chunks_created": 0,
+                        "chunks_indexed": 0,
+                    }
+                )
+        finally:
+            # Push-invalidate the semantic answer cache for replaced/removed docs
+            # in `finally` so a partial ingestion (per-doc changes recorded, then
+            # a failure e.g. in stale-source deletion) still evicts the cache
+            # entries citing those now-stale docs (§G/§L). Fails open, so it never
+            # masks the original error or blocks ingestion.
+            from redis_sre_agent.core.semantic_cache.service import invalidate_changed_sources
 
-        # Push-invalidate the semantic answer cache for replaced/removed docs
-        # (design §G/§L); fails open and runs regardless of the kill switch.
-        from redis_sre_agent.core.semantic_cache.service import invalidate_changed_sources
-
-        await invalidate_changed_sources(results)
+            await invalidate_changed_sources(results)
 
         return results
 

--- a/tests/unit/core/semantic_cache/test_cacheability.py
+++ b/tests/unit/core/semantic_cache/test_cacheability.py
@@ -1,0 +1,33 @@
+"""US-005: cacheability gate truth table (only grounded answers are stored)."""
+
+from redis_sre_agent.core.semantic_cache.cacheability import decide_cacheability
+
+
+def test_ungrounded_empty_results_not_cacheable():
+    decision = decide_cacheability([], response="some answer")
+    assert decision.cacheable is False
+    assert decision.reason == "ungrounded"
+
+
+def test_ungrounded_none_results_not_cacheable():
+    decision = decide_cacheability(None, response="some answer")
+    assert decision.cacheable is False
+    assert decision.reason == "ungrounded"
+
+
+def test_grounded_answer_cacheable():
+    decision = decide_cacheability([{"source_document_path": "a.md"}], response="answer")
+    assert decision.cacheable is True
+    assert decision.reason == "grounded"
+
+
+def test_empty_response_not_cacheable_even_if_grounded():
+    decision = decide_cacheability([{"source_document_path": "a.md"}], response="   ")
+    assert decision.cacheable is False
+    assert decision.reason == "empty_response"
+
+
+def test_response_optional_defaults_to_grounding_only():
+    # When response is not supplied, only grounding is considered.
+    assert decide_cacheability([{"x": 1}]).cacheable is True
+    assert decide_cacheability([]).cacheable is False

--- a/tests/unit/core/semantic_cache/test_client.py
+++ b/tests/unit/core/semantic_cache/test_client.py
@@ -1,0 +1,129 @@
+"""US-003: LangCacheClient HTTP wrapper — payload shapes + fail-open behavior."""
+
+import httpx
+import pytest
+
+from redis_sre_agent.core.semantic_cache.client import LangCacheClient
+
+
+class _FakeResponse:
+    def __init__(self, status_code=200, payload=None, raise_exc=None):
+        self.status_code = status_code
+        self._payload = payload or {}
+        self._raise_exc = raise_exc
+
+    def raise_for_status(self):
+        if self._raise_exc is not None:
+            raise self._raise_exc
+
+    def json(self):
+        return self._payload
+
+
+class _FakeHTTPClient:
+    """Records calls and returns queued responses (or raises)."""
+
+    def __init__(self):
+        self.calls = []
+        self.responses = {}  # method -> _FakeResponse or Exception
+
+    async def post(self, url, json=None, headers=None):
+        return self._respond("post", url, json, headers)
+
+    async def delete(self, url, headers=None):
+        return self._respond("delete", url, None, headers)
+
+    def _respond(self, method, url, json, headers):
+        self.calls.append({"method": method, "url": url, "json": json, "headers": headers})
+        result = self.responses.get(method)
+        if isinstance(result, Exception):
+            raise result
+        return result if result is not None else _FakeResponse()
+
+    async def aclose(self):
+        pass
+
+
+def _make_client(fake):
+    return LangCacheClient(
+        server_url="https://lc.example.com",
+        cache_id="cache-1",
+        api_key="secret",
+        client=fake,
+    )
+
+
+@pytest.mark.asyncio
+async def test_search_sends_strategies_and_attributes():
+    fake = _FakeHTTPClient()
+    fake.responses["post"] = _FakeResponse(
+        payload={
+            "data": [
+                {
+                    "id": "a" * 32,
+                    "prompt": "q",
+                    "response": "r",
+                    "similarity": 0.97,
+                    "attributes": {"version": "latest"},
+                    "searchStrategy": "semantic",
+                }
+            ]
+        }
+    )
+    client = _make_client(fake)
+    entries = await client.search("q", similarity_threshold=0.9, attributes={"version": "latest"})
+
+    call = fake.calls[0]
+    assert call["url"] == "https://lc.example.com/v1/caches/cache-1/entries/search"
+    assert call["json"]["searchStrategies"] == ["exact", "semantic"]
+    assert call["json"]["similarityThreshold"] == 0.9
+    assert call["json"]["attributes"] == {"version": "latest"}
+    assert call["headers"]["Authorization"] == "Bearer secret"
+    assert len(entries) == 1
+    assert entries[0].similarity == 0.97
+    assert entries[0].search_strategy == "semantic"
+
+
+@pytest.mark.asyncio
+async def test_search_fails_open_to_empty_list():
+    fake = _FakeHTTPClient()
+    fake.responses["post"] = httpx.ConnectError("boom")
+    client = _make_client(fake)
+    assert await client.search("q", similarity_threshold=0.9) == []
+
+
+@pytest.mark.asyncio
+async def test_set_entry_returns_entry_id_with_ttl():
+    fake = _FakeHTTPClient()
+    fake.responses["post"] = _FakeResponse(status_code=201, payload={"entryId": "e" * 32})
+    client = _make_client(fake)
+    entry_id = await client.set_entry(
+        "prompt", "response", attributes={"version": "7.8"}, ttl_millis=1000
+    )
+
+    assert entry_id == "e" * 32
+    body = fake.calls[0]["json"]
+    assert body["prompt"] == "prompt"
+    assert body["response"] == "response"
+    assert body["attributes"] == {"version": "7.8"}
+    assert body["ttlMillis"] == 1000
+
+
+@pytest.mark.asyncio
+async def test_set_entry_fails_open_to_none():
+    fake = _FakeHTTPClient()
+    fake.responses["post"] = RuntimeError("nope")
+    client = _make_client(fake)
+    assert await client.set_entry("p", "r") is None
+
+
+@pytest.mark.asyncio
+async def test_delete_entry_success_and_failure():
+    fake = _FakeHTTPClient()
+    fake.responses["delete"] = _FakeResponse(status_code=204)
+    client = _make_client(fake)
+    assert await client.delete_entry("e" * 32) is True
+    assert fake.calls[0]["url"] == "https://lc.example.com/v1/caches/cache-1/entries/" + "e" * 32
+
+    fake.responses["delete"] = httpx.ConnectError("down")
+    assert await client.delete_entry("e" * 32) is False

--- a/tests/unit/core/semantic_cache/test_config_and_keys.py
+++ b/tests/unit/core/semantic_cache/test_config_and_keys.py
@@ -1,0 +1,34 @@
+"""US-002: config settings + Redis key builders for the semantic cache."""
+
+from redis_sre_agent.core.config import Settings
+from redis_sre_agent.core.keys import RedisKeys
+
+
+def test_semantic_cache_defaults_disabled(monkeypatch):
+    # Clear ambient env (config.py load_dotenv() may have injected a local .env
+    # that enables the cache for the docker stack) so this tests field defaults.
+    for var in ("SEMANTIC_CACHE_ENABLED", "LANGCACHE_CACHE_ID", "LANGCACHE_API_KEY"):
+        monkeypatch.delenv(var, raising=False)
+    cfg = Settings(_env_file=None)
+    assert cfg.semantic_cache_enabled is False
+    assert cfg.semantic_cache_similarity_threshold == 0.9
+    assert cfg.semantic_cache_ttl_latest_ms == 60 * 60 * 1000
+    assert cfg.semantic_cache_ttl_pinned_ms == 24 * 60 * 60 * 1000
+    # Credentials default to absent so from_settings refuses to build.
+    assert cfg.langcache_cache_id is None
+    assert cfg.langcache_api_key is None
+    assert cfg.langcache_server_url.startswith("https://")
+
+
+def test_langcache_secrets_are_secretstr():
+    cfg = Settings(langcache_cache_id="cache-123", langcache_api_key="key-abc")
+    # Secrets must not leak via repr/str.
+    assert "key-abc" not in repr(cfg.langcache_api_key)
+    assert cfg.langcache_api_key.get_secret_value() == "key-abc"
+    assert cfg.langcache_cache_id.get_secret_value() == "cache-123"
+
+
+def test_provenance_key_builders():
+    assert RedisKeys.semantic_cache_provenance("abc123") == "cache_prov:abc123"
+    assert RedisKeys.semantic_cache_meta("entry1") == "cache_meta:entry1"
+    assert RedisKeys.semantic_cache_invalidation("abc123") == "cache_inval:abc123"

--- a/tests/unit/core/semantic_cache/test_extraction.py
+++ b/tests/unit/core/semantic_cache/test_extraction.py
@@ -56,3 +56,21 @@ def test_plain_query_scope_defaults():
     scope = extract_cache_scope("how do I tune maxmemory-policy?")
     assert scope.version == "latest"
     assert scope.entity_id is None
+
+
+def test_multiple_tickets_flag_multi_entity():
+    scope = extract_cache_scope("compare RET-4421 and RET-4422 latency")
+    assert scope.multi_entity is True
+    assert scope.entity_id is None
+
+
+def test_single_ticket_is_not_multi_entity():
+    scope = extract_cache_scope("status of RET-4421")
+    assert scope.multi_entity is False
+    assert scope.entity_id == "RET-4421"
+
+
+def test_same_ticket_repeated_is_not_multi_entity():
+    scope = extract_cache_scope("RET-4421 — is RET-4421 resolved?")
+    assert scope.multi_entity is False
+    assert scope.entity_id == "RET-4421"

--- a/tests/unit/core/semantic_cache/test_extraction.py
+++ b/tests/unit/core/semantic_cache/test_extraction.py
@@ -1,0 +1,58 @@
+"""US-004: entity-ID + query-version extraction (version-first precedence)."""
+
+import pytest
+
+from redis_sre_agent.core.semantic_cache.extraction import (
+    extract_cache_scope,
+    extract_entity_id,
+    extract_query_version,
+)
+
+
+@pytest.mark.parametrize(
+    "query,expected",
+    [
+        ("what changed in 7.8?", "7.8"),
+        ("upgrade to v7.8 now", "7.8"),
+        ("behaviour in version 7.2", "7.2"),
+        ("how does it work in 7.4", "7.4"),
+        ("how do I configure maxmemory?", "latest"),
+        ("", "latest"),
+        ("ticket RET-4421 status", "latest"),
+    ],
+)
+def test_extract_query_version(query, expected):
+    assert extract_query_version(query) == expected
+
+
+@pytest.mark.parametrize(
+    "query",
+    ["7.8", "version 7.2", "maxmemory policy", "OOM error", "what is 42 plus 1", ""],
+)
+def test_non_tickets_have_no_entity_id(query):
+    """Versions, config directives, error tokens, bare numbers are not entities."""
+    assert extract_entity_id(query) is None
+
+
+@pytest.mark.parametrize(
+    "query,expected",
+    [
+        ("status of RET-4421 ticket", "RET-4421"),
+        ("INC-99 details", "INC-99"),
+        ("look at ABC-1", "ABC-1"),
+    ],
+)
+def test_ticket_ids_extracted(query, expected):
+    assert extract_entity_id(query) == expected
+
+
+def test_version_first_precedence_for_mixed_query():
+    scope = extract_cache_scope("RET-4421 regression in 7.8")
+    assert scope.version == "7.8"
+    assert scope.entity_id == "RET-4421"
+
+
+def test_plain_query_scope_defaults():
+    scope = extract_cache_scope("how do I tune maxmemory-policy?")
+    assert scope.version == "latest"
+    assert scope.entity_id is None

--- a/tests/unit/core/semantic_cache/test_provenance.py
+++ b/tests/unit/core/semantic_cache/test_provenance.py
@@ -1,0 +1,70 @@
+"""US-005: provenance reverse index, side metadata, and tombstones (our Redis)."""
+
+import fakeredis.aioredis
+import pytest
+
+from redis_sre_agent.core.keys import RedisKeys
+from redis_sre_agent.core.semantic_cache.provenance import (
+    ProvenanceStore,
+    path_hash_for_source,
+)
+
+
+@pytest.fixture
+def redis_client():
+    return fakeredis.aioredis.FakeRedis()
+
+
+def test_path_hash_matches_ingestion_algorithm():
+    import hashlib
+
+    source = "runbooks/memory.md"
+    expected = hashlib.sha256(source.encode("utf-8")).hexdigest()[:16]
+    assert path_hash_for_source(source) == expected
+    assert len(path_hash_for_source(source)) == 16
+
+
+@pytest.mark.asyncio
+async def test_record_and_read_reverse_index(redis_client):
+    store = ProvenanceStore(redis_client)
+    ph = path_hash_for_source("a.md")
+
+    assert await store.record_entry("entry-1", [ph], meta={"k": "v"}) is True
+    assert await store.entries_for_path(ph) == ["entry-1"]
+    # Side metadata persisted.
+    assert await redis_client.get(RedisKeys.semantic_cache_meta("entry-1")) is not None
+
+
+@pytest.mark.asyncio
+async def test_remove_entry_undoes_index_and_meta(redis_client):
+    store = ProvenanceStore(redis_client)
+    ph = path_hash_for_source("a.md")
+    await store.record_entry("entry-1", [ph], meta={"k": "v"})
+
+    await store.remove_entry("entry-1", [ph])
+    assert await store.entries_for_path(ph) == []
+    assert await redis_client.get(RedisKeys.semantic_cache_meta("entry-1")) is None
+
+
+@pytest.mark.asyncio
+async def test_clear_path_drops_set_and_meta(redis_client):
+    store = ProvenanceStore(redis_client)
+    ph = path_hash_for_source("a.md")
+    await store.record_entry("entry-1", [ph], meta={"k": "v"})
+    await store.record_entry("entry-2", [ph], meta={"k": "v"})
+
+    await store.clear_path(ph, ["entry-1", "entry-2"])
+    assert await store.entries_for_path(ph) == []
+    assert await redis_client.get(RedisKeys.semantic_cache_meta("entry-1")) is None
+
+
+@pytest.mark.asyncio
+async def test_tombstone_lifecycle(redis_client):
+    store = ProvenanceStore(redis_client, tombstone_ttl_seconds=60)
+    ph = path_hash_for_source("a.md")
+
+    assert await store.has_fresh_tombstone([ph]) is False
+    await store.write_tombstone(ph)
+    assert await store.has_fresh_tombstone([ph]) is True
+    # An unrelated path is unaffected.
+    assert await store.has_fresh_tombstone([path_hash_for_source("b.md")]) is False

--- a/tests/unit/core/semantic_cache/test_request_helpers.py
+++ b/tests/unit/core/semantic_cache/test_request_helpers.py
@@ -87,3 +87,21 @@ async def test_schedule_store_noop_when_disabled():
         schedule_store("q", "answer", [{"source_document_path": "a.md"}])
         await asyncio.gather(*list(_STORE_TASKS))
     # No cache built => nothing to assert beyond "did not raise".
+
+
+@pytest.mark.asyncio
+async def test_lookup_preserves_key_when_lookup_errors():
+    """If the lookup path errors after the key is computed, the key is still
+    returned so the store can reuse it (no second nano rewrite)."""
+    fake_cache = MagicMock()
+    fake_cache.canonical_key = AsyncMock(return_value="canonical-q")
+    fake_cache.lookup = AsyncMock(side_effect=RuntimeError("lookup boom"))
+    fake_cache.aclose = AsyncMock()
+    with (
+        patch.object(service_mod.SemanticCache, "from_settings", return_value=fake_cache),
+        patch("redis_sre_agent.core.redis.get_redis_client", return_value=MagicMock()),
+    ):
+        result, key = await lookup_cached_answer("q")
+    assert result is None
+    assert key == "canonical-q"
+    fake_cache.aclose.assert_awaited_once()

--- a/tests/unit/core/semantic_cache/test_request_helpers.py
+++ b/tests/unit/core/semantic_cache/test_request_helpers.py
@@ -1,0 +1,89 @@
+"""Request-path helpers used by the knowledge-only worker turn (docket_tasks).
+
+These are the real integration seam (the knowledge agent class is eval-only), so
+they must fail open when disabled and reuse one canonical key for lookup+store.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+import redis_sre_agent.core.semantic_cache.service as service_mod
+from redis_sre_agent.core.semantic_cache.service import (
+    _STORE_TASKS,
+    lookup_cached_answer,
+    schedule_store,
+)
+
+
+@pytest.mark.asyncio
+async def test_lookup_returns_none_when_cache_disabled():
+    # from_settings returns None when disabled/misconfigured => (None, None).
+    with (
+        patch.object(service_mod.SemanticCache, "from_settings", return_value=None),
+        patch("redis_sre_agent.core.redis.get_redis_client", return_value=MagicMock()),
+    ):
+        result, key = await lookup_cached_answer("how do I tune maxmemory?")
+    assert result is None and key is None
+
+
+@pytest.mark.asyncio
+async def test_lookup_computes_key_once_and_reuses_it_for_lookup():
+    fake_cache = MagicMock()
+    fake_cache.canonical_key = AsyncMock(return_value="canonical-q")
+    fake_cache.lookup = AsyncMock(return_value="CACHED_RESPONSE")
+    fake_cache.aclose = AsyncMock()
+
+    with (
+        patch.object(service_mod.SemanticCache, "from_settings", return_value=fake_cache),
+        patch("redis_sre_agent.core.redis.get_redis_client", return_value=MagicMock()),
+    ):
+        result, key = await lookup_cached_answer("q", conversation_history=None)
+
+    assert result == "CACHED_RESPONSE"
+    assert key == "canonical-q"
+    # The canonical key computed once is the one passed to lookup (design §F).
+    fake_cache.lookup.assert_awaited_once()
+    assert fake_cache.lookup.await_args.kwargs["rewritten_query"] == "canonical-q"
+    fake_cache.aclose.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_lookup_fails_open_on_error():
+    with (
+        patch.object(service_mod.SemanticCache, "from_settings", side_effect=RuntimeError("boom")),
+        patch("redis_sre_agent.core.redis.get_redis_client", return_value=MagicMock()),
+    ):
+        result, key = await lookup_cached_answer("q")
+    assert result is None and key is None
+
+
+@pytest.mark.asyncio
+async def test_schedule_store_runs_store_in_background():
+    fake_cache = MagicMock()
+    fake_cache.store = AsyncMock(return_value="entry-1")
+    fake_cache.aclose = AsyncMock()
+
+    with (
+        patch.object(service_mod.SemanticCache, "from_settings", return_value=fake_cache),
+        patch("redis_sre_agent.core.redis.get_redis_client", return_value=MagicMock()),
+    ):
+        schedule_store("q", "answer", [{"source_document_path": "a.md"}], None, "canonical-q")
+        # Let the fire-and-forget task run to completion.
+        await asyncio.gather(*list(_STORE_TASKS))
+
+    fake_cache.store.assert_awaited_once()
+    assert fake_cache.store.await_args.kwargs["rewritten_query"] == "canonical-q"
+    fake_cache.aclose.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_schedule_store_noop_when_disabled():
+    with (
+        patch.object(service_mod.SemanticCache, "from_settings", return_value=None),
+        patch("redis_sre_agent.core.redis.get_redis_client", return_value=MagicMock()),
+    ):
+        schedule_store("q", "answer", [{"source_document_path": "a.md"}])
+        await asyncio.gather(*list(_STORE_TASKS))
+    # No cache built => nothing to assert beyond "did not raise".

--- a/tests/unit/core/semantic_cache/test_rewrite.py
+++ b/tests/unit/core/semantic_cache/test_rewrite.py
@@ -1,0 +1,54 @@
+"""US-006: mid-conversation query rewriting (nano), first-turn passthrough."""
+
+from unittest.mock import patch
+
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage
+
+from redis_sre_agent.core.semantic_cache import rewrite as rewrite_mod
+from redis_sre_agent.core.semantic_cache.rewrite import rewrite_query
+
+
+class _FakeLLM:
+    def __init__(self, content):
+        self._content = content
+        self.invoked = False
+
+    async def ainvoke(self, messages):
+        self.invoked = True
+        return AIMessage(content=self._content)
+
+
+class _RaisingLLM:
+    async def ainvoke(self, messages):
+        raise RuntimeError("llm down")
+
+
+@pytest.mark.asyncio
+async def test_first_turn_returns_raw_without_calling_llm():
+    fake = _FakeLLM("SHOULD NOT BE USED")
+    with patch.object(rewrite_mod, "create_nano_llm", return_value=fake):
+        out = await rewrite_query("what is maxmemory?", conversation_history=None)
+    assert out == "what is maxmemory?"
+    assert fake.invoked is False
+
+
+@pytest.mark.asyncio
+async def test_mid_conversation_uses_nano_rewrite():
+    fake = _FakeLLM("How do I set maxmemory in Redis 7.2?")
+    history = [
+        HumanMessage(content="How do I configure Redis 7.2?"),
+        AIMessage(content="You can use CONFIG SET."),
+    ]
+    with patch.object(rewrite_mod, "create_nano_llm", return_value=fake):
+        out = await rewrite_query("what about maxmemory?", conversation_history=history)
+    assert out == "How do I set maxmemory in Redis 7.2?"
+    assert fake.invoked is True
+
+
+@pytest.mark.asyncio
+async def test_rewrite_fails_open_to_raw_query():
+    history = [HumanMessage(content="prior")]
+    with patch.object(rewrite_mod, "create_nano_llm", return_value=_RaisingLLM()):
+        out = await rewrite_query("follow up question", conversation_history=history)
+    assert out == "follow up question"

--- a/tests/unit/core/semantic_cache/test_service.py
+++ b/tests/unit/core/semantic_cache/test_service.py
@@ -50,11 +50,12 @@ class FakeLangCache:
 class FakeProvenance:
     """Provenance double with programmable tombstone responses."""
 
-    def __init__(self, tombstone_sequence=None):
+    def __init__(self, tombstone_sequence=None, record_ok=True):
         self.records = []
         self.removed = []
         self.tombstones_written = []
         self._tombstone_sequence = list(tombstone_sequence or [])
+        self._record_ok = record_ok
         self.entries = {}
 
     async def has_fresh_tombstone(self, path_hashes):
@@ -64,7 +65,7 @@ class FakeProvenance:
 
     async def record_entry(self, entry_id, path_hashes, *, meta=None):
         self.records.append((entry_id, list(path_hashes), meta))
-        return True
+        return self._record_ok
 
     async def remove_entry(self, entry_id, path_hashes):
         self.removed.append((entry_id, list(path_hashes)))
@@ -405,3 +406,28 @@ async def test_meta_provenance_path_hashes_align_with_mixed_citations():
     assert prov_list[2]["path_hash"] == path_hash_for_source("b.md")
     # Reverse index still only carries the two real paths.
     assert prov.records[0][1] == [path_hash_for_source("a.md"), path_hash_for_source("b.md")]
+
+
+@pytest.mark.asyncio
+async def test_store_rolls_back_when_provenance_recording_fails():
+    """If reverse-index recording fails, the LangCache entry must be rolled back
+    so it can't linger un-invalidatable (only TTL would reach it)."""
+    client = FakeLangCache()
+    prov = FakeProvenance(record_ok=False)
+    cache = _make_cache(client, prov)
+    entry_id = await cache.store("q", "answer", [{"source_document_path": "a.md"}])
+    assert entry_id is None
+    assert client.set_calls and client.deleted == ["entry-xyz"]  # stored then undone
+    assert prov.removed and prov.removed[0][0] == "entry-xyz"
+
+
+@pytest.mark.asyncio
+async def test_store_no_paths_not_rolled_back_on_meta_only_failure():
+    """An entry with no source paths is TTL-only by design; a meta-only record
+    failure should NOT delete an otherwise-servable entry."""
+    client = FakeLangCache()
+    prov = FakeProvenance(record_ok=False)
+    cache = _make_cache(client, prov)
+    entry_id = await cache.store("q", "answer", [{"source": "configuration"}])
+    assert entry_id == "entry-xyz"
+    assert client.deleted == []  # not rolled back (no reverse index was expected)

--- a/tests/unit/core/semantic_cache/test_service.py
+++ b/tests/unit/core/semantic_cache/test_service.py
@@ -1,0 +1,314 @@
+"""US-007/US-009: SemanticCache lookup, store (race guard), and invalidation."""
+
+import json
+
+import fakeredis.aioredis
+import pytest
+
+from redis_sre_agent.core.semantic_cache.client import LangCacheEntry
+from redis_sre_agent.core.semantic_cache.provenance import ProvenanceStore, path_hash_for_source
+from redis_sre_agent.core.semantic_cache.service import (
+    SemanticCache,
+    _changed_source_paths,
+    invalidate_changed_sources,
+)
+
+
+class FakeLangCache:
+    def __init__(self):
+        self.search_result = []
+        self.search_exc = None
+        self.set_result = "entry-xyz"
+        self.search_calls = []
+        self.set_calls = []
+        self.deleted = []
+
+    async def search(
+        self, prompt, *, similarity_threshold, attributes=None, search_strategies=None
+    ):
+        self.search_calls.append(
+            {"prompt": prompt, "threshold": similarity_threshold, "attributes": attributes}
+        )
+        if self.search_exc is not None:
+            raise self.search_exc
+        return self.search_result
+
+    async def set_entry(self, prompt, response, *, attributes=None, ttl_millis=None):
+        self.set_calls.append(
+            {"prompt": prompt, "response": response, "attributes": attributes, "ttl": ttl_millis}
+        )
+        return self.set_result
+
+    async def delete_entry(self, entry_id):
+        self.deleted.append(entry_id)
+        return True
+
+    async def aclose(self):
+        pass
+
+
+class FakeProvenance:
+    """Provenance double with programmable tombstone responses."""
+
+    def __init__(self, tombstone_sequence=None):
+        self.records = []
+        self.removed = []
+        self.tombstones_written = []
+        self._tombstone_sequence = list(tombstone_sequence or [])
+        self.entries = {}
+
+    async def has_fresh_tombstone(self, path_hashes):
+        if self._tombstone_sequence:
+            return self._tombstone_sequence.pop(0)
+        return False
+
+    async def record_entry(self, entry_id, path_hashes, *, meta=None):
+        self.records.append((entry_id, list(path_hashes), meta))
+        return True
+
+    async def remove_entry(self, entry_id, path_hashes):
+        self.removed.append((entry_id, list(path_hashes)))
+
+    async def entries_for_path(self, path_hash):
+        return self.entries.get(path_hash, [])
+
+    async def clear_path(self, path_hash, entry_ids):
+        self.entries.pop(path_hash, None)
+
+    async def write_tombstone(self, path_hash):
+        self.tombstones_written.append(path_hash)
+
+
+def _make_cache(client, provenance):
+    return SemanticCache(
+        client=client,
+        provenance=provenance,
+        similarity_threshold=0.9,
+        ttl_latest_ms=3600_000,
+        ttl_pinned_ms=86_400_000,
+    )
+
+
+def _entry(response_payload, *, similarity=0.97, attributes=None, strategy="semantic"):
+    return LangCacheEntry(
+        id="a" * 32,
+        prompt="q",
+        response=json.dumps(response_payload),
+        similarity=similarity,
+        attributes=attributes or {},
+        search_strategy=strategy,
+    )
+
+
+# -- lookup -----------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_lookup_hit_reconstructs_response_and_sources():
+    client = FakeLangCache()
+    client.search_result = [
+        _entry({"response": "cached answer", "search_results": [{"title": "Doc"}]})
+    ]
+    cache = _make_cache(client, FakeProvenance())
+
+    result = await cache.lookup("how do I tune maxmemory?")
+    assert result is not None
+    assert result.response == "cached answer"
+    assert result.search_results == [{"title": "Doc"}]
+
+
+@pytest.mark.asyncio
+async def test_lookup_miss_returns_none():
+    client = FakeLangCache()
+    client.search_result = []
+    cache = _make_cache(client, FakeProvenance())
+    assert await cache.lookup("anything") is None
+
+
+@pytest.mark.asyncio
+async def test_lookup_below_threshold_rejected():
+    client = FakeLangCache()
+    client.search_result = [_entry({"response": "x"}, similarity=0.5)]
+    cache = _make_cache(client, FakeProvenance())
+    assert await cache.lookup("anything") is None
+
+
+@pytest.mark.asyncio
+async def test_lookup_post_filter_rejects_entity_mismatch():
+    client = FakeLangCache()
+    # Candidate is for RET-9999 but query asks about RET-4421.
+    client.search_result = [
+        _entry({"response": "wrong ticket"}, attributes={"entity_id": "RET-9999"})
+    ]
+    cache = _make_cache(client, FakeProvenance())
+
+    result = await cache.lookup("status of RET-4421")
+    assert result is None
+    # The lookup did scope by entity_id in the request attributes.
+    assert client.search_calls[0]["attributes"].get("entity_id") == "RET-4421"
+
+
+@pytest.mark.asyncio
+async def test_lookup_post_filter_accepts_entity_match():
+    client = FakeLangCache()
+    client.search_result = [
+        _entry({"response": "right ticket"}, attributes={"entity_id": "RET-4421"})
+    ]
+    cache = _make_cache(client, FakeProvenance())
+    result = await cache.lookup("status of RET-4421")
+    assert result is not None and result.response == "right ticket"
+
+
+@pytest.mark.asyncio
+async def test_lookup_fails_open_on_client_error():
+    client = FakeLangCache()
+    client.search_exc = RuntimeError("langcache down")
+    cache = _make_cache(client, FakeProvenance())
+    assert await cache.lookup("anything") is None
+
+
+# -- store ------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_store_grounded_writes_entry_and_index():
+    client = FakeLangCache()
+    prov = FakeProvenance()
+    cache = _make_cache(client, prov)
+
+    entry_id = await cache.store(
+        "how do I tune maxmemory?",
+        "the answer",
+        [{"source_document_path": "runbooks/mem.md", "title": "Mem"}],
+    )
+    assert entry_id == "entry-xyz"
+    assert len(client.set_calls) == 1
+    # Canonical-key invariant: first-turn store key == raw query == lookup key.
+    assert client.set_calls[0]["prompt"] == "how do I tune maxmemory?"
+    assert client.set_calls[0]["attributes"]["cache_origin"] == "dynamic"
+    assert client.set_calls[0]["attributes"]["version"] == "latest"
+    # Reverse index recorded against the cited source's path_hash.
+    recorded_entry, recorded_hashes, _meta = prov.records[0]
+    assert recorded_entry == "entry-xyz"
+    assert recorded_hashes == [path_hash_for_source("runbooks/mem.md")]
+
+
+@pytest.mark.asyncio
+async def test_store_reuses_supplied_rewritten_key_without_calling_nano(monkeypatch):
+    """When the caller supplies the canonical key (§F), store must not rewrite again."""
+    import redis_sre_agent.core.semantic_cache.service as service_mod
+
+    def _boom(*args, **kwargs):
+        raise AssertionError("rewrite_query must not be called when key is supplied")
+
+    monkeypatch.setattr(service_mod, "rewrite_query", _boom)
+
+    client = FakeLangCache()
+    cache = _make_cache(client, FakeProvenance())
+    entry_id = await cache.store(
+        "follow up?",
+        "answer",
+        [{"source_document_path": "a.md"}],
+        conversation_history=[object()],
+        rewritten_query="precomputed standalone question",
+    )
+    assert entry_id == "entry-xyz"
+    assert client.set_calls[0]["prompt"] == "precomputed standalone question"
+
+
+@pytest.mark.asyncio
+async def test_canonical_key_truncates_to_prompt_limit():
+    client = FakeLangCache()
+    cache = _make_cache(client, FakeProvenance())
+    key = await cache.canonical_key("x" * 5000, conversation_history=None)
+    assert key == "x" * 1024
+
+
+@pytest.mark.asyncio
+async def test_store_ungrounded_skipped():
+    client = FakeLangCache()
+    cache = _make_cache(client, FakeProvenance())
+    entry_id = await cache.store("q", "answer", [])
+    assert entry_id is None
+    assert client.set_calls == []
+
+
+@pytest.mark.asyncio
+async def test_store_skipped_when_tombstone_present_before_write():
+    client = FakeLangCache()
+    prov = FakeProvenance(tombstone_sequence=[True])  # fresh tombstone before store
+    cache = _make_cache(client, prov)
+    entry_id = await cache.store("q", "answer", [{"source_document_path": "a.md"}])
+    assert entry_id is None
+    assert client.set_calls == []
+
+
+@pytest.mark.asyncio
+async def test_store_undone_when_tombstone_appears_during_write():
+    client = FakeLangCache()
+    # False before write, True on the post-SADD recheck.
+    prov = FakeProvenance(tombstone_sequence=[False, True])
+    cache = _make_cache(client, prov)
+
+    entry_id = await cache.store("q", "answer", [{"source_document_path": "a.md"}])
+    assert entry_id is None
+    assert len(client.set_calls) == 1  # it was stored...
+    assert client.deleted == ["entry-xyz"]  # ...then undone
+    assert prov.removed and prov.removed[0][0] == "entry-xyz"
+
+
+@pytest.mark.asyncio
+async def test_store_pinned_version_uses_longer_ttl():
+    client = FakeLangCache()
+    cache = _make_cache(client, FakeProvenance())
+    await cache.store("what changed in 7.8?", "answer", [{"source_document_path": "a.md"}])
+    assert client.set_calls[0]["ttl"] == 86_400_000
+    assert client.set_calls[0]["attributes"]["version"] == "7.8"
+
+
+# -- invalidation -----------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_invalidate_deletes_entries_and_writes_tombstone():
+    client = FakeLangCache()
+    redis_client = fakeredis.aioredis.FakeRedis()
+    store = ProvenanceStore(redis_client)
+    cache = _make_cache(client, store)
+
+    ph = path_hash_for_source("changed.md")
+    await store.record_entry("e1", [ph], meta={})
+    await store.record_entry("e2", [ph], meta={})
+
+    deleted = await cache.invalidate(["changed.md"])
+    assert deleted == 2
+    assert set(client.deleted) == {"e1", "e2"}
+    assert await store.entries_for_path(ph) == []
+    assert await store.has_fresh_tombstone([ph]) is True
+
+
+def test_changed_source_paths_filters_to_replaced_or_removed():
+    summary = {
+        "files": [
+            {"path": "a.md", "action": "update"},
+            {"path": "b.md", "action": "add"},
+            {"path": "c.md", "action": "delete"},
+            {"path": "d.md", "action": "unchanged"},
+        ]
+    }
+    assert _changed_source_paths(summary) == ["a.md", "c.md"]
+    # Also supports the workflow-mixin "file" key shape.
+    assert _changed_source_paths([{"file": "x.md", "action": "updated"}]) == ["x.md"]
+
+
+@pytest.mark.asyncio
+async def test_invalidate_changed_sources_noop_without_credentials():
+    # Default settings have no LangCache credentials => no-op, returns 0.
+    deleted = await invalidate_changed_sources({"files": [{"path": "a.md", "action": "update"}]})
+    assert deleted == 0
+
+
+@pytest.mark.asyncio
+async def test_invalidate_changed_sources_noop_for_pure_adds():
+    deleted = await invalidate_changed_sources([{"file": "a.md", "action": "add"}])
+    assert deleted == 0

--- a/tests/unit/core/semantic_cache/test_service.py
+++ b/tests/unit/core/semantic_cache/test_service.py
@@ -491,3 +491,24 @@ async def test_invalidate_multi_path_shared_entry_clears_all_links():
     assert client.deleted == ["shared"]  # not re-deleted on the second path
     assert await store.entries_for_path(ph_a) == []
     assert await store.entries_for_path(ph_b) == []  # no orphan
+
+
+@pytest.mark.asyncio
+async def test_lookup_skips_multi_entity_query():
+    client = FakeLangCache()
+    client.search_result = [_entry({"response": "x"})]
+    cache = _make_cache(client, FakeProvenance())
+    result = await cache.lookup("compare RET-4421 and RET-4422")
+    assert result is None
+    assert client.search_calls == []  # never even queried LangCache
+
+
+@pytest.mark.asyncio
+async def test_store_skips_multi_entity_query():
+    client = FakeLangCache()
+    cache = _make_cache(client, FakeProvenance())
+    entry_id = await cache.store(
+        "compare RET-4421 and RET-4422", "answer", [{"source_document_path": "a.md"}]
+    )
+    assert entry_id is None
+    assert client.set_calls == []  # never stored

--- a/tests/unit/core/semantic_cache/test_service.py
+++ b/tests/unit/core/semantic_cache/test_service.py
@@ -471,3 +471,23 @@ async def test_aclose_never_raises():
         ttl_pinned_ms=1,
     )
     await cache.aclose()  # must not raise
+
+
+@pytest.mark.asyncio
+async def test_invalidate_multi_path_shared_entry_clears_all_links():
+    """An entry cited by several changed paths must be deleted once and have its
+    link cleared from EVERY path's reverse-index set (no orphan on later paths)."""
+    client = FakeLangCache()
+    redis_client = fakeredis.aioredis.FakeRedis()
+    store = ProvenanceStore(redis_client)
+    cache = _make_cache(client, store)
+
+    ph_a = path_hash_for_source("a.md")
+    ph_b = path_hash_for_source("b.md")
+    await store.record_entry("shared", [ph_a, ph_b], meta={})
+
+    deleted = await cache.invalidate(["a.md", "b.md"])
+    assert deleted == 1  # deleted once, not double-counted
+    assert client.deleted == ["shared"]  # not re-deleted on the second path
+    assert await store.entries_for_path(ph_a) == []
+    assert await store.entries_for_path(ph_b) == []  # no orphan

--- a/tests/unit/core/semantic_cache/test_service.py
+++ b/tests/unit/core/semantic_cache/test_service.py
@@ -22,6 +22,7 @@ class FakeLangCache:
         self.search_calls = []
         self.set_calls = []
         self.deleted = []
+        self.delete_fail = set()  # entry_ids for which delete_entry returns False
 
     async def search(
         self, prompt, *, similarity_threshold, attributes=None, search_strategies=None
@@ -41,7 +42,7 @@ class FakeLangCache:
 
     async def delete_entry(self, entry_id):
         self.deleted.append(entry_id)
-        return True
+        return entry_id not in self.delete_fail
 
     async def aclose(self):
         pass
@@ -431,3 +432,23 @@ async def test_store_no_paths_not_rolled_back_on_meta_only_failure():
     entry_id = await cache.store("q", "answer", [{"source": "configuration"}])
     assert entry_id == "entry-xyz"
     assert client.deleted == []  # not rolled back (no reverse index was expected)
+
+
+@pytest.mark.asyncio
+async def test_invalidate_keeps_reverse_index_for_failed_deletes():
+    """A failed LangCache delete must NOT drop its reverse-index link — the row
+    may still exist and needs to stay invalidatable on a later retry."""
+    client = FakeLangCache()
+    client.delete_fail = {"e_fail"}
+    redis_client = fakeredis.aioredis.FakeRedis()
+    store = ProvenanceStore(redis_client)
+    cache = _make_cache(client, store)
+
+    ph = path_hash_for_source("changed.md")
+    await store.record_entry("e_ok", [ph], meta={})
+    await store.record_entry("e_fail", [ph], meta={})
+
+    deleted = await cache.invalidate(["changed.md"])
+    assert deleted == 1  # only e_ok
+    remaining = await store.entries_for_path(ph)
+    assert remaining == ["e_fail"]  # failed delete kept for retry; e_ok removed

--- a/tests/unit/core/semantic_cache/test_service.py
+++ b/tests/unit/core/semantic_cache/test_service.py
@@ -312,3 +312,71 @@ async def test_invalidate_changed_sources_noop_without_credentials():
 async def test_invalidate_changed_sources_noop_for_pure_adds():
     deleted = await invalidate_changed_sources([{"file": "a.md", "action": "add"}])
     assert deleted == 0
+
+
+# -- regression coverage for PR review findings ------------------------------
+
+
+@pytest.mark.asyncio
+async def test_store_version_resolved_from_rewritten_key_not_raw_query():
+    """Version/entity are tagged from the canonical key, not the raw query.
+
+    A referential mid-conversation turn ("what about that version?") has no
+    version in the raw text, but the nano rewrite resolves it (e.g. 7.2). The
+    stored entry must carry version=7.2 (+ pinned TTL), not latest.
+    """
+    client = FakeLangCache()
+    cache = _make_cache(client, FakeProvenance())
+    await cache.store(
+        "what about that version?",
+        "answer",
+        [{"source_document_path": "a.md"}],
+        conversation_history=[object()],
+        rewritten_query="How do I configure clustering in Redis 7.2?",
+    )
+    assert client.set_calls[0]["attributes"]["version"] == "7.2"
+    assert client.set_calls[0]["ttl"] == 86_400_000  # pinned TTL, not latest
+
+
+@pytest.mark.asyncio
+async def test_lookup_version_resolved_from_rewritten_key():
+    client = FakeLangCache()
+    client.search_result = []
+    cache = _make_cache(client, FakeProvenance())
+    await cache.lookup(
+        "what about that version?",
+        conversation_history=[object()],
+        rewritten_query="How do I configure clustering in Redis 7.2?",
+    )
+    assert client.search_calls[0]["attributes"]["version"] == "7.2"
+
+
+def test_path_hashes_ignores_source_fallback():
+    """Only source_document_path is hashed; `source` is not a fallback (would
+    mint a hash ingestion never emits -> un-invalidatable entries)."""
+    assert SemanticCache._path_hashes([{"source": "configuration"}]) == []
+    assert SemanticCache._path_hashes([{"source_document_path": "runbooks/x.md"}]) == [
+        path_hash_for_source("runbooks/x.md")
+    ]
+
+
+@pytest.mark.asyncio
+async def test_store_without_source_document_path_records_no_reverse_index():
+    client = FakeLangCache()
+    prov = FakeProvenance()
+    cache = _make_cache(client, prov)
+    entry_id = await cache.store("q", "answer", [{"source": "configuration", "title": "X"}])
+    assert entry_id == "entry-xyz"  # still stored (grounded)
+    assert prov.records[0][1] == []  # ...but no path_hashes -> no reverse index
+
+
+@pytest.mark.asyncio
+async def test_lookup_rejects_ticket_entry_for_general_query():
+    """A general query (no entity_id) must not be served a ticket-scoped entry."""
+    client = FakeLangCache()
+    client.search_result = [
+        _entry({"response": "ticket-scoped answer"}, attributes={"entity_id": "RET-4421"})
+    ]
+    cache = _make_cache(client, FakeProvenance())
+    result = await cache.lookup("how do I tune maxmemory?")  # no entity_id
+    assert result is None

--- a/tests/unit/core/semantic_cache/test_service.py
+++ b/tests/unit/core/semantic_cache/test_service.py
@@ -380,3 +380,28 @@ async def test_lookup_rejects_ticket_entry_for_general_query():
     cache = _make_cache(client, FakeProvenance())
     result = await cache.lookup("how do I tune maxmemory?")  # no entity_id
     assert result is None
+
+
+@pytest.mark.asyncio
+async def test_meta_provenance_path_hashes_align_with_mixed_citations():
+    """cache_meta provenance must pair each result with ITS OWN path_hash, even
+    when some cited rows lack source_document_path (would misalign under zip)."""
+    client = FakeLangCache()
+    prov = FakeProvenance()
+    cache = _make_cache(client, prov)
+    await cache.store(
+        "q",
+        "answer",
+        [
+            {"source_document_path": "a.md", "title": "A"},
+            {"source": "configuration", "title": "no-path"},  # no source_document_path
+            {"source_document_path": "b.md", "title": "B"},
+        ],
+    )
+    meta = prov.records[0][2]
+    prov_list = meta["provenance"]
+    assert prov_list[0]["path_hash"] == path_hash_for_source("a.md")
+    assert prov_list[1]["path_hash"] is None  # row without a path stays None
+    assert prov_list[2]["path_hash"] == path_hash_for_source("b.md")
+    # Reverse index still only carries the two real paths.
+    assert prov.records[0][1] == [path_hash_for_source("a.md"), path_hash_for_source("b.md")]

--- a/tests/unit/core/semantic_cache/test_service.py
+++ b/tests/unit/core/semantic_cache/test_service.py
@@ -452,3 +452,22 @@ async def test_invalidate_keeps_reverse_index_for_failed_deletes():
     assert deleted == 1  # only e_ok
     remaining = await store.entries_for_path(ph)
     assert remaining == ["e_fail"]  # failed delete kept for retry; e_ok removed
+
+
+@pytest.mark.asyncio
+async def test_aclose_never_raises():
+    """Cleanup must be exception-safe so a failed close in a finally can't
+    discard an already-computed lookup result/key."""
+
+    class _BoomClient:
+        async def aclose(self):
+            raise RuntimeError("close boom")
+
+    cache = SemanticCache(
+        client=_BoomClient(),
+        provenance=FakeProvenance(),
+        similarity_threshold=0.9,
+        ttl_latest_ms=1,
+        ttl_pinned_ms=1,
+    )
+    await cache.aclose()  # must not raise

--- a/tests/unit/core/test_search_source_document_path.py
+++ b/tests/unit/core/test_search_source_document_path.py
@@ -1,0 +1,95 @@
+"""US-001: source_document_path is surfaced in knowledge search results.
+
+The semantic cache's provenance/invalidation keys on source_document_path, so it
+must reach the serialized search-result dict (design §0).
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from redis_sre_agent.core.knowledge_helpers import (
+    _SEARCH_RETURN_FIELDS,
+    search_knowledge_base_helper,
+)
+
+
+def test_source_document_path_in_return_fields():
+    """RediSearch RETURN must request the hash field so it reaches results."""
+    assert "source_document_path" in _SEARCH_RETURN_FIELDS
+
+
+@pytest.mark.asyncio
+async def test_search_result_includes_source_document_path():
+    mock_index = AsyncMock()
+    mock_index.query = AsyncMock(
+        return_value=[
+            {
+                "id": "doc-1",
+                "document_hash": "hash-1",
+                "chunk_index": 0,
+                "title": "Redis Memory",
+                "content": "Redis memory management guide",
+                "source": "docs",
+                "category": "monitoring",
+                "doc_type": "runbook",
+                "version": "latest",
+                "source_document_path": "runbooks/memory.md",
+                "score": 0.95,
+            }
+        ]
+    )
+    mock_vectorizer = MagicMock()
+    mock_vectorizer.aembed_many = AsyncMock(return_value=[[0.1, 0.2, 0.3]])
+
+    with (
+        patch(
+            "redis_sre_agent.core.knowledge_helpers.get_knowledge_index",
+            new_callable=AsyncMock,
+            return_value=mock_index,
+        ),
+        patch(
+            "redis_sre_agent.core.knowledge_helpers.get_vectorizer",
+            return_value=mock_vectorizer,
+        ),
+    ):
+        result = await search_knowledge_base_helper(query="redis memory", limit=10)
+
+    assert result["results"][0]["source_document_path"] == "runbooks/memory.md"
+
+
+@pytest.mark.asyncio
+async def test_search_result_source_document_path_defaults_empty():
+    """A doc hash without the field serializes to an empty string, not a KeyError."""
+    mock_index = AsyncMock()
+    mock_index.query = AsyncMock(
+        return_value=[
+            {
+                "id": "doc-2",
+                "document_hash": "hash-2",
+                "title": "No path doc",
+                "content": "body",
+                "source": "docs",
+                "doc_type": "runbook",
+                "version": "latest",
+                "score": 0.9,
+            }
+        ]
+    )
+    mock_vectorizer = MagicMock()
+    mock_vectorizer.aembed_many = AsyncMock(return_value=[[0.1, 0.2, 0.3]])
+
+    with (
+        patch(
+            "redis_sre_agent.core.knowledge_helpers.get_knowledge_index",
+            new_callable=AsyncMock,
+            return_value=mock_index,
+        ),
+        patch(
+            "redis_sre_agent.core.knowledge_helpers.get_vectorizer",
+            return_value=mock_vectorizer,
+        ),
+    ):
+        result = await search_knowledge_base_helper(query="x", limit=10)
+
+    assert result["results"][0]["source_document_path"] == ""


### PR DESCRIPTION
## Summary

Adds a flag-gated (`semantic_cache_enabled`, default **OFF**) semantic answer cache in front of the knowledge-only agent turn. On a sufficiently similar prior question it serves the cached answer and short-circuits the graph. Backend is managed **Redis LangCache** (embeddings/index/similarity/TTL/attribute filters); provenance for surgical invalidation lives in our existing Redis.

## What gets cached

An answer is stored only when **grounded** — `search_results` (citations from the turn) is non-empty — so there's real document provenance to stamp and invalidate against. Ungrounded answers are the only hard `do_not_cache` reason. Single global cache (knowledge corpus is shared, no per-user ACL).

```
┌─────────────── LangCache (managed) — one entry per answer ───────────────┐
│ prompt      canonical/rewritten question (LangCache embeds it)           │
│ response    answer + source citations (JSON string)                      │
│ attributes  version · cache_origin · entity_id     (3, scalar, ≤5 allowed)│
│ ttlMillis   fixed at store time (short for latest, longer for pinned)    │
│ entry_id    returned by set                                              │
└──────────────────────────────────────────────────────────────────────────┘
        │ entry_id                         ▲ path_hash → entry_ids
        ▼                                   │
┌──────────────── Our Redis (existing instance) ──────────────────────────┐
│ cache_prov:{path_hash}  → SET of entry_ids       (reverse index)         │
│ cache_meta:{entry_id}   → JSON provenance + audit (debug; off serve path)│
│ cache_inval:{path_hash} → short-TTL tombstone     (write-vs-invalidate)  │
└──────────────────────────────────────────────────────────────────────────┘
```

**Attributes** (declared at cache creation, immutable, scalar exact-match): `version` (lookup filter, never serve latest to a 7.2 query), `cache_origin` (`dynamic`; `curated` reserved for Phase-2 warming), `entity_id` (support-ticket IDs only, e.g. `RET-4421`).

**Reverse index** `cache_prov:{path_hash}` (`path_hash = sha256(source_document_path)[:16]`, same hash ingestion uses): `SADD` per cited doc at store; `SMEMBERS → delete_entry` at invalidation. This is what makes surgical per-document invalidation possible without LangCache multi-value support.

**Side metadata** `cache_meta:{entry_id}`: full provenance + audit for debugging; not on the serve path (sources ride inside the LangCache `response`).

## Read path
1. Gate on `semantic_cache_enabled` (+ knowledge-only turn).
2. Resolve version from the query (default `latest`); extract `entity_id` for ticket-ID queries (version-first precedence).
3. Compute the canonical key **once** (first-turn: raw query; mid-conversation: nano rewrite preserving must-keep tokens).
4. Single LangCache `search` with `searchStrategies:[exact, semantic]` + attribute filter + threshold (0.9).
5. **Post-filter safety net**: reject if the hit's `entity_id` ≠ requested (correct regardless of LangCache filter ordering).
6. On hit: reconstruct the `AgentResponse` (answer + sources) from the stored payload; log `hit via exact|semantic` + similarity. **Fail open** on any error → treat as miss.

## Write path (miss)
Run the graph, return to the user, then **async fire-and-forget**: gate on grounded; check tombstone; store with attributes + fixed TTL; `SADD` reverse index; write `cache_meta`; **recheck tombstone after `SADD` and undo on race**. Errors/ungrounded → no write. TTL is a fixed backstop; correctness comes from push invalidation.

## Invalidation
On ingestion completion, for each **replaced/removed** doc (not pure adds): write tombstone → `SMEMBERS cache_prov:{path_hash}` → `delete_entry` each → clear the set. Runs even when serving is disabled (kill switch keeps invalidation alive). Fails open.

## Integration point
Wired into `docket_tasks.process_agent_turn`'s `is_knowledge_only` branch (the real worker path). `KnowledgeOnlyAgent` is eval-only; the live knowledge route runs through `ChatAgent`, so the cache attaches where traffic actually flows. Instance-scoped chat/triage turns stay uncached by design.

## Deferred to a later PR
Feedback-driven eviction, curated pre-warming, multi-entity decomposition, single-flight stampede lock, chunk-level invalidation, redis-target `entity_id`, and **eval-suite coverage** (semantic caching has unit tests + manual live E2E, but no eval scenario yet — a conscious deferral).

## Validation
Unit tests (`tests/unit/core/semantic_cache/`, ~64) + live E2E against real LangCache (two-session store→hit, provenance verified, push invalidation). CI-parity: ruff, docs, `test-eval-pr` (292), `test-eval-pr-live` (3/3) all green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes answer correctness and freshness for knowledge queries when enabled; mitigations include default-off, fail-open, grounded-only writes, and ingestion push invalidation, but similarity hits and race windows still need ops validation.
> 
> **Overview**
> Adds a **flag-gated semantic answer cache** (`semantic_cache_enabled`, default **OFF**) in front of **knowledge-only** worker turns in `docket_tasks`, skipping the LangGraph run on similar prior questions. Managed **LangCache** holds prompts/responses and attribute filters; **local Redis** holds `cache_prov` / `cache_meta` / `cache_inval` for provenance and push invalidation.
> 
> New `redis_sre_agent/core/semantic_cache/` implements lookup (`exact` then `semantic`), mid-conversation **nano** rewrite for canonical keys, version/ticket **entity_id** scoping with a post-filter safety net, grounded-only async stores, and tombstone-guarded write races. **Ingestion** calls `invalidate_changed_sources` in `finally` blocks when docs are updated or removed.
> 
> **Prerequisite:** `source_document_path` is added to knowledge search return fields for invalidation hashing. Config adds LangCache URLs, thresholds, and TTLs. A design doc and broad unit tests cover the module and integration helpers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25d8e8954c3f675e33ea09e274b39579f17aef0d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->