### PR TITLE
Support Packages upload to the redis_sre_agent

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -116,6 +116,12 @@ RUN useradd --create-home --shell /bin/bash app && \
 COPY --from=builder --chown=app:app /app /app
 RUN chown app:app /app
 
+# Pre-create the support package directory owned by "app". Named volumes
+# mounted here inherit this ownership on first use, so the non-root app user
+# can write without a manual chown.
+RUN mkdir -p /tmp/sre_agent/support_packages && \
+    chown -R app:app /tmp/sre_agent
+
 # Add the virtual environment and uv tools to PATH
 # This allows us to run "uvicorn" or "python" directly without "uv run"
 ENV PATH="/app/.venv/bin:/opt/uv/tools/bin:$PATH"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -203,6 +203,7 @@ services:
       - ./evals:/app/evals  # Mount live eval suites and scenarios for container CLI runs
       - ./redis_sre_agent:/app/redis_sre_agent  # Mount source code for development
       - ./tests:/app/tests  # Mount tests for development
+      - support_packages:/tmp/sre_agent/support_packages  # Shared with sre-worker; persists uploads
     group_add:
       - "0"  # Docker Desktop exposes the socket as root:root
     command: uvicorn redis_sre_agent.api.app:app --host 0.0.0.0 --port 8000 --reload
@@ -241,6 +242,7 @@ services:
       - ./redis_sre_agent:/app/redis_sre_agent  # Mount source code for development
       - ./tests:/app/tests  # Mount tests for development
       - uv_cache:/root/.cache/uv  # Persist UV cache for MCP server deps
+      - support_packages:/tmp/sre_agent/support_packages  # Shared with sre-agent; persists uploads
     group_add:
       - "0"  # Docker Desktop exposes the socket as root:root
     # Run the worker directly from the project virtualenv instead of via
@@ -398,3 +400,4 @@ volumes:
   loki_data:
   tempo_data:
   uv_cache:  # Persist UV cache for MCP server dependencies
+  support_packages:  # Shared between sre-agent and sre-worker; survives restarts

--- a/redis_sre_agent/api/middleware.py
+++ b/redis_sre_agent/api/middleware.py
@@ -116,7 +116,7 @@ def setup_middleware(app: FastAPI) -> None:
         CORSMiddleware,
         allow_origins=settings.allowed_hosts,
         allow_credentials=True,
-        allow_methods=["GET", "POST", "PUT", "DELETE", "OPTIONS"],
+        allow_methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
         allow_headers=["*"],
     )
 

--- a/redis_sre_agent/api/support_package.py
+++ b/redis_sre_agent/api/support_package.py
@@ -5,7 +5,7 @@ import tempfile
 from pathlib import Path
 from typing import List, Optional
 
-from fastapi import APIRouter, File, HTTPException, Query, UploadFile
+from fastapi import APIRouter, Body, File, HTTPException, Query, UploadFile
 from pydantic import BaseModel
 
 from redis_sre_agent.core.config import settings
@@ -56,6 +56,7 @@ class PackageInfoResponse(BaseModel):
     is_extracted: bool
     storage_path: Optional[str] = None
     checksum: Optional[str] = None
+    tags: List[str] = []
 
 
 class PackageListResponse(BaseModel):
@@ -100,7 +101,11 @@ async def upload_package(
             tmp_path = Path(tmp.name)
 
         try:
-            result_id = await manager.upload(tmp_path, package_id=package_id)
+            result_id = await manager.upload(
+                tmp_path,
+                package_id=package_id,
+                original_filename=file.filename or None,
+            )
             return PackageUploadResponse(
                 package_id=result_id,
                 status="uploaded",
@@ -136,6 +141,7 @@ async def list_packages(
                     is_extracted=is_extracted,
                     storage_path=pkg.storage_path,
                     checksum=pkg.checksum,
+                    tags=pkg.tags,
                 )
             )
 
@@ -166,6 +172,7 @@ async def get_package_info(package_id: str):
             is_extracted=is_extracted,
             storage_path=metadata.storage_path,
             checksum=metadata.checksum,
+            tags=metadata.tags,
         )
 
     except HTTPException:
@@ -210,4 +217,30 @@ async def delete_package(package_id: str):
 
     except Exception as e:
         logger.error(f"Failed to delete package: {e}")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.patch("/support-packages/{package_id}/tags", response_model=PackageInfoResponse)
+async def update_package_tags(
+    package_id: str,
+    tags: List[str] = Body(..., description="Complete list of tags to set on this package"),
+):
+    """Replace the tag list for a support package."""
+    try:
+        manager = get_manager()
+        updated = await manager.update_tags(package_id, tags)
+        is_extracted = await manager.is_extracted(package_id)
+        return PackageInfoResponse(
+            package_id=updated.package_id,
+            filename=updated.filename,
+            size_bytes=updated.size_bytes,
+            uploaded_at=updated.uploaded_at.isoformat(),
+            is_extracted=is_extracted,
+            storage_path=updated.storage_path,
+            checksum=updated.checksum,
+            tags=updated.tags,
+        )
+
+    except Exception as e:
+        logger.error(f"Failed to update tags for package {package_id}: {e}")
         raise HTTPException(status_code=500, detail=str(e))

--- a/redis_sre_agent/api/tasks.py
+++ b/redis_sre_agent/api/tasks.py
@@ -142,6 +142,16 @@ async def create_task_endpoint(req: TaskCreateRequest) -> TaskCreateResponse:
             detail="Please provide only one of instance_id or cluster_id in context",
         )
 
+    if context.get("support_package_id") and not context.get("support_package_path"):
+        from redis_sre_agent.core.query_helpers import _resolve_support_package_context
+
+        try:
+            context.update(
+                await _resolve_support_package_context(context["support_package_id"])
+            )
+        except ValueError as e:
+            raise HTTPException(status_code=404, detail=str(e))
+
     try:
         redis_client = get_redis_client()
         data = await create_task(

--- a/redis_sre_agent/tools/manager.py
+++ b/redis_sre_agent/tools/manager.py
@@ -739,6 +739,25 @@ class ToolManager:
                 )
                 return
 
+            # The package may have been extracted in a different container
+            # (e.g. the API container extracts on upload); if the directory is
+            # missing here, re-extract it from storage. The extraction dir is
+            # named after the package ID.
+            package_dir = Path(self.support_package_path)
+            if not package_dir.exists():
+                from redis_sre_agent.core.support_package_helpers import (
+                    get_support_package_manager,
+                )
+
+                package_id = package_dir.name
+                logger.info(
+                    f"Support package path missing locally; re-extracting '{package_id}' "
+                    "from storage"
+                )
+                self.support_package_path = await get_support_package_manager().extract(
+                    package_id
+                )
+
             # Create and enter the provider's async context
             provider = SupportPackageToolProvider(package_path=self.support_package_path)
             provider = await self._stack.enter_async_context(provider)

--- a/redis_sre_agent/tools/support_package/manager.py
+++ b/redis_sre_agent/tools/support_package/manager.py
@@ -3,7 +3,7 @@
 import shutil
 import tarfile
 from pathlib import Path
-from typing import List, Optional
+from typing import List, Optional, Sequence
 
 from .provider import SupportPackageToolProvider
 from .storage.protocols import PackageMetadata, SupportPackageStorage
@@ -35,17 +35,19 @@ class SupportPackageManager:
         self,
         source_path: Path,
         package_id: Optional[str] = None,
+        original_filename: Optional[str] = None,
     ) -> str:
         """Upload a support package to storage.
 
         Args:
             source_path: Path to the support package file
             package_id: Optional custom package ID
+            original_filename: Original filename from the upload request
 
         Returns:
             The package ID
         """
-        return await self.storage.upload(source_path, package_id)
+        return await self.storage.upload(source_path, package_id, original_filename)
 
     async def list_packages(self) -> List[PackageMetadata]:
         """List all uploaded packages.
@@ -163,6 +165,18 @@ class SupportPackageManager:
         """
         extract_path = self.extract_dir / package_id
         return extract_path.exists() and any(extract_path.iterdir())
+
+    async def update_tags(self, package_id: str, tags: Sequence[str]):
+        """Replace the tag list for a package.
+
+        Args:
+            package_id: ID of the package
+            tags: New list of tags
+
+        Returns:
+            Updated PackageMetadata
+        """
+        return await self.storage.update_tags(package_id, list(tags))
 
     async def get_tool_provider(self, package_id: str) -> SupportPackageToolProvider:
         """Get a tool provider for a package.

--- a/redis_sre_agent/tools/support_package/storage/local.py
+++ b/redis_sre_agent/tools/support_package/storage/local.py
@@ -54,6 +54,7 @@ class LocalStorage(SupportPackageStorage):
         self,
         source_path: Path,
         package_id: Optional[str] = None,
+        original_filename: Optional[str] = None,
     ) -> str:
         """Upload a support package to local storage."""
         if package_id is None:
@@ -70,7 +71,7 @@ class LocalStorage(SupportPackageStorage):
         checksum = self._compute_checksum(dest_file)
         metadata = PackageMetadata(
             package_id=package_id,
-            filename=source_path.name,
+            filename=original_filename or source_path.name,
             size_bytes=dest_file.stat().st_size,
             uploaded_at=datetime.now(timezone.utc),
             storage_path=str(dest_file),
@@ -134,3 +135,12 @@ class LocalStorage(SupportPackageStorage):
     async def exists(self, package_id: str) -> bool:
         """Check if a package exists in local storage."""
         return self._package_file(package_id).exists()
+
+    async def update_tags(self, package_id: str, tags: List[str]) -> PackageMetadata:
+        """Replace the tag list for a package and persist to metadata.json."""
+        metadata = await self.get_metadata(package_id)
+        if metadata is None:
+            raise PackageNotFoundError(package_id)
+        updated = metadata.model_copy(update={"tags": list(tags)})
+        self._metadata_file(package_id).write_text(updated.model_dump_json(indent=2))
+        return updated

--- a/redis_sre_agent/tools/support_package/storage/protocols.py
+++ b/redis_sre_agent/tools/support_package/storage/protocols.py
@@ -28,6 +28,7 @@ class PackageMetadata(BaseModel):
     )
     content_type: str = Field(default="application/gzip", description="MIME type of the package")
     checksum: Optional[str] = Field(default=None, description="SHA-256 checksum of the package")
+    tags: List[str] = Field(default_factory=list, description="User-defined tags for the package")
 
 
 class SupportPackageStorage(ABC):
@@ -42,6 +43,7 @@ class SupportPackageStorage(ABC):
         self,
         source_path: Path,
         package_id: Optional[str] = None,
+        original_filename: Optional[str] = None,
     ) -> str:
         """Upload a support package to storage.
 
@@ -117,5 +119,21 @@ class SupportPackageStorage(ABC):
 
         Returns:
             True if the package exists, False otherwise
+        """
+        ...
+
+    @abstractmethod
+    async def update_tags(self, package_id: str, tags: List[str]) -> PackageMetadata:
+        """Replace the tag list for a package.
+
+        Args:
+            package_id: ID of the package
+            tags: New list of tags (replaces existing)
+
+        Returns:
+            Updated PackageMetadata
+
+        Raises:
+            PackageNotFoundError: If the package doesn't exist
         """
         ...

--- a/redis_sre_agent/tools/support_package/storage/s3.py
+++ b/redis_sre_agent/tools/support_package/storage/s3.py
@@ -76,6 +76,7 @@ class S3Storage(SupportPackageStorage):
         self,
         source_path: Path,
         package_id: Optional[str] = None,
+        original_filename: Optional[str] = None,
     ) -> str:
         """Upload a support package to S3."""
         if package_id is None:
@@ -92,7 +93,7 @@ class S3Storage(SupportPackageStorage):
             ExtraArgs={
                 "ContentType": "application/gzip",
                 "Metadata": {
-                    "original-filename": source_path.name,
+                    "original-filename": original_filename or source_path.name,
                     "checksum-sha256": checksum,
                     "uploaded-at": datetime.now(timezone.utc).isoformat(),
                 },
@@ -208,3 +209,22 @@ class S3Storage(SupportPackageStorage):
             if e.response["Error"]["Code"] == "404":
                 return False
             raise
+
+    async def update_tags(self, package_id: str, tags: List[str]) -> PackageMetadata:
+        """Store tags as a sidecar JSON object alongside the package in S3."""
+        import json as _json
+
+        if not await self.exists(package_id):
+            raise PackageNotFoundError(package_id)
+
+        tags_key = f"{self.prefix}{package_id}.tags.json"
+        self._client.put_object(
+            Bucket=self.bucket,
+            Key=tags_key,
+            Body=_json.dumps(tags).encode(),
+            ContentType="application/json",
+        )
+
+        metadata = await self.get_metadata(package_id)
+        # Attach tags from the sidecar to the returned metadata object
+        return metadata.model_copy(update={"tags": list(tags)})

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -11,6 +11,7 @@ import Triage from "./pages/Triage";
 import Knowledge from "./pages/Knowledge";
 import KnowledgeDocumentChunks from "./pages/KnowledgeDocumentChunks";
 import Schedules from "./pages/Schedules";
+import SupportPackages from "./pages/SupportPackages";
 import Settings from "./pages/Settings";
 import { useApp } from "./hooks/useApp";
 
@@ -56,6 +57,7 @@ function App() {
           element={<KnowledgeDocumentChunks />}
         />
         <Route path="/schedules" element={<Schedules />} />
+        <Route path="/support-packages" element={<SupportPackages />} />
         <Route path="/settings" element={<Settings />} />
         {/* Redirect instances to settings with instances section */}
         <Route

--- a/ui/src/hooks/useApp.ts
+++ b/ui/src/hooks/useApp.ts
@@ -33,6 +33,11 @@ export const useApp = () => {
       isActive: location.pathname === "/schedules",
     },
     {
+      label: "Support Packages",
+      href: "/support-packages",
+      isActive: location.pathname === "/support-packages",
+    },
+    {
       label: "Settings",
       href: "/settings",
       isActive:

--- a/ui/src/pages/SupportPackages.tsx
+++ b/ui/src/pages/SupportPackages.tsx
@@ -434,19 +434,33 @@ const SupportPackages = () => {
                   ref={fileInputRef}
                   type="file"
                   accept=".tar.gz,.tgz,.gz,.zip"
-                  className="w-full px-3 py-2 border rounded-redis-sm focus:outline-none focus:ring-2 focus:ring-redis-blue-03 text-redis-sm"
-                  style={{
-                    backgroundColor: "var(--input)",
-                    color: "var(--input-foreground)",
-                    borderColor: "var(--border)",
-                  }}
+                  className="hidden"
                   onChange={(e) => setUploadFile(e.target.files?.[0] ?? null)}
                 />
-                {uploadFile && (
-                  <p className="text-redis-xs text-muted-foreground mt-1">
-                    {uploadFile.name} — {formatBytes(uploadFile.size)}
-                  </p>
-                )}
+                <div
+                  className="flex items-center gap-3 w-full px-3 py-2 border rounded-redis-sm text-redis-sm"
+                  style={{
+                    backgroundColor: "var(--input)",
+                    borderColor: "var(--border)",
+                  }}
+                >
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    onClick={() => fileInputRef.current?.click()}
+                  >
+                    {uploadFile ? "Change File" : "Choose File"}
+                  </Button>
+                  <span
+                    className="truncate"
+                    style={{ color: "var(--input-foreground)" }}
+                  >
+                    {uploadFile
+                      ? `${uploadFile.name} — ${formatBytes(uploadFile.size)}`
+                      : "No file selected"}
+                  </span>
+                </div>
               </div>
 
               <div>

--- a/ui/src/pages/SupportPackages.tsx
+++ b/ui/src/pages/SupportPackages.tsx
@@ -1,0 +1,505 @@
+import { useState, useEffect, useRef, KeyboardEvent } from "react";
+import { useNavigate } from "react-router-dom";
+import {
+  Card,
+  CardHeader,
+  CardContent,
+  Button,
+  Loader,
+  ErrorMessage,
+} from "@radar/ui-kit";
+import sreAgentApi from "../services/sreAgentApi";
+
+interface SupportPackage {
+  package_id: string;
+  filename: string;
+  size_bytes: number;
+  uploaded_at: string;
+  is_extracted: boolean;
+  storage_path?: string;
+  checksum?: string;
+  tags: string[];
+}
+
+const formatBytes = (bytes: number): string => {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  if (bytes < 1024 * 1024 * 1024)
+    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)} GB`;
+};
+
+const formatTimestamp = (ts: string): string =>
+  new Date(ts).toLocaleString();
+
+const SupportPackages = () => {
+  const navigate = useNavigate();
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const [packages, setPackages] = useState<SupportPackage[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [showUploadModal, setShowUploadModal] = useState(false);
+
+  const [uploadFile, setUploadFile] = useState<File | null>(null);
+  const [uploadPackageId, setUploadPackageId] = useState("");
+  const [isUploading, setIsUploading] = useState(false);
+
+  const [extractingId, setExtractingId] = useState<string | null>(null);
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+
+  // Tag editing state: packageId -> current draft input value
+  const [tagInputs, setTagInputs] = useState<Record<string, string>>({});
+  // Which package has its tag input open
+  const [tagEditingId, setTagEditingId] = useState<string | null>(null);
+  const tagInputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    loadPackages();
+  }, []);
+
+  const loadPackages = async () => {
+    try {
+      setError(null);
+      const data = await sreAgentApi.listSupportPackages();
+      setPackages(
+        [...data.packages]
+          .sort(
+            (a, b) =>
+              new Date(b.uploaded_at).getTime() -
+              new Date(a.uploaded_at).getTime(),
+          )
+          .map((p) => ({ ...p, tags: p.tags ?? [] })),
+      );
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "Failed to load support packages",
+      );
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleUpload = async () => {
+    if (!uploadFile) return;
+    try {
+      setIsUploading(true);
+      setError(null);
+      await sreAgentApi.uploadSupportPackage(
+        uploadFile,
+        uploadPackageId || undefined,
+      );
+      setShowUploadModal(false);
+      setUploadFile(null);
+      setUploadPackageId("");
+      await loadPackages();
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "Failed to upload support package",
+      );
+    } finally {
+      setIsUploading(false);
+    }
+  };
+
+  const handleExtract = async (pkg: SupportPackage) => {
+    try {
+      setError(null);
+      setExtractingId(pkg.package_id);
+      await sreAgentApi.extractSupportPackage(pkg.package_id);
+      await loadPackages();
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "Failed to extract support package",
+      );
+    } finally {
+      setExtractingId(null);
+    }
+  };
+
+  const handleDelete = async (pkg: SupportPackage) => {
+    if (
+      !confirm(
+        `Are you sure you want to delete "${pkg.filename}"? This cannot be undone.`,
+      )
+    )
+      return;
+    try {
+      setError(null);
+      setDeletingId(pkg.package_id);
+      await sreAgentApi.deleteSupportPackage(pkg.package_id);
+      await loadPackages();
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "Failed to delete support package",
+      );
+    } finally {
+      setDeletingId(null);
+    }
+  };
+
+  const openTagInput = (packageId: string) => {
+    setTagEditingId(packageId);
+    setTagInputs((prev) => ({ ...prev, [packageId]: "" }));
+    // Focus after render
+    setTimeout(() => tagInputRef.current?.focus(), 0);
+  };
+
+  const commitTag = async (packageId: string, currentTags: string[], raw: string) => {
+    const newTag = raw.trim().toLowerCase();
+    setTagInputs((prev) => ({ ...prev, [packageId]: "" }));
+    setTagEditingId(null);
+
+    if (!newTag || currentTags.includes(newTag)) return;
+
+    const newTags = [...currentTags, newTag];
+    setPackages((prev) =>
+      prev.map((p) => (p.package_id === packageId ? { ...p, tags: newTags } : p)),
+    );
+    try {
+      await sreAgentApi.updateSupportPackageTags(packageId, newTags);
+    } catch {
+      setPackages((prev) =>
+        prev.map((p) => (p.package_id === packageId ? { ...p, tags: currentTags } : p)),
+      );
+    }
+  };
+
+  const removeTag = async (pkg: SupportPackage, tag: string) => {
+    const newTags = pkg.tags.filter((t) => t !== tag);
+    // Optimistic update
+    setPackages((prev) =>
+      prev.map((p) =>
+        p.package_id === pkg.package_id ? { ...p, tags: newTags } : p,
+      ),
+    );
+    try {
+      await sreAgentApi.updateSupportPackageTags(pkg.package_id, newTags);
+    } catch {
+      setPackages((prev) =>
+        prev.map((p) =>
+          p.package_id === pkg.package_id ? { ...p, tags: pkg.tags } : p,
+        ),
+      );
+    }
+  };
+
+  const handleTagKeyDown = (
+    e: KeyboardEvent<HTMLInputElement>,
+    pkg: SupportPackage,
+  ) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      commitTag(pkg.package_id, pkg.tags, tagInputs[pkg.package_id] ?? "");
+    } else if (e.key === "Escape") {
+      setTagEditingId(null);
+    }
+  };
+
+  const handleAnalyze = (pkg: SupportPackage) => {
+    navigate(
+      `/chat?support_package_id=${encodeURIComponent(pkg.package_id)}&subject=${encodeURIComponent(`Analyze support package: ${pkg.filename}`)}`,
+    );
+  };
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center py-8">
+        <Loader size="lg" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-redis-xl font-bold text-foreground">
+            Support Packages
+          </h1>
+          <p className="text-redis-sm text-muted-foreground mt-1">
+            Upload, extract, and analyze Redis support packages
+          </p>
+        </div>
+        <Button variant="primary" onClick={() => setShowUploadModal(true)}>
+          Upload Package
+        </Button>
+      </div>
+
+      {error && <ErrorMessage message={error} title="Error" />}
+
+      {/* Package List */}
+      <div className="grid grid-cols-1 gap-4">
+        {packages.length === 0 ? (
+          <Card>
+            <CardContent>
+              <div className="text-center py-8 text-muted-foreground">
+                <div className="text-lg mb-2">📦</div>
+                <div className="text-sm mb-3">No support packages uploaded</div>
+                <Button
+                  variant="outline"
+                  onClick={() => setShowUploadModal(true)}
+                >
+                  Upload First Package
+                </Button>
+              </div>
+            </CardContent>
+          </Card>
+        ) : (
+          packages.map((pkg) => (
+            <Card key={pkg.package_id}>
+              <CardHeader>
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center gap-2 flex-wrap min-w-0">
+                    <h3 className="text-redis-lg font-semibold text-foreground truncate max-w-sm">
+                      {pkg.filename}
+                    </h3>
+                    <span
+                      className={`shrink-0 text-redis-xs px-2 py-1 rounded border ${
+                        pkg.is_extracted
+                          ? "bg-redis-green text-white border-transparent"
+                          : "bg-white text-gray-600 border-gray-300"
+                      }`}
+                    >
+                      {pkg.is_extracted ? "Extracted" : "Uploaded"}
+                    </span>
+
+                    {/* Tags inline after Extracted badge */}
+                    {pkg.tags.map((tag) => (
+                      <span
+                        key={tag}
+                        className="shrink-0 inline-flex items-center gap-1 pl-2 pr-1 py-0.5 rounded-full text-redis-xs font-medium bg-orange-500 text-white"
+                      >
+                        {tag}
+                        <button
+                          onClick={() => removeTag(pkg, tag)}
+                          aria-label={`Remove tag ${tag}`}
+                          className="inline-flex items-center justify-center w-3.5 h-3.5 rounded-full bg-white text-gray-400 hover:text-gray-600 leading-none transition-colors"
+                        >
+                          ×
+                        </button>
+                      </span>
+                    ))}
+
+                    {tagEditingId === pkg.package_id ? (
+                      <span className="shrink-0 inline-flex items-center gap-1">
+                        <input
+                          ref={tagInputRef}
+                          type="text"
+                          value={tagInputs[pkg.package_id] ?? ""}
+                          onChange={(e) =>
+                            setTagInputs((prev) => ({
+                              ...prev,
+                              [pkg.package_id]: e.target.value,
+                            }))
+                          }
+                          onKeyDown={(e) => handleTagKeyDown(e, pkg)}
+                          onBlur={() => setTagEditingId(null)}
+                          placeholder="new tag…"
+                          className="px-2 py-0.5 text-redis-xs border rounded-full w-24 focus:outline-none focus:ring-1 focus:ring-redis-blue-03"
+                          style={{
+                            backgroundColor: "var(--input)",
+                            color: "var(--input-foreground)",
+                            borderColor: "var(--border)",
+                          }}
+                        />
+                        <button
+                          onMouseDown={(e) => {
+                            e.preventDefault(); // keep input focused so blur doesn't fire
+                            commitTag(pkg.package_id, pkg.tags, tagInputs[pkg.package_id] ?? "");
+                          }}
+                          className="text-redis-xs text-redis-green font-bold hover:opacity-70"
+                          aria-label="Confirm tag"
+                        >
+                          ✓
+                        </button>
+                      </span>
+                    ) : (
+                      <button
+                        onClick={() => openTagInput(pkg.package_id)}
+                        className="shrink-0 inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-redis-xs border border-dashed text-muted-foreground hover:text-foreground hover:border-foreground transition-colors"
+                        style={{ borderColor: "var(--border)" }}
+                      >
+                        + Tag
+                      </button>
+                    )}
+                  </div>
+                  <div className="flex gap-2">
+                    {!pkg.is_extracted && (
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={() => handleExtract(pkg)}
+                        disabled={extractingId === pkg.package_id}
+                      >
+                        {extractingId === pkg.package_id
+                          ? "Extracting…"
+                          : "Extract"}
+                      </Button>
+                    )}
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => handleAnalyze(pkg)}
+                      disabled={!pkg.is_extracted}
+                      title={
+                        !pkg.is_extracted
+                          ? "Extract the package first"
+                          : "Open chat with this package loaded"
+                      }
+                    >
+                      Analyze
+                    </Button>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => handleDelete(pkg)}
+                      disabled={deletingId === pkg.package_id}
+                      className="text-redis-red hover:bg-redis-red hover:text-white"
+                    >
+                      {deletingId === pkg.package_id ? "Deleting…" : "Delete"}
+                    </Button>
+                  </div>
+                </div>
+              </CardHeader>
+              <CardContent>
+                <div className="grid grid-cols-2 md:grid-cols-4 gap-4 text-redis-sm">
+                  <div>
+                    <div className="font-medium text-foreground">Package ID</div>
+                    <div
+                      className="text-muted-foreground font-mono text-redis-xs truncate"
+                      title={pkg.package_id}
+                    >
+                      {pkg.package_id}
+                    </div>
+                  </div>
+                  <div>
+                    <div className="font-medium text-foreground">Size</div>
+                    <div className="text-muted-foreground">
+                      {formatBytes(pkg.size_bytes)}
+                    </div>
+                  </div>
+                  <div>
+                    <div className="font-medium text-foreground">Uploaded</div>
+                    <div className="text-muted-foreground">
+                      {formatTimestamp(pkg.uploaded_at)}
+                    </div>
+                  </div>
+                  {pkg.checksum && (
+                    <div>
+                      <div className="font-medium text-foreground">Checksum</div>
+                      <div
+                        className="text-muted-foreground font-mono text-redis-xs truncate"
+                        title={pkg.checksum}
+                      >
+                        {pkg.checksum.slice(0, 16)}…
+                      </div>
+                    </div>
+                  )}
+                </div>
+
+              </CardContent>
+            </Card>
+          ))
+        )}
+      </div>
+
+      {/* Upload Modal */}
+      {showUploadModal && (
+        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+          <div
+            className="rounded-lg p-6 max-w-lg w-full mx-4"
+            style={{
+              backgroundColor: "var(--card)",
+              color: "var(--card-foreground)",
+            }}
+          >
+            <h3
+              className="text-lg font-semibold mb-4"
+              style={{ color: "var(--foreground)" }}
+            >
+              Upload Support Package
+            </h3>
+
+            <div className="space-y-4">
+              <div>
+                <label
+                  className="block text-redis-sm font-medium mb-2"
+                  style={{ color: "var(--foreground)" }}
+                >
+                  Package file (.tar.gz) *
+                </label>
+                <input
+                  ref={fileInputRef}
+                  type="file"
+                  accept=".tar.gz,.tgz,.gz,.zip"
+                  className="w-full px-3 py-2 border rounded-redis-sm focus:outline-none focus:ring-2 focus:ring-redis-blue-03 text-redis-sm"
+                  style={{
+                    backgroundColor: "var(--input)",
+                    color: "var(--input-foreground)",
+                    borderColor: "var(--border)",
+                  }}
+                  onChange={(e) => setUploadFile(e.target.files?.[0] ?? null)}
+                />
+                {uploadFile && (
+                  <p className="text-redis-xs text-muted-foreground mt-1">
+                    {uploadFile.name} — {formatBytes(uploadFile.size)}
+                  </p>
+                )}
+              </div>
+
+              <div>
+                <label
+                  className="block text-redis-sm font-medium mb-2"
+                  style={{ color: "var(--foreground)" }}
+                >
+                  Custom Package ID{" "}
+                  <span className="text-muted-foreground font-normal">
+                    (optional)
+                  </span>
+                </label>
+                <input
+                  type="text"
+                  value={uploadPackageId}
+                  onChange={(e) => setUploadPackageId(e.target.value)}
+                  placeholder="Auto-generated if left empty"
+                  className="w-full px-3 py-2 border rounded-redis-sm focus:outline-none focus:ring-2 focus:ring-redis-blue-03"
+                  style={{
+                    backgroundColor: "var(--input)",
+                    color: "var(--input-foreground)",
+                    borderColor: "var(--border)",
+                  }}
+                />
+              </div>
+            </div>
+
+            <div className="flex justify-end gap-3 mt-6">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => {
+                  setShowUploadModal(false);
+                  setUploadFile(null);
+                  setUploadPackageId("");
+                }}
+                disabled={isUploading}
+              >
+                Cancel
+              </Button>
+              <Button
+                variant="primary"
+                onClick={handleUpload}
+                disabled={!uploadFile || isUploading}
+              >
+                {isUploading ? "Uploading…" : "Upload"}
+              </Button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default SupportPackages;

--- a/ui/src/pages/Triage.tsx
+++ b/ui/src/pages/Triage.tsx
@@ -276,6 +276,8 @@ const Triage = () => {
   const [clusters, setClusters] = useState<RedisCluster[]>([]);
   const [selectedInstanceId, setSelectedInstanceId] = useState<string>("");
   const [selectedClusterId, setSelectedClusterId] = useState<string>("");
+  // Support package to analyze, passed from the Support Packages page via URL
+  const supportPackageId = searchParams.get("support_package_id") || "";
   const [isThinking, setIsThinking] = useState(false);
   const [showWebSocketMonitor, setShowWebSocketMonitor] = useState(false);
   const [isThreadBusy, setIsThreadBusy] = useState(false);
@@ -708,6 +710,10 @@ const Triage = () => {
       const params = new URLSearchParams(window.location.search);
       if (threadId) {
         params.set("thread", threadId);
+        // One-shot params from the Support Packages "Analyze" flow: consumed
+        // when the thread is created, so later conversations don't inherit them.
+        params.delete("support_package_id");
+        params.delete("subject");
       } else {
         params.delete("thread");
       }
@@ -787,6 +793,16 @@ const Triage = () => {
       setShowNewConversation(true);
     }
   }, [threads.length, activeThreadId, showNewConversation, searchParams]);
+
+  // Prefill the message when arriving from the Support Packages "Analyze" button
+  useEffect(() => {
+    if (supportPackageId && !activeThreadId && !inputMessage) {
+      const subject = searchParams.get("subject");
+      setInputMessage(subject || "Analyze this support package");
+    }
+    // Only on mount / param change — don't re-prefill as the user types
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [supportPackageId]);
 
   // Cleanup polling on unmount
   useEffect(() => {
@@ -1421,6 +1437,7 @@ const Triage = () => {
           undefined,
           selectedInstanceId || undefined,
           selectedClusterId || undefined,
+          supportPackageId || undefined,
         );
         threadId = triageResponse;
 

--- a/ui/src/services/sreAgentApi.ts
+++ b/ui/src/services/sreAgentApi.ts
@@ -593,6 +593,7 @@ export class SREAgentAPI {
     tags?: string[],
     instanceId?: string,
     clusterId?: string,
+    supportPackageId?: string,
   ): Promise<TriageResponse> {
     if (instanceId && clusterId) {
       throw new Error(
@@ -614,6 +615,7 @@ export class SREAgentAPI {
           tags,
           ...(instanceId && { instance_id: instanceId }),
           ...(clusterId && { cluster_id: clusterId }),
+          ...(supportPackageId && { support_package_id: supportPackageId }),
         },
       }),
     });
@@ -1179,6 +1181,7 @@ export class SREAgentAPI {
     tags?: string[],
     instanceId?: string,
     clusterId?: string,
+    supportPackageId?: string,
   ): Promise<string> {
     const triageResponse = await this.submitTriageRequest(
       message,
@@ -1188,6 +1191,7 @@ export class SREAgentAPI {
       tags,
       instanceId,
       clusterId,
+      supportPackageId,
     );
     return triageResponse.thread_id;
   }

--- a/ui/src/services/sreAgentApi.ts
+++ b/ui/src/services/sreAgentApi.ts
@@ -1765,6 +1765,89 @@ export class SREAgentAPI {
     return response.json();
   }
 
+  // Support Package Methods
+  async listSupportPackages(): Promise<{
+    packages: Array<{
+      package_id: string;
+      filename: string;
+      size_bytes: number;
+      uploaded_at: string;
+      is_extracted: boolean;
+      storage_path?: string;
+      checksum?: string;
+    }>;
+    total: number;
+  }> {
+    const response = await fetch(`${this.tasksBaseUrl}/support-packages`);
+    if (!response.ok) {
+      throw new Error(`Failed to list support packages: ${response.statusText}`);
+    }
+    return response.json();
+  }
+
+  async uploadSupportPackage(
+    file: File,
+    packageId?: string,
+  ): Promise<{ package_id: string; status: string; filename: string }> {
+    const formData = new FormData();
+    formData.append("file", file);
+    const url = this.createURL(`${this.tasksBaseUrl}/support-packages/upload`);
+    if (packageId) url.searchParams.set("package_id", packageId);
+    const response = await fetch(url.toString(), {
+      method: "POST",
+      body: formData,
+    });
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`Failed to upload support package: ${errorText}`);
+    }
+    return response.json();
+  }
+
+  async extractSupportPackage(
+    packageId: string,
+  ): Promise<{ package_id: string; status: string; path: string }> {
+    const response = await fetch(
+      `${this.tasksBaseUrl}/support-packages/${packageId}/extract`,
+      { method: "POST" },
+    );
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`Failed to extract support package: ${errorText}`);
+    }
+    return response.json();
+  }
+
+  async deleteSupportPackage(packageId: string): Promise<void> {
+    const response = await fetch(
+      `${this.tasksBaseUrl}/support-packages/${packageId}`,
+      { method: "DELETE" },
+    );
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`Failed to delete support package: ${errorText}`);
+    }
+  }
+
+  async updateSupportPackageTags(
+    packageId: string,
+    tags: string[],
+  ): Promise<{ package_id: string; tags: string[] }> {
+    const response = await fetch(
+      `${this.tasksBaseUrl}/support-packages/${packageId}/tags`,
+      {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(tags),
+      },
+    );
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`Failed to update tags: ${errorText}`);
+    }
+    return response.json();
+  }
+
   async submitFeedback(
     taskId: string,
     verdict: FeedbackVerdict,


### PR DESCRIPTION
- This Pull request adds a Support Package tar.gz File upload facility to the sre_agent, before it can be extracted and analysed by the agent. 
- The user can add custom tags to each uploaded support package. Sorting and filtering Support packages using the tags will be added  in a future release.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Shared volume and cross-container re-extract change how package files are stored and consumed by the worker; task context now auto-extracts packages, which affects agent tooling paths but not auth or payments.
> 
> **Overview**
> Adds end-to-end **support package** management: upload `.tar.gz` archives, extract them, tag them, and start agent tasks that analyze a chosen package.
> 
> **Infrastructure:** Docker pre-creates `/tmp/sre_agent/support_packages` owned by the non-root `app` user, and Compose mounts a named `support_packages` volume on both **sre-agent** and **sre-worker** so uploads and extractions survive restarts and are visible across containers.
> 
> **API & storage:** Uploads can record the **original filename** (not only the temp path). **Tags** are stored on package metadata (local `metadata.json`; S3 via a `.tags.json` sidecar) with a new **`PATCH /support-packages/{id}/tags`** endpoint and tags returned on list/get. **Task creation** resolves `support_package_id` into `support_package_path` (extract if needed) before queuing work. CORS allows **PATCH**. The worker **re-extracts** from storage when the extract directory is missing locally.
> 
> **UI:** New **Support Packages** page (list, upload, extract, delete, inline tag editing) plus nav route; **Analyze** opens chat with `support_package_id` and a prefilled subject, passes the ID into new conversations, then strips one-shot URL params after the thread is created.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c608112d654f489ba409e8d824bb3e79340403d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->