### PR TITLE
Restore fallback task listing

### DIFF
--- a/redis_sre_agent/core/tasks.py
+++ b/redis_sre_agent/core/tasks.py
@@ -723,7 +723,7 @@ async def list_tasks(
 
         fetch_size = max(limit * 10, 200)
         raw_summaries = await thread_manager.list_threads(
-            user_id=user_id, status_filter=None, limit=fetch_size, offset=0
+            user_id=user_id, limit=fetch_size, offset=0
         )
         if statuses is None:
             thread_summaries = raw_summaries[:limit]

--- a/tests/unit/core/test_task_manager.py
+++ b/tests/unit/core/test_task_manager.py
@@ -1124,6 +1124,11 @@ class TestListTasksFunction:
 
             assert len(result) == 1
             assert result[0]["thread_id"] == "thread-1"
+            mock_thread_manager.list_threads.assert_awaited_once_with(
+                user_id=None,
+                limit=500,
+                offset=0,
+            )
 
 
 class TestDeleteTaskFunction:


### PR DESCRIPTION
## Summary

Removes an unsupported keyword argument from the thread-backed task-list fallback. The fallback now calls ThreadManager through its current public contract, and the regression test asserts that exact call shape.

## How Has This Been Tested?

- 64 task-manager and task-inspection tests passed
- 2 MCP task-list tests passed
- Ruff lint and format checks passed
- Full unit target: 3,122 passed, 150 skipped, 1 unrelated failure because an existing feedback-route test attempted to reach a local Redis instance
- Pre-commit hooks passed

## Linked Items

None.

## Breaking Changes

None.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow API-alignment fix in a degraded-index code path; behavior change is limited to restoring a broken fallback.
> 
> **Overview**
> When the tasks search index is unavailable, **`list_tasks`** still falls back to **`ThreadManager.list_threads`**, but it no longer passes a removed **`status_filter`** argument that would break the call.
> 
> The fallback fetches threads with **`user_id`**, **`limit`**, and **`offset`** only; active-status filtering continues in Python on the returned summaries. A unit test now asserts that exact **`list_threads`** invocation (**`limit=500`** for the default **`limit=50`** path).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bfbf365625cd2fcb3c2258b91f38ef597d85adc3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->