### PR TITLE
Validate release knowledge pack source coverage

### DIFF
--- a/redis_sre_agent/knowledge_pack/builder.py
+++ b/redis_sre_agent/knowledge_pack/builder.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import base64
+import hashlib
 import json
+import re
 import shutil
 import subprocess
 import tempfile
@@ -13,6 +15,7 @@ from typing import Any, Optional
 from zipfile import ZIP_DEFLATED, ZipFile
 
 from redis_sre_agent.core.config import Settings, settings
+from redis_sre_agent.core.keys import RedisKeys
 from redis_sre_agent.core.redis import SRE_KNOWLEDGE_SCHEMA, get_knowledge_index
 
 from .checksums import build_checksums_for_directory, write_checksums_file
@@ -34,6 +37,9 @@ from .utils import utcnow
 
 _MANIFEST_FILE = "manifest.json"
 _CHECKSUMS_FILE = "checksums.txt"
+_SOURCE_DOCUMENTS_SCRAPER = "source_documents"
+_NON_KNOWLEDGE_RESTORE_DOC_TYPES = {"skill", "support_ticket"}
+_MAX_MISSING_EXAMPLES = 5
 
 
 def _git_rev_parse(target: str, cwd: Path) -> str | None:
@@ -199,6 +205,135 @@ def _copy_batch_artifacts(source_batch_path: Path, destination_root: Path) -> in
     )
 
 
+def _iter_artifact_payloads(batch_root: Path) -> list[tuple[Path, dict[str, Any]]]:
+    payloads: list[tuple[Path, dict[str, Any]]] = []
+    for artifact_path in sorted(batch_root.rglob("*.json")):
+        if artifact_path.name in {"batch_manifest.json", "ingestion_manifest.json"}:
+            continue
+        payload = json.loads(artifact_path.read_text(encoding="utf-8"))
+        if isinstance(payload, dict):
+            payloads.append((artifact_path, payload))
+    return payloads
+
+
+def _normalize_doc_type(value: Any) -> str:
+    normalized = re.sub(r"[\s-]+", "_", str(value or "").strip().lower())
+    return normalized or "knowledge"
+
+
+def _artifact_doc_type(payload: dict[str, Any]) -> str:
+    metadata = payload.get("metadata")
+    metadata_doc_type = metadata.get("doc_type") if isinstance(metadata, dict) else None
+    return _normalize_doc_type(payload.get("doc_type") or metadata_doc_type or "knowledge")
+
+
+def _artifact_source_document_path(payload: dict[str, Any]) -> str:
+    metadata = payload.get("metadata")
+    if not isinstance(metadata, dict):
+        return ""
+    return str(metadata.get("source_document_path") or "").strip()
+
+
+def _knowledge_source_meta_key(source_document_path: str) -> str:
+    path_hash = hashlib.sha256(source_document_path.encode("utf-8")).hexdigest()[:16]
+    return RedisKeys.knowledge_source_meta(path_hash)
+
+
+def _expected_repo_source_document_paths(repo_root: Path) -> set[str]:
+    source_root = repo_root / "source_documents"
+    if not source_root.exists():
+        return set()
+    return {
+        path.relative_to(source_root).as_posix()
+        for path in source_root.rglob("*.md")
+        if path.is_file() and path.name.lower() != "readme.md"
+    }
+
+
+def _format_missing_values(values: set[str]) -> str:
+    examples = sorted(values)[:_MAX_MISSING_EXAMPLES]
+    suffix = "" if len(values) <= _MAX_MISSING_EXAMPLES else ", ..."
+    return ", ".join(examples) + suffix
+
+
+def _validate_repo_source_artifact_coverage(
+    *,
+    repo_root: Path,
+    source_batch_path: Path,
+    artifact_payloads: list[tuple[Path, dict[str, Any]]],
+    scrapers_run: list[str],
+) -> int:
+    if _SOURCE_DOCUMENTS_SCRAPER not in scrapers_run:
+        return 0
+
+    expected_source_paths = _expected_repo_source_document_paths(repo_root)
+    if not expected_source_paths:
+        return 0
+
+    artifact_source_paths = {
+        source_document_path
+        for _, payload in artifact_payloads
+        if (source_document_path := _artifact_source_document_path(payload))
+    }
+    missing = expected_source_paths - artifact_source_paths
+    if missing:
+        raise ValueError(
+            "Knowledge-pack artifact batch is missing "
+            f"{len(missing)} source_documents artifacts from {source_batch_path}: "
+            f"{_format_missing_values(missing)}"
+        )
+    return len(expected_source_paths)
+
+
+def _expected_knowledge_restore_keys(
+    artifact_payloads: list[tuple[Path, dict[str, Any]]],
+) -> tuple[set[str], set[str]]:
+    document_meta_keys: set[str] = set()
+    source_meta_keys: set[str] = set()
+    for artifact_path, payload in artifact_payloads:
+        if _artifact_doc_type(payload) in _NON_KNOWLEDGE_RESTORE_DOC_TYPES:
+            continue
+
+        content_hash = str(payload.get("content_hash") or "").strip()
+        if not content_hash:
+            raise ValueError(f"Knowledge artifact is missing content_hash: {artifact_path}")
+
+        document_meta_keys.add(RedisKeys.knowledge_document_meta(content_hash))
+        source_document_path = _artifact_source_document_path(payload)
+        if source_document_path:
+            source_meta_keys.add(_knowledge_source_meta_key(source_document_path))
+    return document_meta_keys, source_meta_keys
+
+
+def _validate_restore_record_coverage(
+    *,
+    expected_document_meta_keys: set[str],
+    expected_source_meta_keys: set[str],
+    document_meta_records: list[dict[str, Any]],
+    source_meta_records: list[dict[str, Any]],
+) -> None:
+    actual_document_meta_keys = {str(record.get("key") or "") for record in document_meta_records}
+    actual_source_meta_keys = {str(record.get("key") or "") for record in source_meta_records}
+    missing_document_meta = expected_document_meta_keys - actual_document_meta_keys
+    missing_source_meta = expected_source_meta_keys - actual_source_meta_keys
+
+    errors: list[str] = []
+    if missing_document_meta:
+        errors.append(
+            f"missing {len(missing_document_meta)} document metadata records "
+            f"({_format_missing_values(missing_document_meta)})"
+        )
+    if missing_source_meta:
+        errors.append(
+            f"missing {len(missing_source_meta)} source tracking records "
+            f"({_format_missing_values(missing_source_meta)})"
+        )
+    if errors:
+        raise ValueError(
+            "Knowledge-pack restore records do not cover the artifact batch: " + "; ".join(errors)
+        )
+
+
 def _build_source_revisions(repo_root: Path, repo_sha: str | None) -> dict[str, Any]:
     source_revisions: dict[str, Any] = {}
     if repo_sha:
@@ -265,6 +400,18 @@ async def build_knowledge_pack(
 
     index = await get_knowledge_index(config=cfg)
     redis_client = index.client
+    normalized_scrapers_run = scrapers_run or []
+    artifact_payloads = _iter_artifact_payloads(source_batch_path)
+    repo_source_documents = _validate_repo_source_artifact_coverage(
+        repo_root=repo_root,
+        source_batch_path=source_batch_path,
+        artifact_payloads=artifact_payloads,
+        scrapers_run=normalized_scrapers_run,
+    )
+    expected_document_meta_keys, expected_source_meta_keys = _expected_knowledge_restore_keys(
+        artifact_payloads
+    )
+
     chunk_records = await _scan_chunk_records(redis_client)
     document_meta_records = await _scan_meta_records(redis_client, pattern="sre_knowledge_meta:*")
     source_meta_records = [
@@ -282,6 +429,12 @@ async def build_knowledge_pack(
         raise ValueError(
             "Knowledge index is empty; ingest the target batch before building a pack."
         )
+    _validate_restore_record_coverage(
+        expected_document_meta_keys=expected_document_meta_keys,
+        expected_source_meta_keys=expected_source_meta_keys,
+        document_meta_records=document_meta_records,
+        source_meta_records=source_meta_records,
+    )
 
     pack_id = uuid.uuid4().hex
     active_registry = ActiveKnowledgePackRegistry(
@@ -322,6 +475,9 @@ async def build_knowledge_pack(
             source_revisions=source_revisions,
             record_counts=RecordCounts(
                 artifact_documents=artifact_documents,
+                repo_source_documents=repo_source_documents,
+                knowledge_artifact_documents=len(expected_document_meta_keys),
+                knowledge_source_documents=len(expected_source_meta_keys),
                 chunk_records=len(chunk_records),
                 document_meta_records=len(document_meta_records),
                 source_meta_records=len(source_meta_records),

--- a/redis_sre_agent/knowledge_pack/models.py
+++ b/redis_sre_agent/knowledge_pack/models.py
@@ -23,6 +23,9 @@ class RecordCounts(BaseModel):
     """Counts of exported records included in a knowledge pack."""
 
     artifact_documents: int = 0
+    repo_source_documents: int = 0
+    knowledge_artifact_documents: int = 0
+    knowledge_source_documents: int = 0
     chunk_records: int = 0
     document_meta_records: int = 0
     source_meta_records: int = 0

--- a/tests/integration/test_knowledge_pack_integration.py
+++ b/tests/integration/test_knowledge_pack_integration.py
@@ -1,3 +1,4 @@
+import hashlib
 import json
 from array import array
 from pathlib import Path
@@ -45,6 +46,7 @@ def _write_artifact_batch(root: Path, batch_date: str) -> None:
                 "doc_type": "knowledge",
                 "severity": "medium",
                 "content_hash": "content-hash-1",
+                "metadata": {"source_document_path": "shared/release-doc.md"},
             }
         )
         + "\n",
@@ -60,8 +62,10 @@ async def test_build_and_restore_knowledge_pack_round_trip(
     await create_indices(config=test_settings)
     index = await get_knowledge_index(config=test_settings)
     vector = array("f", [0.0] * test_settings.vector_dim).tobytes()
-    document_hash = "dochash-roundtrip"
+    document_hash = "content-hash-1"
     chunk_key = RedisKeys.knowledge_chunk(document_hash, 0)
+    source_document_path = "shared/release-doc.md"
+    source_path_hash = hashlib.sha256(source_document_path.encode("utf-8")).hexdigest()[:16]
 
     await index.load(
         data=[
@@ -86,9 +90,9 @@ async def test_build_and_restore_knowledge_pack_round_trip(
         mapping={"document_hash": document_hash, "content_hash": "content-hash-1"},
     )
     await async_redis_client.hset(
-        RedisKeys.knowledge_source_meta("sourcehash-1"),
+        RedisKeys.knowledge_source_meta(source_path_hash),
         mapping={
-            "source_document_path": "shared/release-doc.md",
+            "source_document_path": source_document_path,
             "document_hash": document_hash,
         },
     )
@@ -110,6 +114,8 @@ async def test_build_and_restore_knowledge_pack_round_trip(
 
     assert pack_path.exists()
     assert build_result["record_counts"]["chunk_records"] == 1
+    assert build_result["record_counts"]["knowledge_artifact_documents"] == 1
+    assert build_result["record_counts"]["knowledge_source_documents"] == 1
 
     await async_redis_client.flushdb()
     await create_indices(config=test_settings)

--- a/tests/unit/knowledge_pack/test_builder.py
+++ b/tests/unit/knowledge_pack/test_builder.py
@@ -2,8 +2,14 @@ import json
 from pathlib import Path
 from unittest.mock import Mock
 
+import pytest
+
+from redis_sre_agent.core.keys import RedisKeys
 from redis_sre_agent.knowledge_pack.builder import (
     _copy_batch_artifacts,
+    _expected_knowledge_restore_keys,
+    _validate_repo_source_artifact_coverage,
+    _validate_restore_record_coverage,
     compute_embedding_fingerprint,
     compute_schema_hash,
     resolve_pack_embedding_profile,
@@ -101,3 +107,78 @@ def test_copy_batch_artifacts_excludes_batch_manifest_from_fallback_count(tmp_pa
     copied_count = _copy_batch_artifacts(source_batch_path, tmp_path / "pack-root")
 
     assert copied_count == 2
+
+
+def test_validate_repo_source_artifact_coverage_requires_declared_source_documents(
+    tmp_path: Path,
+):
+    repo_root = tmp_path / "repo"
+    source_doc = repo_root / "source_documents" / "shared" / "source.md"
+    source_doc.parent.mkdir(parents=True)
+    source_doc.write_text("# Source\n", encoding="utf-8")
+    batch_root = tmp_path / "artifacts" / "2026-05-12"
+
+    with pytest.raises(ValueError, match="missing 1 source_documents artifacts"):
+        _validate_repo_source_artifact_coverage(
+            repo_root=repo_root,
+            source_batch_path=batch_root,
+            artifact_payloads=[],
+            scrapers_run=["source_documents"],
+        )
+
+
+def test_expected_knowledge_restore_keys_excludes_non_knowledge_indices(tmp_path: Path):
+    artifact_payloads = [
+        (
+            tmp_path / "knowledge.json",
+            {
+                "content_hash": "knowledge-hash",
+                "doc_type": "knowledge",
+                "metadata": {"source_document_path": "shared/knowledge.md"},
+            },
+        ),
+        (
+            tmp_path / "runbook.json",
+            {
+                "content_hash": "runbook-hash",
+                "doc_type": "runbook",
+                "metadata": {"source_document_path": "shared/runbook.md"},
+            },
+        ),
+        (
+            tmp_path / "skill.json",
+            {
+                "content_hash": "skill-hash",
+                "doc_type": "skill",
+                "metadata": {"source_document_path": "shared/skill.md"},
+            },
+        ),
+        (
+            tmp_path / "ticket.json",
+            {
+                "content_hash": "ticket-hash",
+                "doc_type": "support_ticket",
+                "metadata": {"source_document_path": "shared/ticket.md"},
+            },
+        ),
+    ]
+
+    document_meta_keys, source_meta_keys = _expected_knowledge_restore_keys(artifact_payloads)
+
+    assert document_meta_keys == {
+        RedisKeys.knowledge_document_meta("knowledge-hash"),
+        RedisKeys.knowledge_document_meta("runbook-hash"),
+    }
+    assert len(source_meta_keys) == 2
+
+
+def test_validate_restore_record_coverage_requires_source_tracking():
+    with pytest.raises(ValueError, match="missing 1 source tracking records"):
+        _validate_restore_record_coverage(
+            expected_document_meta_keys={RedisKeys.knowledge_document_meta("doc-hash")},
+            expected_source_meta_keys={RedisKeys.knowledge_source_meta("source-hash")},
+            document_meta_records=[
+                {"key": RedisKeys.knowledge_document_meta("doc-hash"), "mapping": {}}
+            ],
+            source_meta_records=[],
+        )


### PR DESCRIPTION
## Summary

- Fail knowledge-pack builds when `source_documents` is declared in `--scrapers-run` but the artifact batch is missing repo source document artifacts.
- Derive expected `sre_knowledge` document/source tracking keys from the artifact batch and fail before writing the pack when restore records do not cover them.
- Record source coverage counts in the pack manifest and update knowledge-pack tests around matching artifact/content/source hashes.

## How Has This Been Tested?

- `make lint`
- `make test`
- `uv run pytest tests/unit/knowledge_pack/test_builder.py tests/unit/cli/test_cli_knowledge_pack.py tests/integration/test_knowledge_pack_integration.py`

## Linked Items

Closes #200

## Breaking Changes

None.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds hard failures to the release pack pipeline when scrapers or ingestion are incomplete; behavior change for builds that previously succeeded with gaps.
> 
> **Overview**
> Knowledge-pack **build** now fails early when release artifacts or Redis export state do not fully match what restore expects.
> 
> If `source_documents` is listed in `scrapers_run`, the builder compares every repo `source_documents/**/*.md` (excluding README) to artifact `metadata.source_document_path` values and raises if any sources are missing from the batch.
> 
> It also walks the artifact JSON batch to compute expected document/source meta Redis keys (skipping `skill` and `support_ticket`), requires each knowledge artifact to have `content_hash`, and verifies scanned restore NDJSON keys cover those sets before writing the pack.
> 
> The manifest `record_counts` gain **repo** and **knowledge** source/artifact counts; unit and integration tests cover the new validators and aligned content/source hashes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d9dcd484de26ce4f82049ffdf17d3520a7019ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->