### PR TITLE
Add redisvl semantic cache backend

### DIFF
--- a/docs/how-to/semantic-cache.md
+++ b/docs/how-to/semantic-cache.md
@@ -11,6 +11,52 @@
 
 ---
 
+## Backends
+
+The cache strategy — canonical key, scope resolution, cacheability, provenance,
+tombstones, invalidation — is identical regardless of backend. Only the
+match-and-store transport differs, selected by `semantic_cache_backend`:
+
+| | `redisvl` (default) | `langcache` |
+|---|---|---|
+| Where it runs | This service's own Redis | Managed LangCache service |
+| Setup required | None | `langcache_cache_id` + `langcache_api_key` |
+| Embeddings | Client-side (this process) | Server-side |
+| Missing config | N/A | Degrades to no cache, with a warning |
+
+Both are gated by `semantic_cache_enabled`, which remains **off by default**.
+Enabling the cache on the `redisvl` backend needs no external provisioning, which
+is what makes the feature demonstrable on a plain local stack.
+
+One backend is active at a time. Switching backends abandons existing entries
+rather than migrating them; they expire on their own TTL (≤24h).
+
+### Divergences on the `redisvl` backend
+
+1. **No server-side exact-match tier.** LangCache tries `exact` then `semantic`;
+   redisvl is vector-only, so `search_strategy` is always reported as
+   `semantic`. Behaviourally equivalent in practice — identical text yields
+   distance 0, so an exact match still outranks a semantic neighbour.
+2. **A miss costs an embedding round trip.** Because embeddings are computed
+   client-side, a *novel* query must be embedded before the miss is known.
+   Repeated queries are free (`create_vectorizer` attaches an `EmbeddingsCache`),
+   but this is the main operational difference to watch: LangCache is one network
+   hop, redisvl is an OpenAI hop plus a Redis hop.
+3. **TTL-refresh-on-read is deliberately disabled.** `acheck()` refreshes the TTL
+   of every hit it returns, which would turn our fixed store-time TTLs into a
+   sliding window — a popular `latest` answer would then never expire, defeating
+   the short TTL it has precisely because it tracks a moving pointer. The backend
+   therefore never passes a cache-level `ttl`, and a test pins that invariant.
+4. **Entry ids are deterministic.** redisvl derives an entry id from
+   `hash(prompt, filters)`, so re-storing the same prompt and scope overwrites in
+   place, where LangCache mints a fresh `entryId` per set.
+5. **Schema changes are breaking.** Changing the filterable fields or
+   `embedding_model` makes redisvl's index-schema check raise, which fail-open
+   turns into a permanently dead cache behind a single warning. The index must be
+   dropped for the new schema to take effect.
+
+---
+
 ## What the Cache Contains
 
 An answer is cacheable only when all of these hold:
@@ -30,7 +76,7 @@ LangCache is a managed service — it owns embeddings, the vector index, similar
 | `prompt` | — | The canonical/rewritten question, the string LangCache embeds and matches on |
 | `response` | text | The served payload — the answer plus its source citations (titles/paths), serialized as JSON so a hit reconstructs sources with no extra read |
 | `entry_id` | — | Unique ID LangCache returns from `astore()`, our join key to the Redis-side structures |
-| `ttlMillis` | — | Per-entry expiry, fixed at store time (1h for latest, 24h for pinned). No refresh-on-hit |
+| `ttlMillis` | — | Per-entry expiry, fixed at store time (1h for latest, 24h for pinned). No refresh-on-hit on either backend — see divergence 3 for how that is preserved on `redisvl` |
 
 **Attributes (declared at cache creation, immutable, scalar, exact-equality filters):**
 
@@ -38,7 +84,7 @@ LangCache is a managed service — it owns embeddings, the vector index, similar
 |---|---|---|
 | `version` | `latest` / `7.8` / `7.4` | Lookup filter — never serve latest to a 7.2 query |
 | `cache_origin` | `dynamic` / `curated` | Distinguishes generated vs. pre-warmed (for warming) |
-| `entity_id` | `RET-4421` | Exact identifier gate set only on identifier queries when referencing a support ticket or specific Redis target name; pre-filters before similarity so `RET-4422` can't match `RET-4421` |
+| `entity_id` | `RET-4421` or `_none` | Exact identifier gate; pre-filters before similarity so `RET-4422` can't match `RET-4421`. **Always written**, using the `_none` sentinel when a query names no ticket — a tag filter cannot express "field absent", and an empty tag value compiles to `*` (match *everything*), so omitting it would let a general query match ticket-scoped entries. Collision-free: real ids must match `[A-Z]{2,}-\d+` |
 
 > **Note:** Attributes are a 1:1 relationship in LangCache. They are scalar exact-match filter fields, so any query with multiple attribute matches is skipped for now and scoped for a future iteration.
 
@@ -119,13 +165,15 @@ The only thing derived from provenance is the reverse index: one `SADD cache_pro
 
 1. Query comes in. Any query that is instance-scoped is bypassed entirely. Only `knowledge_only` turns hit the cache.
 2. Check `semantic_cache_enabled` flag. If off, straight to the agent, no cache calls.
-3. Connect to the cache. If creds are missing or disabled, returns `None` and exits cache flow.
+3. Build the configured backend. If it cannot be built — `langcache` without credentials, or `redisvl` failing to construct — returns `None` and exits the cache flow.
 4. Compute the canonical key on the raw query. Resolve the scope from that key:
    - **Version**: default `latest`
    - **Entity_id**: only a single support_ticket ID
    - **Multi-entity flag**: if enabled (≥ 2 tickets), treat as a miss, don't serve
-5. Query LangCache. If no entries or top similarity < 0.9, miss.
-6. Does the candidate's `entity_id` match the requested one? Mismatch = miss.
+5. Query the backend. If no entries come back, miss.
+6. Scan the returned entries for the first one at or above the similarity threshold whose `entity_id` matches the requested scope exactly, comparing sentinel-to-sentinel in both directions. If none qualifies, miss.
+
+   > Scanning rather than judging only the top hit is deliberate: a transport that ranks an out-of-scope near-miss first would otherwise produce a *false* miss while a valid in-scope answer sat right behind it.
 7. On a hit, reconstruct the `AgentResponse` (answer + citations) from the entry's response JSON, log the hit via `exact|semantic (similarity=..)`; close the client.
 
 > **Note:** Any errors are failed open, logged, and treated as a miss.

--- a/redis_sre_agent/core/config.py
+++ b/redis_sre_agent/core/config.py
@@ -373,7 +373,16 @@ class Settings(BaseSettings):
     )
     langcache_api_key: Optional[SecretStr] = Field(
         default=None,
-        description="LangCache API key (required when semantic_cache_enabled).",
+        description="LangCache API key (required when semantic_cache_backend='langcache').",
+    )
+    semantic_cache_backend: Literal["redisvl", "langcache"] = Field(
+        default="redisvl",
+        description=(
+            "Semantic cache transport. 'redisvl' runs on this service's own Redis and "
+            "needs no external provisioning (embeddings computed client-side). "
+            "'langcache' uses the managed LangCache service and requires "
+            "langcache_cache_id + langcache_api_key."
+        ),
     )
 
     # OIDC SSO Authentication (authn only) — default OFF

--- a/redis_sre_agent/core/semantic_cache/__init__.py
+++ b/redis_sre_agent/core/semantic_cache/__init__.py
@@ -1,17 +1,25 @@
-"""Semantic answer cache (LangCache) for the knowledge agent.
+"""Semantic answer cache for the knowledge agent.
 
 A flag-gated (``settings.semantic_cache_enabled``, default OFF) semantic answer
 cache that sits above the knowledge-agent LangGraph run. On a sufficiently
 similar prior question it serves the previously synthesized answer and
 short-circuits the entire graph.
 
-Backend split (see ``docs/design/semantic-cache-knowledge-agent.md``): LangCache
-(managed) owns embeddings/index/similarity/TTL/attribute filters; our Redis owns
-provenance (``path_hash -> {entry_id}`` reverse index, side metadata, tombstones).
+Two transports, chosen by ``settings.semantic_cache_backend``, behind one
+:class:`~redis_sre_agent.core.semantic_cache.backend.CacheBackend` seam:
+
+* ``redisvl`` (default) -- ``redisvl``'s ``SemanticCache`` on this service's own
+  Redis. No external provisioning; embeddings computed client-side.
+* ``langcache`` -- the managed LangCache service, which owns embeddings, index,
+  similarity and attribute filters; requires credentials.
+
+Either way our Redis owns provenance (``path_hash -> {entry_id}`` reverse index,
+side metadata, tombstones), and the whole strategy layer in ``service.py`` is
+shared verbatim. See ``docs/how-to/semantic-cache.md``.
 
 ``SemanticCache`` is the only entry point callers need; the submodules
-(extraction, cacheability, provenance, client, rewrite, service) are imported
-directly where used.
+(backend, extraction, cacheability, provenance, client, redisvl_backend, rewrite,
+service) are imported directly where used.
 """
 
 from redis_sre_agent.core.semantic_cache.service import SemanticCache

--- a/redis_sre_agent/core/semantic_cache/backend.py
+++ b/redis_sre_agent/core/semantic_cache/backend.py
@@ -1,0 +1,95 @@
+"""Backend seam for the semantic answer cache.
+
+``SemanticCache`` (service.py) owns all cache *strategy* -- query rewrite, scope
+extraction, cacheability, provenance, tombstones, invalidation -- and reaches its
+transport through exactly the four methods declared here. Two transports exist:
+
+* :class:`~redis_sre_agent.core.semantic_cache.client.LangCacheClient` -- the
+  managed LangCache REST service, which embeds server-side.
+* :class:`~redis_sre_agent.core.semantic_cache.redisvl_backend.RedisVLBackend`
+  -- ``redisvl``'s ``SemanticCache`` on plain Redis, which embeds client-side.
+
+The contract deliberately speaks LangCache's units -- **similarity** (higher is
+stricter) and **milliseconds** -- because those are the units the existing
+``semantic_cache_*`` settings already use. A backend whose library speaks other
+units converts at its own boundary so the strategy layer never learns them.
+
+Nothing in this repo type-checks (``make lint`` is ruff-only and mypy is not
+wired into any gate), so conformance is asserted at runtime instead: the Protocol
+is ``runtime_checkable`` and the tests assert ``isinstance`` for every backend.
+That catches a method added here but missed in one implementation, which would
+otherwise surface only as an ``AttributeError`` swallowed by service.py's
+fail-open handlers.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List, Optional, Protocol, runtime_checkable
+
+from redis_sre_agent.core.semantic_cache.client import CacheEntry
+
+# Sentinel for "this query names no entity".
+#
+# A tag filter cannot express "field is absent", and redisvl's ``Tag`` renders an
+# empty value as ``*`` -- match EVERYTHING, not nothing -- so omitting entity_id
+# would let a general query match ticket-scoped entries. Writing an explicit
+# value keeps the filter an exact equality match on either backend.
+#
+# Collision-free by construction: extraction.py only ever produces entity ids
+# matching ``[A-Z]{2,}-\d+``, which this cannot match.
+NO_ENTITY = "_none"
+
+
+@runtime_checkable
+class CacheBackend(Protocol):
+    """The transport surface ``SemanticCache`` depends on.
+
+    Every method **fails open**: transport errors are logged and converted to a
+    miss/no-op return value so the cache stays transparent to the agent.
+    """
+
+    async def search(
+        self,
+        prompt: str,
+        *,
+        similarity_threshold: float,
+        attributes: Optional[Dict[str, str]] = None,
+    ) -> List[CacheEntry]:
+        """Return candidate entries ordered best-first, or ``[]`` on any error.
+
+        ``similarity_threshold`` is a similarity, where higher is stricter.
+        """
+        ...
+
+    async def set_entry(
+        self,
+        prompt: str,
+        response: str,
+        *,
+        attributes: Optional[Dict[str, str]] = None,
+        ttl_millis: Optional[int] = None,
+    ) -> Optional[str]:
+        """Store an entry and return an opaque id for it, or None on error.
+
+        The returned id is whatever :meth:`delete_entry` accepts; callers treat
+        it as opaque and only ever round-trip it.
+        """
+        ...
+
+    async def delete_entry(self, entry_id: str) -> bool:
+        """Delete the entry named by an id from :meth:`set_entry`/:meth:`search`.
+
+        Returns True only when the entry is confirmed gone. ``invalidate`` keeps
+        the provenance link for anything that returns False so a later pass can
+        retry, so a falsely-True return permanently strands the entry.
+        """
+        ...
+
+    async def aclose(self) -> None:
+        """Release only resources this instance exclusively owns.
+
+        A per-turn transport closes its client here. A process-lifetime transport
+        is shared across turns and MUST make this a no-op -- see
+        ``RedisVLBackend.aclose``.
+        """
+        ...

--- a/redis_sre_agent/core/semantic_cache/client.py
+++ b/redis_sre_agent/core/semantic_cache/client.py
@@ -28,8 +28,13 @@ DEFAULT_SEARCH_STRATEGIES: Sequence[str] = ("exact", "semantic")
 
 
 @dataclass(frozen=True)
-class LangCacheEntry:
-    """A single cache entry returned by a search (api.yaml ``CacheEntry``)."""
+class CacheEntry:
+    """A single cache entry returned by a search (api.yaml ``CacheEntry``).
+
+    Backend-neutral: both transports map their native hit shape onto this. All
+    six fields are load-bearing -- ``response`` is what gets served and
+    ``attributes`` is what the scope check in service.py compares against.
+    """
 
     id: str
     prompt: str
@@ -39,7 +44,7 @@ class LangCacheEntry:
     search_strategy: str
 
     @classmethod
-    def from_payload(cls, payload: Dict[str, Any]) -> "LangCacheEntry":
+    def from_payload(cls, payload: Dict[str, Any]) -> "CacheEntry":
         return cls(
             id=str(payload.get("id", "")),
             prompt=str(payload.get("prompt", "")),
@@ -48,6 +53,10 @@ class LangCacheEntry:
             attributes=dict(payload.get("attributes") or {}),
             search_strategy=str(payload.get("searchStrategy", "")),
         )
+
+
+# Historical name from when LangCache was the only transport.
+LangCacheEntry = CacheEntry
 
 
 class LangCacheClient:
@@ -100,7 +109,7 @@ class LangCacheClient:
         similarity_threshold: float,
         attributes: Optional[Dict[str, str]] = None,
         search_strategies: Sequence[str] = DEFAULT_SEARCH_STRATEGIES,
-    ) -> List[LangCacheEntry]:
+    ) -> List[CacheEntry]:
         """Search the cache. Returns matching entries (possibly empty) or [] on error."""
         body: Dict[str, Any] = {
             "prompt": prompt,
@@ -114,7 +123,7 @@ class LangCacheClient:
             resp = await client.post(self._url("/entries/search"), json=body, headers=self._headers)
             resp.raise_for_status()
             data = resp.json().get("data") or []
-            return [LangCacheEntry.from_payload(item) for item in data]
+            return [CacheEntry.from_payload(item) for item in data]
         except Exception as exc:
             logger.warning("LangCache search failed (fail-open miss): %s", exc)
             return []

--- a/redis_sre_agent/core/semantic_cache/redisvl_backend.py
+++ b/redis_sre_agent/core/semantic_cache/redisvl_backend.py
@@ -1,0 +1,277 @@
+"""``redisvl``-backed transport for the semantic answer cache.
+
+Same strategy as the LangCache transport, different tool: ``redisvl``'s
+``SemanticCache`` runs on the plain Redis this service already uses, so the cache
+works with no external provisioning.
+
+The one real operational difference is that embeddings are computed
+**client-side** here, where LangCache computes them server-side. A repeated query
+is free (``create_vectorizer`` attaches an ``EmbeddingsCache``), but a *novel*
+query pays an embedding round trip before the miss is even known.
+
+Two unit conversions live here so the strategy layer never learns them:
+
+* **Threshold** -- ``distance_threshold`` is Redis COSINE distance in ``[0, 2]``
+  where *lower* is stricter, the inverse of our similarity setting.
+* **TTL** -- ``astore`` takes seconds; ``semantic_cache_ttl_*_ms`` are millis.
+
+**Identifier shape.** ``astore`` returns the *full prefixed Redis key*, while
+``adrop(ids=...)`` expects an unprefixed id and re-prefixes it itself. Passing
+one to the other deletes nothing while appearing to succeed -- which would make
+``invalidate`` clear the provenance link for a live entry and strand it past its
+own retry path. So the full key is the single identifier used everywhere: what
+``set_entry`` returns, what ``search`` reads from ``hit["key"]``, and what goes
+to ``adrop(keys=...)``.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List, Optional
+
+from redis_sre_agent.core.config import Settings
+from redis_sre_agent.core.config import settings as global_settings
+from redis_sre_agent.core.semantic_cache.client import CacheEntry
+
+logger = logging.getLogger(__name__)
+
+# Index name for the cache's own RediSearch index, in the service's own Redis.
+# Changing this (or the fields/embedding model below) orphans existing entries;
+# they expire on their own TTL.
+INDEX_NAME = "sre_semantic_cache"
+
+# Declared up front: redisvl bakes filterable fields into the index schema, so
+# they must exist before the first store. These are plain dicts -- the
+# `filterable_fields` parameter is typed `list[dict]`, NOT a list of query-filter
+# objects, and passing `Tag(...)` objects raises inside the constructor (which
+# service.py's fail-open would then swallow into a permanently dead cache).
+_FILTERABLE_FIELDS: List[Dict[str, Any]] = [
+    {"name": "version", "type": "tag"},
+    {"name": "entity_id", "type": "tag"},
+    {"name": "cache_origin", "type": "tag"},
+]
+_ATTRIBUTE_FIELDS = tuple(str(field["name"]) for field in _FILTERABLE_FIELDS)
+
+# The attribute pre-filter is exact, so one hit is normally enough. A few extra
+# cost almost nothing and give service.py's in-scope scan something to work with
+# if a filter ever fails to apply.
+_NUM_RESULTS = 4
+
+
+def _distance_for(similarity_threshold: float) -> float:
+    """Similarity (higher is stricter) -> COSINE distance (lower is stricter)."""
+    return max(0.0, min(2.0, 1.0 - float(similarity_threshold)))
+
+
+def _similarity_for(vector_distance: Any) -> float:
+    """COSINE distance -> similarity, the inverse of :func:`_distance_for`."""
+    return 1.0 - float(vector_distance or 0.0)
+
+
+def _ttl_seconds(ttl_millis: Optional[int]) -> Optional[int]:
+    """Milliseconds -> whole seconds, floored at 1.
+
+    Flooring matters: redisvl treats a TTL of 0 as "no TTL" (store forever), so a
+    sub-second TTL must not round down to it.
+    """
+    if ttl_millis is None:
+        return None
+    return max(1, round(int(ttl_millis) / 1000))
+
+
+def _filter_for(attributes: Optional[Dict[str, str]]) -> Any:
+    """AND together an exact tag match per supplied attribute.
+
+    Fields with no value are skipped rather than filtered on, because an empty
+    ``Tag`` value renders as ``*`` -- match everything -- which would silently
+    widen the query instead of narrowing it.
+    """
+    from redisvl.query.filter import Tag
+
+    expression = None
+    for name in _ATTRIBUTE_FIELDS:
+        value = (attributes or {}).get(name)
+        if not value:
+            continue
+        clause = Tag(name) == value
+        expression = clause if expression is None else expression & clause
+    return expression
+
+
+def _entry_from_hit(hit: Dict[str, Any]) -> CacheEntry:
+    """Map a redisvl hit onto the backend-neutral :class:`CacheEntry`.
+
+    All six fields matter. ``attributes`` especially: redisvl calls these
+    "filters" and returns them flattened onto the hit, so leaving them out would
+    make service.py's scope check reject every entity-scoped hit while general
+    queries kept working -- a partial failure hidden behind fail-open.
+    """
+    return CacheEntry(
+        # The full Redis key, not the bare entry_id -- see the module docstring.
+        id=str(hit.get("key", "")),
+        prompt=str(hit.get("prompt", "")),
+        response=str(hit.get("response", "")),
+        similarity=_similarity_for(hit.get("vector_distance")),
+        attributes={name: str(hit[name]) for name in _ATTRIBUTE_FIELDS if hit.get(name)},
+        # redisvl has no server-side exact-match tier; every hit is a vector hit.
+        search_strategy="semantic",
+    )
+
+
+class RedisVLBackend:
+    """A :class:`CacheBackend` over ``redisvl``'s ``SemanticCache``.
+
+    Accepts the underlying cache by injection so tests can drive the real mapping
+    logic against a stub with no Redis, no vectorizer and no network.
+    """
+
+    def __init__(self, cache: Any):
+        self._cache = cache
+
+    async def search(
+        self,
+        prompt: str,
+        *,
+        similarity_threshold: float,
+        attributes: Optional[Dict[str, str]] = None,
+    ) -> List[CacheEntry]:
+        """Search the cache. Returns matching entries (possibly empty) or [] on error."""
+        try:
+            hits = await self._cache.acheck(
+                prompt,
+                num_results=_NUM_RESULTS,
+                filter_expression=_filter_for(attributes),
+                distance_threshold=_distance_for(similarity_threshold),
+            )
+            return [_entry_from_hit(hit) for hit in hits or []]
+        except Exception as exc:
+            logger.warning("redisvl cache search failed (fail-open miss): %s", exc)
+            return []
+
+    async def set_entry(
+        self,
+        prompt: str,
+        response: str,
+        *,
+        attributes: Optional[Dict[str, str]] = None,
+        ttl_millis: Optional[int] = None,
+    ) -> Optional[str]:
+        """Store an entry. Returns the full Redis key, or None on error."""
+        try:
+            return await self._cache.astore(
+                prompt,
+                response,
+                filters=dict(attributes or {}),
+                ttl=_ttl_seconds(ttl_millis),
+            )
+        except Exception as exc:
+            logger.warning("redisvl cache set failed (fail-open no-op): %s", exc)
+            return None
+
+    async def delete_entry(self, entry_id: str) -> bool:
+        """Delete one entry by the key ``set_entry``/``search`` returned.
+
+        Uses ``keys=`` rather than ``ids=`` because ``entry_id`` is already the
+        full prefixed key; ``ids=`` would prefix it a second time and delete
+        nothing. Returns True only if the drop did not raise -- an
+        already-absent key counts as gone, which is what ``invalidate`` asks.
+        """
+        try:
+            await self._cache.adrop(keys=[entry_id])
+            return True
+        except Exception as exc:
+            logger.warning("redisvl cache delete_entry failed: %s", exc)
+            return False
+
+    async def aclose(self) -> None:
+        """No-op: this instance is process-wide and shared across turns.
+
+        service.py closes its backend in a ``finally`` on every turn. For a
+        memoized transport that must not tear anything down, or the next turn
+        would find dead connections. See :func:`get_redisvl_backend`.
+        """
+        return None
+
+
+# Memoized per settings identity. Construction is expensive AND blocking:
+# `SemanticCache.__init__` does a synchronous Redis round trip, and
+# `create_vectorizer()` makes an *uncached* synchronous OpenAI call to discover
+# embedding dimensions (redisvl's `_set_model_dims` calls the private `_embed`,
+# bypassing its own EmbeddingsCache despite a comment claiming otherwise).
+# service.py builds a cache twice per turn, so without this every turn would pay
+# both costs twice.
+_BACKENDS: Dict[tuple, "RedisVLBackend"] = {}
+
+
+def _identity(cfg: Settings) -> tuple:
+    """Everything that determines which backend instance is the right one.
+
+    Spelled out because ``Settings`` is not hashable. ``vectorizer_factory`` is
+    included because it selects the embedding implementation; the module-global
+    override installed by ``set_vectorizer_factory`` cannot be keyed at all,
+    which is why that setter calls :func:`reset_backend_cache` instead.
+    """
+    return (
+        cfg.redis_url.get_secret_value(),
+        cfg.embedding_provider,
+        cfg.embedding_model,
+        cfg.embeddings_cache_ttl,
+        cfg.openai_base_url,
+        getattr(cfg, "vectorizer_factory", None),
+    )
+
+
+def _build_cache(cfg: Settings) -> Any:
+    """Construct the underlying ``redisvl`` cache. Blocking; call once."""
+    from redisvl.extensions.cache.llm import SemanticCache
+
+    from redis_sre_agent.core.vectorizer_helpers import create_vectorizer
+
+    return SemanticCache(
+        name=INDEX_NAME,
+        vectorizer=create_vectorizer(cfg),
+        filterable_fields=_FILTERABLE_FIELDS,
+        redis_url=cfg.redis_url.get_secret_value(),
+        # Deliberately no `ttl=`. `acheck()` refreshes the TTL of every hit it
+        # returns, so a cache-level TTL would turn our fixed store-time TTLs into
+        # a sliding window -- and a popular "latest" answer, which is short-lived
+        # precisely because it tracks a moving pointer, would never expire.
+        # Per-entry TTLs passed to `astore(ttl=...)` are unaffected by reads.
+    )
+
+
+def get_redisvl_backend(settings: Optional[Settings] = None) -> Optional[RedisVLBackend]:
+    """Return the process-wide backend for these settings, building it once.
+
+    Deliberately synchronous. A plain function called from a coroutine has no
+    await point inside it, so two concurrent turns cannot interleave through it
+    and no lock is needed. Wrapping the build in ``asyncio.to_thread`` would
+    *introduce* the double-construction race that a lock would then have to
+    guard, to avoid a single once-per-process stall that is smaller than what the
+    knowledge-search path already takes on the loop today.
+
+    Returns None (and logs) if construction fails, so a misconfigured cache
+    degrades to "no cache" instead of breaking the agent. Failures are not
+    memoized, so a transient error is retried on the next turn.
+    """
+    cfg = settings or global_settings
+    key = _identity(cfg)
+    backend = _BACKENDS.get(key)
+    if backend is not None:
+        return backend
+    try:
+        backend = RedisVLBackend(_build_cache(cfg))
+    except Exception as exc:
+        logger.warning("redisvl semantic cache unavailable (disabling): %s", exc)
+        return None
+    _BACKENDS[key] = backend
+    return backend
+
+
+def reset_backend_cache() -> None:
+    """Drop memoized backends.
+
+    Used by tests, and by ``set_vectorizer_factory`` since a module-global
+    factory override cannot be part of the memo key.
+    """
+    _BACKENDS.clear()

--- a/redis_sre_agent/core/semantic_cache/redisvl_backend.py
+++ b/redis_sre_agent/core/semantic_cache/redisvl_backend.py
@@ -29,6 +29,8 @@ from __future__ import annotations
 import logging
 from typing import Any, Dict, List, Optional
 
+from redisvl.query.filter import Tag
+
 from redis_sre_agent.core.config import Settings
 from redis_sre_agent.core.config import settings as global_settings
 from redis_sre_agent.core.semantic_cache.client import CacheEntry
@@ -86,8 +88,6 @@ def _filter_for(attributes: Optional[Dict[str, str]]) -> Any:
     ``Tag`` value renders as ``*`` -- match everything -- which would silently
     widen the query instead of narrowing it.
     """
-    from redisvl.query.filter import Tag
-
     expression = None
     for name in _ATTRIBUTE_FIELDS:
         value = (attributes or {}).get(name)
@@ -193,32 +193,19 @@ class RedisVLBackend:
         return None
 
 
-# Memoized per settings identity. Construction is expensive AND blocking:
+# Built once per process. Construction is expensive AND blocking:
 # `SemanticCache.__init__` does a synchronous Redis round trip, and
 # `create_vectorizer()` makes an *uncached* synchronous OpenAI call to discover
 # embedding dimensions (redisvl's `_set_model_dims` calls the private `_embed`,
 # bypassing its own EmbeddingsCache despite a comment claiming otherwise).
 # service.py builds a cache twice per turn, so without this every turn would pay
 # both costs twice.
-_BACKENDS: Dict[tuple, "RedisVLBackend"] = {}
-
-
-def _identity(cfg: Settings) -> tuple:
-    """Everything that determines which backend instance is the right one.
-
-    Spelled out because ``Settings`` is not hashable. ``vectorizer_factory`` is
-    included because it selects the embedding implementation; the module-global
-    override installed by ``set_vectorizer_factory`` cannot be keyed at all,
-    which is why that setter calls :func:`reset_backend_cache` instead.
-    """
-    return (
-        cfg.redis_url.get_secret_value(),
-        cfg.embedding_provider,
-        cfg.embedding_model,
-        cfg.embeddings_cache_ttl,
-        cfg.openai_base_url,
-        getattr(cfg, "vectorizer_factory", None),
-    )
+#
+# Not keyed on settings: `from_settings` uses global settings on every production
+# path, so one instance per process is the only shape that occurs. Tests that vary
+# settings call `reset_backend_cache`.
+_BACKEND: Optional["RedisVLBackend"] = None
+_BUILD_FAILED = False
 
 
 def _build_cache(cfg: Settings) -> Any:
@@ -241,7 +228,7 @@ def _build_cache(cfg: Settings) -> Any:
 
 
 def get_redisvl_backend(settings: Optional[Settings] = None) -> Optional[RedisVLBackend]:
-    """Return the process-wide backend for these settings, building it once.
+    """Return the process-wide backend, building it at most once.
 
     Deliberately synchronous. A plain function called from a coroutine has no
     await point inside it, so two concurrent turns cannot interleave through it
@@ -251,27 +238,33 @@ def get_redisvl_backend(settings: Optional[Settings] = None) -> Optional[RedisVL
     knowledge-search path already takes on the loop today.
 
     Returns None (and logs) if construction fails, so a misconfigured cache
-    degrades to "no cache" instead of breaking the agent. Failures are not
-    memoized, so a transient error is retried on the next turn.
+    degrades to "no cache" instead of breaking the agent.
+
+    A failure is remembered, deliberately. The realistic failure is *permanent* --
+    an index-schema mismatch after changing ``filterable_fields`` or
+    ``embedding_model`` -- and every retry pays the uncached blocking OpenAI
+    dimension probe again, twice per turn, on the event loop. So a broken cache
+    would not just be dead, it would actively slow every request. Trading
+    recovery-without-restart for that is worth it: this cache is a non-essential
+    optimization that already fails open, and a worker restart clears the flag.
     """
-    cfg = settings or global_settings
-    key = _identity(cfg)
-    backend = _BACKENDS.get(key)
-    if backend is not None:
-        return backend
+    global _BACKEND, _BUILD_FAILED
+    if _BACKEND is not None or _BUILD_FAILED:
+        return _BACKEND
     try:
-        backend = RedisVLBackend(_build_cache(cfg))
+        _BACKEND = RedisVLBackend(_build_cache(settings or global_settings))
     except Exception as exc:
+        _BUILD_FAILED = True
         logger.warning("redisvl semantic cache unavailable (disabling): %s", exc)
-        return None
-    _BACKENDS[key] = backend
-    return backend
+    return _BACKEND
 
 
 def reset_backend_cache() -> None:
-    """Drop memoized backends.
+    """Forget the memoized backend and any remembered failure.
 
-    Used by tests, and by ``set_vectorizer_factory`` since a module-global
-    factory override cannot be part of the memo key.
+    Used by tests, and by ``set_vectorizer_factory`` since a module-global factory
+    override cannot be detected from settings.
     """
-    _BACKENDS.clear()
+    global _BACKEND, _BUILD_FAILED
+    _BACKEND = None
+    _BUILD_FAILED = False

--- a/redis_sre_agent/core/semantic_cache/service.py
+++ b/redis_sre_agent/core/semantic_cache/service.py
@@ -1,8 +1,13 @@
 """SemanticCache orchestrator: read (lookup) and write (store) + invalidation.
 
-This ties together the LangCache client (match + serve), the provenance store
+This ties together a cache backend (match + serve), the provenance store
 (invalidate), and the extraction/rewrite/cacheability helpers. It is the only
 object the agent and ingestion paths interact with.
+
+Backend-agnostic: everything here is strategy, reached through the four methods
+of :class:`~redis_sre_agent.core.semantic_cache.backend.CacheBackend`. Which
+transport is used is a settings choice (``semantic_cache_backend``); no logic in
+this module branches on it.
 
 Design references: read path §D, write path §H, invalidation §G, identifiers §I.
 """
@@ -22,9 +27,14 @@ if TYPE_CHECKING:
 
 from redis_sre_agent.core.config import Settings
 from redis_sre_agent.core.config import settings as global_settings
+from redis_sre_agent.core.semantic_cache.backend import NO_ENTITY, CacheBackend
 from redis_sre_agent.core.semantic_cache.cacheability import decide_cacheability
-from redis_sre_agent.core.semantic_cache.client import LangCacheClient
-from redis_sre_agent.core.semantic_cache.extraction import DEFAULT_VERSION, extract_cache_scope
+from redis_sre_agent.core.semantic_cache.client import CacheEntry, LangCacheClient
+from redis_sre_agent.core.semantic_cache.extraction import (
+    DEFAULT_VERSION,
+    CacheScope,
+    extract_cache_scope,
+)
 from redis_sre_agent.core.semantic_cache.provenance import ProvenanceStore, path_hash_for_source
 from redis_sre_agent.core.semantic_cache.rewrite import rewrite_query
 
@@ -35,13 +45,41 @@ _MAX_PROMPT_LEN = 1024
 _CACHE_ORIGIN_DYNAMIC = "dynamic"
 
 
+def build_backend(cfg: Settings) -> Optional[CacheBackend]:
+    """Build the configured cache transport, or None when it cannot run.
+
+    ``redisvl`` (the default) runs on this service's own Redis and needs no
+    external provisioning. ``langcache`` keeps its historical behaviour of
+    degrading to "no cache" when credentials are absent, so enabling the flag
+    without provisioning logs a warning rather than raising.
+    """
+    if cfg.semantic_cache_backend == "langcache":
+        if not cfg.langcache_cache_id or not cfg.langcache_api_key:
+            if cfg.semantic_cache_enabled:
+                logger.warning(
+                    "semantic_cache_enabled but LangCache credentials missing; disabling."
+                )
+            return None
+        return LangCacheClient(
+            server_url=cfg.langcache_server_url,
+            cache_id=cfg.langcache_cache_id.get_secret_value(),
+            api_key=cfg.langcache_api_key.get_secret_value(),
+        )
+
+    # Imported lazily so `redisvl`'s cache extension (and the vectorizer it
+    # builds) is only touched when this backend is actually selected.
+    from redis_sre_agent.core.semantic_cache.redisvl_backend import get_redisvl_backend
+
+    return get_redisvl_backend(cfg)
+
+
 class SemanticCache:
     """Semantic answer cache sitting above the knowledge-agent graph."""
 
     def __init__(
         self,
         *,
-        client: LangCacheClient,
+        client: CacheBackend,
         provenance: ProvenanceStore,
         similarity_threshold: float,
         ttl_latest_ms: int,
@@ -65,26 +103,19 @@ class SemanticCache:
     ) -> Optional["SemanticCache"]:
         """Build a SemanticCache from settings, or None if it cannot/should not run.
 
-        Returns None when LangCache credentials are missing. When
-        ``require_enabled`` is True (serve/store paths) it also returns None
-        while ``semantic_cache_enabled`` is False. Invalidation passes
-        ``require_enabled=False`` so push invalidation keeps running even with
-        the kill switch off (design §L). Callers treat None as "cache absent".
+        Returns None when the configured backend cannot be built (see
+        :func:`build_backend`). When ``require_enabled`` is True (serve/store
+        paths) it also returns None while ``semantic_cache_enabled`` is False.
+        Invalidation passes ``require_enabled=False`` so push invalidation keeps
+        running even with the kill switch off (design §L). Callers treat None as
+        "cache absent".
         """
         cfg = settings or global_settings
         if require_enabled and not cfg.semantic_cache_enabled:
             return None
-        if not cfg.langcache_cache_id or not cfg.langcache_api_key:
-            if cfg.semantic_cache_enabled:
-                logger.warning(
-                    "semantic_cache_enabled but LangCache credentials missing; disabling."
-                )
+        client = build_backend(cfg)
+        if client is None:
             return None
-        client = LangCacheClient(
-            server_url=cfg.langcache_server_url,
-            cache_id=cfg.langcache_cache_id.get_secret_value(),
-            api_key=cfg.langcache_api_key.get_secret_value(),
-        )
         provenance = ProvenanceStore(
             redis_client,
             tombstone_ttl_seconds=cfg.semantic_cache_inval_tombstone_ttl_seconds,
@@ -127,6 +158,31 @@ class SemanticCache:
 
     def _ttl_for_version(self, version: str) -> int:
         return self._ttl_latest_ms if version == DEFAULT_VERSION else self._ttl_pinned_ms
+
+    def _first_in_scope(
+        self, entries: Sequence[CacheEntry], scope: CacheScope
+    ) -> Optional[CacheEntry]:
+        """First entry above threshold whose entity scope matches exactly (§D note 4).
+
+        Scanning instead of trusting ``entries[0]`` removes the last dependence on
+        a backend's own filtering. If a transport ranks a near-miss from another
+        entity ahead of a valid in-scope entry, that entry is still found rather
+        than the lookup reporting a false miss.
+
+        The entity comparison normalizes BOTH sides: ``scope.entity_id`` is
+        Optional while stored attributes always carry an explicit value, so
+        comparing them raw would reject every general query. A general query must
+        not receive a ticket-scoped entry, and vice versa.
+        """
+        wanted = scope.entity_id or NO_ENTITY
+        for entry in entries:
+            if entry.similarity < self._threshold:
+                continue
+            if (entry.attributes.get("entity_id") or NO_ENTITY) != wanted:
+                logger.debug("semantic-cache post-filter reject: entity_id mismatch")
+                continue
+            return entry
+        return None
 
     # -- read path (§D) -------------------------------------------------------
 
@@ -173,9 +229,14 @@ class SemanticCache:
                 # single entity_id.
                 logger.debug("semantic-cache lookup skipped: multi-entity query")
                 return None
-            attributes: Dict[str, str] = {"version": scope.version}
-            if scope.entity_id:
-                attributes["entity_id"] = scope.entity_id
+            # entity_id is ALWAYS sent (NO_ENTITY when the query names none) so the
+            # backend filter is an exact equality match. Omitting it is not the
+            # same as "no entity": a tag filter cannot express absence, and an
+            # empty tag value renders as `*` — match everything.
+            attributes: Dict[str, str] = {
+                "version": scope.version,
+                "entity_id": scope.entity_id or NO_ENTITY,
+            }
 
             entries = await self._client.search(
                 key,
@@ -186,16 +247,9 @@ class SemanticCache:
                 logger.debug("semantic-cache miss")
                 return None
 
-            candidate = entries[0]
-            if candidate.similarity < self._threshold:
-                return None
-
-            # Post-filter safety net (§D note 4): the served entry's entity_id must
-            # EQUAL the requested one — symmetrically. A general query (no entity_id)
-            # must not receive a ticket-scoped entry, and vice versa. Holds
-            # regardless of whether LangCache pre- or post-filters on attributes.
-            if (candidate.attributes.get("entity_id") or None) != scope.entity_id:
-                logger.debug("semantic-cache post-filter reject: entity_id mismatch")
+            candidate = self._first_in_scope(entries, scope)
+            if candidate is None:
+                logger.debug("semantic-cache miss: no in-scope candidate")
                 return None
 
             response = self._reconstruct_response(candidate.response)
@@ -262,12 +316,13 @@ class SemanticCache:
                 # scope — deferred per §J, so don't store them under one ticket.
                 logger.debug("semantic-cache store skipped: multi-entity query")
                 return None
+            # Mirrors the lookup attribute map: entity_id is always written so the
+            # lookup filter can match it exactly on either backend.
             attributes: Dict[str, str] = {
                 "version": scope.version,
+                "entity_id": scope.entity_id or NO_ENTITY,
                 "cache_origin": _CACHE_ORIGIN_DYNAMIC,
             }
-            if scope.entity_id:
-                attributes["entity_id"] = scope.entity_id
 
             payload = json.dumps(
                 {"response": response, "search_results": list(search_results)}, default=str

--- a/redis_sre_agent/core/vectorizer_helpers.py
+++ b/redis_sre_agent/core/vectorizer_helpers.py
@@ -82,6 +82,13 @@ def set_vectorizer_factory(factory: Optional[VectorizerFactory]) -> None:
     _settings_vectorizer_factory = None
     _factory_initialized = True
 
+    # The semantic cache memoizes a backend holding a vectorizer built by this
+    # factory. That memo cannot key on a module global, so drop it here or the
+    # override would be silently inert for an already-built cache.
+    from redis_sre_agent.core.semantic_cache.redisvl_backend import reset_backend_cache
+
+    reset_backend_cache()
+
 
 def get_vectorizer_factory() -> Optional[VectorizerFactory]:
     """Get the currently registered global vectorizer factory, if any."""

--- a/tests/unit/core/semantic_cache/test_backend_contract.py
+++ b/tests/unit/core/semantic_cache/test_backend_contract.py
@@ -36,7 +36,10 @@ _STORED_KEY = "sre_semantic_cache:contract"
 
 
 def test_contract_covers_every_protocol_method():
-    assert set(CacheBackend.__protocol_attrs__) == _COVERED_METHODS
+    # Read the methods off the class rather than `__protocol_attrs__`, which
+    # does not exist before Python 3.12 (CI runs 3.11 and 3.12).
+    declared = {name for name, value in vars(CacheBackend).items() if callable(value)}
+    assert {n for n in declared if not n.startswith("_")} == _COVERED_METHODS
 
 
 # -- backend construction ----------------------------------------------------

--- a/tests/unit/core/semantic_cache/test_backend_contract.py
+++ b/tests/unit/core/semantic_cache/test_backend_contract.py
@@ -1,0 +1,295 @@
+"""The backend-parametrized contract suite: one matrix, both REAL backends.
+
+``test_service.py`` proves the *strategy* layer is transport-agnostic by driving
+it through a Protocol-shaped fake. This file proves the other half: that each
+real transport actually honours the contract that layer depends on -- unit
+conversions, the attribute round trip, and the identifier shape.
+
+Both backends run their real mapping code here. Only the outermost boundary is
+faked, at the last line of code we own:
+
+* LangCache -- an ``httpx.MockTransport``, so request construction and JSON
+  parsing are exercised for real.
+* redisvl -- a stub with ``acheck``/``astore``/``adrop``, since redisvl's own
+  internals (vectorizer, index, Redis) are not ours to test.
+
+Consequence: zero network calls and zero embedding calls. The memoized factory is
+deliberately bypassed -- backends are constructed directly.
+"""
+
+import json
+
+import httpx
+import pytest
+
+from redis_sre_agent.core.semantic_cache.backend import NO_ENTITY, CacheBackend
+from redis_sre_agent.core.semantic_cache.client import LangCacheClient
+from redis_sre_agent.core.semantic_cache.redisvl_backend import RedisVLBackend
+
+# Tripwire: adding a method to CacheBackend must come with a contract case here.
+# Without this, a new method silently gets no cross-backend coverage, and a
+# missing implementation surfaces only as an AttributeError that service.py's
+# fail-open swallows.
+_COVERED_METHODS = {"search", "set_entry", "delete_entry", "aclose"}
+
+_STORED_KEY = "sre_semantic_cache:contract"
+
+
+def test_contract_covers_every_protocol_method():
+    assert set(CacheBackend.__protocol_attrs__) == _COVERED_METHODS
+
+
+# -- backend construction ----------------------------------------------------
+
+
+class _RedisVLStub:
+    """redisvl's SemanticCache surface, backed by an in-memory dict."""
+
+    def __init__(self):
+        self.entries = {}
+        self.last_check = None
+
+    async def acheck(self, prompt, num_results=1, filter_expression=None, distance_threshold=None):
+        self.last_check = {
+            "filter": str(filter_expression) if filter_expression is not None else None,
+            "distance_threshold": distance_threshold,
+        }
+        # Return everything; the contract asserts on mapping, and service.py owns
+        # scope selection. Shape mirrors redisvl: filters flattened onto the hit.
+        return list(self.entries.values())
+
+    async def astore(self, prompt, response, filters=None, ttl=None):
+        hit = {
+            "key": _STORED_KEY,
+            "entry_id": "contract",
+            "prompt": prompt,
+            "response": response,
+            "vector_distance": 0.02,
+            **(filters or {}),
+        }
+        self.entries[_STORED_KEY] = hit
+        return _STORED_KEY
+
+    async def adrop(self, ids=None, keys=None):
+        if ids is not None:
+            # Mirrors the real re-prefixing, so passing a full key as an id
+            # resolves to a name that does not exist and deletes nothing.
+            for entry_id in ids:
+                self.entries.pop(f"sre_semantic_cache:{entry_id}", None)
+        for key in keys or []:
+            self.entries.pop(key, None)
+
+
+def _make_langcache():
+    """Real LangCacheClient over an in-memory MockTransport LangCache."""
+    store = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content or b"{}")
+        path = request.url.path
+        if path.endswith("/entries/search"):
+            wanted = body.get("attributes") or {}
+            data = [
+                entry
+                for entry in store.values()
+                if all(entry["attributes"].get(k) == v for k, v in wanted.items())
+            ]
+            return httpx.Response(200, json={"data": data})
+        if path.endswith("/entries"):
+            store[_STORED_KEY] = {
+                "id": _STORED_KEY,
+                "prompt": body["prompt"],
+                "response": body["response"],
+                "similarity": 0.98,
+                "attributes": body.get("attributes") or {},
+                "searchStrategy": "semantic",
+            }
+            return httpx.Response(200, json={"entryId": _STORED_KEY})
+        if request.method == "DELETE":
+            existed = store.pop(path.rsplit("/", 1)[-1], None)
+            return httpx.Response(200 if existed else 404, json={})
+        return httpx.Response(404, json={})
+
+    return LangCacheClient(
+        server_url="https://langcache.test",
+        cache_id="cache-1",
+        api_key="key-1",
+        client=httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+    ), store
+
+
+@pytest.fixture(params=["langcache", "redisvl"])
+def backend(request):
+    if request.param == "langcache":
+        client, _ = _make_langcache()
+        return client
+    return RedisVLBackend(cache=_RedisVLStub())
+
+
+# -- the contract ------------------------------------------------------------
+
+
+def test_backend_satisfies_the_protocol(backend):
+    assert isinstance(backend, CacheBackend)
+
+
+@pytest.mark.asyncio
+async def test_store_returns_an_id_that_search_reports_back(backend):
+    """The identifier shape must be one thing across store, search and delete."""
+    entry_id = await backend.set_entry(
+        "how do I tune maxmemory",
+        json.dumps({"response": "answer"}),
+        attributes={"version": "latest", "entity_id": NO_ENTITY, "cache_origin": "dynamic"},
+        ttl_millis=3_600_000,
+    )
+    assert entry_id
+
+    entries = await backend.search(
+        "how do I tune maxmemory",
+        similarity_threshold=0.9,
+        attributes={"version": "latest", "entity_id": NO_ENTITY},
+    )
+    assert [e.id for e in entries] == [entry_id]
+
+
+@pytest.mark.asyncio
+async def test_stored_attributes_survive_the_round_trip(backend):
+    """service.py's scope check reads ``attributes``; an empty dict breaks it.
+
+    With attributes dropped, general queries would keep working while every
+    entity-scoped lookup silently missed -- so assert a ticket-scoped value
+    positively, not just that rejection happens.
+    """
+    await backend.set_entry(
+        "status of RET-4421",
+        json.dumps({"response": "ticket answer"}),
+        attributes={"version": "7.8", "entity_id": "RET-4421", "cache_origin": "dynamic"},
+        ttl_millis=86_400_000,
+    )
+
+    entries = await backend.search(
+        "status of RET-4421",
+        similarity_threshold=0.9,
+        attributes={"version": "7.8", "entity_id": "RET-4421"},
+    )
+
+    assert entries, "a stored entry must be findable"
+    assert entries[0].attributes["entity_id"] == "RET-4421"
+    assert entries[0].attributes["version"] == "7.8"
+
+
+@pytest.mark.asyncio
+async def test_response_survives_the_round_trip(backend):
+    payload = json.dumps({"response": "answer", "search_results": [{"title": "Doc"}]})
+    await backend.set_entry("q", payload, attributes={"version": "latest", "entity_id": NO_ENTITY})
+
+    entries = await backend.search(
+        "q", similarity_threshold=0.9, attributes={"version": "latest", "entity_id": NO_ENTITY}
+    )
+    assert entries[0].response == payload
+
+
+@pytest.mark.asyncio
+async def test_similarity_is_reported_as_similarity_not_distance(backend):
+    await backend.set_entry("q", "a", attributes={"version": "latest", "entity_id": NO_ENTITY})
+    entries = await backend.search(
+        "q", similarity_threshold=0.9, attributes={"version": "latest", "entity_id": NO_ENTITY}
+    )
+    # Both backends must express a close match as a HIGH number, whatever their
+    # library speaks internally.
+    assert entries[0].similarity >= 0.9
+
+
+@pytest.mark.asyncio
+async def test_delete_removes_the_entry_it_names(backend):
+    """The bug this shape exists to prevent: a delete that reports success and
+    leaves the entry live makes invalidate() drop its provenance link, so no
+    later pass can ever reach it."""
+    entry_id = await backend.set_entry(
+        "q", "a", attributes={"version": "latest", "entity_id": NO_ENTITY}
+    )
+
+    assert await backend.delete_entry(entry_id) is True
+
+    entries = await backend.search(
+        "q", similarity_threshold=0.9, attributes={"version": "latest", "entity_id": NO_ENTITY}
+    )
+    assert entries == [], "delete_entry returned True but the entry is still served"
+
+
+@pytest.mark.asyncio
+async def test_search_miss_returns_empty_list(backend):
+    assert (
+        await backend.search(
+            "never stored", similarity_threshold=0.9, attributes={"version": "latest"}
+        )
+        == []
+    )
+
+
+@pytest.mark.asyncio
+async def test_aclose_is_safe_to_call(backend):
+    # Per-turn transports close their own client; shared ones no-op. Either way
+    # service.py's `finally: aclose()` must never raise.
+    await backend.aclose()
+
+
+# -- fail-open ---------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_search_fails_open_when_the_transport_breaks():
+    def exploding(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("no route to host")
+
+    langcache = LangCacheClient(
+        server_url="https://langcache.test",
+        cache_id="c",
+        api_key="k",
+        client=httpx.AsyncClient(transport=httpx.MockTransport(exploding)),
+    )
+
+    class Broken:
+        async def acheck(self, *a, **k):
+            raise RuntimeError("redis down")
+
+    for candidate in (langcache, RedisVLBackend(cache=Broken())):
+        assert await candidate.search("q", similarity_threshold=0.9) == []
+
+
+@pytest.mark.asyncio
+async def test_set_entry_fails_open_when_the_transport_breaks():
+    def exploding(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("no route to host")
+
+    langcache = LangCacheClient(
+        server_url="https://langcache.test",
+        cache_id="c",
+        api_key="k",
+        client=httpx.AsyncClient(transport=httpx.MockTransport(exploding)),
+    )
+
+    class Broken:
+        async def astore(self, *a, **k):
+            raise RuntimeError("redis down")
+
+    for candidate in (langcache, RedisVLBackend(cache=Broken())):
+        assert await candidate.set_entry("q", "a") is None
+
+
+@pytest.mark.asyncio
+async def test_redisvl_delete_by_id_would_not_remove_the_entry():
+    """Documents why ``delete_entry`` uses ``keys=`` and not ``ids=``.
+
+    ``adrop(ids=...)`` prefixes what it receives, so handing it the already
+    prefixed key that ``astore`` returned resolves to a nonexistent name.
+    """
+    stub = _RedisVLStub()
+    backend = RedisVLBackend(cache=stub)
+    entry_id = await backend.set_entry("q", "a", attributes={"version": "latest"})
+
+    await stub.adrop(ids=[entry_id])  # the wrong call
+    assert entry_id in stub.entries, "sanity check: ids= double-prefixes"
+
+    await backend.delete_entry(entry_id)  # what the backend actually does
+    assert entry_id not in stub.entries

--- a/tests/unit/core/semantic_cache/test_redisvl_backend.py
+++ b/tests/unit/core/semantic_cache/test_redisvl_backend.py
@@ -1,0 +1,395 @@
+"""RedisVLBackend: unit conversions, hit mapping, identifier shape, fail-open.
+
+Drives the real backend against a stub standing in for redisvl's ``SemanticCache``,
+so the mapping code runs for real with no Redis, no vectorizer and no network.
+"""
+
+import pytest
+
+from redis_sre_agent.core.semantic_cache.backend import NO_ENTITY, CacheBackend
+from redis_sre_agent.core.semantic_cache.redisvl_backend import (
+    _FILTERABLE_FIELDS,
+    RedisVLBackend,
+    _distance_for,
+    _entry_from_hit,
+    _filter_for,
+    _similarity_for,
+    _ttl_seconds,
+    get_redisvl_backend,
+    reset_backend_cache,
+)
+
+
+class StubCache:
+    """Stands in for redisvl's SemanticCache at its own API boundary."""
+
+    def __init__(self, hits=None, store_key="sre_semantic_cache:abc123"):
+        self.hits = hits if hits is not None else []
+        self.store_key = store_key
+        self.check_calls = []
+        self.store_calls = []
+        self.dropped = []
+        self.check_exc = None
+        self.store_exc = None
+        self.drop_exc = None
+        # Mirrors the real constructor: no cache-level TTL.
+        self._ttl = None
+
+    async def acheck(self, prompt, num_results=1, filter_expression=None, distance_threshold=None):
+        self.check_calls.append(
+            {
+                "prompt": prompt,
+                "num_results": num_results,
+                "filter": filter_expression,
+                "distance_threshold": distance_threshold,
+            }
+        )
+        if self.check_exc is not None:
+            raise self.check_exc
+        return self.hits
+
+    async def astore(self, prompt, response, filters=None, ttl=None):
+        self.store_calls.append(
+            {"prompt": prompt, "response": response, "filters": filters, "ttl": ttl}
+        )
+        if self.store_exc is not None:
+            raise self.store_exc
+        return self.store_key
+
+    async def adrop(self, ids=None, keys=None):
+        if self.drop_exc is not None:
+            raise self.drop_exc
+        self.dropped.append({"ids": ids, "keys": keys})
+
+
+def _hit(**overrides):
+    """A hit shaped the way redisvl returns them: filters flattened on top."""
+    hit = {
+        "key": "sre_semantic_cache:abc123",
+        "entry_id": "abc123",
+        "prompt": "how do I tune maxmemory",
+        "response": '{"response": "answer"}',
+        "vector_distance": 0.05,
+        "version": "latest",
+        "entity_id": NO_ENTITY,
+        "cache_origin": "dynamic",
+    }
+    hit.update(overrides)
+    return hit
+
+
+# -- conversions -------------------------------------------------------------
+
+
+def test_threshold_converts_similarity_to_cosine_distance():
+    # Our setting is a similarity where higher is stricter; redisvl wants a
+    # distance where lower is stricter.
+    assert _distance_for(0.9) == pytest.approx(0.1)
+    assert _distance_for(1.0) == pytest.approx(0.0)
+    assert _distance_for(0.0) == pytest.approx(1.0)
+
+
+def test_threshold_conversion_stays_in_cosine_range():
+    # Redis rejects a COSINE distance outside [0, 2].
+    assert _distance_for(-5.0) == 2.0
+    assert _distance_for(5.0) == 0.0
+
+
+def test_similarity_is_the_inverse_of_distance():
+    for similarity in (0.9, 0.75, 1.0):
+        assert _similarity_for(_distance_for(similarity)) == pytest.approx(similarity)
+
+
+def test_similarity_treats_missing_distance_as_exact():
+    assert _similarity_for(None) == 1.0
+
+
+def test_ttl_converts_millis_to_seconds():
+    assert _ttl_seconds(3_600_000) == 3600
+    assert _ttl_seconds(86_400_000) == 86_400
+
+
+def test_ttl_floors_at_one_second():
+    # redisvl reads a TTL of 0 as "no TTL", so a sub-second TTL must not round
+    # down into storing forever.
+    assert _ttl_seconds(400) == 1
+    assert _ttl_seconds(1) == 1
+
+
+def test_ttl_passes_through_none():
+    assert _ttl_seconds(None) is None
+
+
+# -- schema / filters --------------------------------------------------------
+
+
+def test_filterable_fields_are_dicts_not_filter_objects():
+    # `filterable_fields` is typed list[dict]; passing Tag() objects raises
+    # inside the constructor, which fail-open would hide as a dead cache.
+    assert _FILTERABLE_FIELDS == [
+        {"name": "version", "type": "tag"},
+        {"name": "entity_id", "type": "tag"},
+        {"name": "cache_origin", "type": "tag"},
+    ]
+
+
+def test_filter_builds_exact_tag_match_per_attribute():
+    # RediSearch tag values are escaped by TokenEscaper, which escapes "." and
+    # "-" -- so a version and a ticket id both come through backslashed.
+    rendered = str(_filter_for({"version": "7.8", "entity_id": "RET-4421"}))
+    assert rendered == r"(@version:{7\.8} @entity_id:{RET\-4421})"
+
+
+def test_filter_includes_the_sentinel_rather_than_omitting_the_field():
+    rendered = str(_filter_for({"version": "latest", "entity_id": NO_ENTITY}))
+    # "_" is not a tag separator, so the sentinel survives unescaped and cannot
+    # collide with a real entity id (extraction.py requires [A-Z]{2,}-\d+).
+    assert rendered == "(@version:{latest} @entity_id:{_none})"
+
+
+def test_filter_for_no_attributes_is_none_not_a_match_all_tag():
+    # An empty Tag value renders as "*" (match everything). Returning None keeps
+    # redisvl from applying a filter at all instead of applying a useless one.
+    assert _filter_for(None) is None
+    assert _filter_for({}) is None
+    assert _filter_for({"version": ""}) is None
+
+
+# -- hit mapping -------------------------------------------------------------
+
+
+def test_hit_maps_all_six_entry_fields():
+    entry = _entry_from_hit(_hit())
+    assert entry.id == "sre_semantic_cache:abc123"
+    assert entry.prompt == "how do I tune maxmemory"
+    assert entry.response == '{"response": "answer"}'
+    assert entry.similarity == pytest.approx(0.95)
+    assert entry.attributes == {
+        "version": "latest",
+        "entity_id": NO_ENTITY,
+        "cache_origin": "dynamic",
+    }
+    assert entry.search_strategy == "semantic"
+
+
+def test_hit_id_is_the_full_key_not_the_bare_entry_id():
+    # set_entry returns astore's full key and delete_entry passes it to
+    # adrop(keys=...); search must use the same shape or invalidation breaks.
+    entry = _entry_from_hit(_hit(key="sre_semantic_cache:xyz", entry_id="xyz"))
+    assert entry.id == "sre_semantic_cache:xyz"
+
+
+def test_hit_preserves_entity_attribute_for_the_scope_check():
+    # An empty attributes dict here would make service.py reject every
+    # entity-scoped hit while general queries kept working.
+    entry = _entry_from_hit(_hit(entity_id="RET-4421"))
+    assert entry.attributes["entity_id"] == "RET-4421"
+
+
+def test_hit_tolerates_missing_optional_fields():
+    entry = _entry_from_hit({"key": "k", "vector_distance": 0.0})
+    assert entry.prompt == "" and entry.response == ""
+    assert entry.attributes == {}
+
+
+# -- transport ---------------------------------------------------------------
+
+
+def test_backend_satisfies_the_protocol():
+    assert isinstance(RedisVLBackend(cache=StubCache()), CacheBackend)
+
+
+@pytest.mark.asyncio
+async def test_search_passes_converted_threshold_and_filter():
+    stub = StubCache(hits=[_hit()])
+    backend = RedisVLBackend(cache=stub)
+
+    entries = await backend.search(
+        "q", similarity_threshold=0.9, attributes={"version": "latest", "entity_id": NO_ENTITY}
+    )
+
+    assert len(entries) == 1
+    assert stub.check_calls[0]["distance_threshold"] == pytest.approx(0.1)
+    assert stub.check_calls[0]["filter"] is not None
+
+
+@pytest.mark.asyncio
+async def test_search_requests_more_than_one_candidate():
+    # service.py scans for the first in-scope entry, so give it room to scan.
+    stub = StubCache()
+    await RedisVLBackend(cache=stub).search("q", similarity_threshold=0.9)
+    assert stub.check_calls[0]["num_results"] > 1
+
+
+@pytest.mark.asyncio
+async def test_search_fails_open_on_error():
+    stub = StubCache()
+    stub.check_exc = RuntimeError("redis down")
+    assert await RedisVLBackend(cache=stub).search("q", similarity_threshold=0.9) == []
+
+
+@pytest.mark.asyncio
+async def test_search_handles_none_hits():
+    stub = StubCache(hits=None)
+    stub.hits = None
+    assert await RedisVLBackend(cache=stub).search("q", similarity_threshold=0.9) == []
+
+
+@pytest.mark.asyncio
+async def test_set_entry_returns_the_full_key_and_converts_ttl():
+    stub = StubCache(store_key="sre_semantic_cache:deadbeef")
+    backend = RedisVLBackend(cache=stub)
+
+    entry_id = await backend.set_entry(
+        "q", "a", attributes={"version": "latest"}, ttl_millis=3_600_000
+    )
+
+    assert entry_id == "sre_semantic_cache:deadbeef"
+    assert stub.store_calls[0]["ttl"] == 3600
+    assert stub.store_calls[0]["filters"] == {"version": "latest"}
+
+
+@pytest.mark.asyncio
+async def test_set_entry_fails_open_on_error():
+    stub = StubCache()
+    stub.store_exc = RuntimeError("nope")
+    assert await RedisVLBackend(cache=stub).set_entry("q", "a") is None
+
+
+@pytest.mark.asyncio
+async def test_delete_entry_drops_by_key_not_id():
+    """Guards the bug this shape exists to prevent.
+
+    ``adrop(ids=...)`` re-prefixes what it is given, so passing astore's already
+    prefixed key as an id would delete nothing while returning success -- which
+    makes invalidate() clear the provenance link for a live entry.
+    """
+    stub = StubCache()
+    backend = RedisVLBackend(cache=stub)
+
+    assert await backend.delete_entry("sre_semantic_cache:abc123") is True
+    assert stub.dropped == [{"ids": None, "keys": ["sre_semantic_cache:abc123"]}]
+
+
+@pytest.mark.asyncio
+async def test_delete_entry_reports_failure_rather_than_false_success():
+    # invalidate() keeps the provenance link when this is False so a later pass
+    # can retry; a falsely-True return would strand the entry until TTL.
+    stub = StubCache()
+    stub.drop_exc = RuntimeError("connection reset")
+    assert await RedisVLBackend(cache=stub).delete_entry("k") is False
+
+
+@pytest.mark.asyncio
+async def test_store_then_delete_round_trips_one_identifier_shape():
+    stub = StubCache(store_key="sre_semantic_cache:rt")
+    backend = RedisVLBackend(cache=stub)
+
+    entry_id = await backend.set_entry("q", "a", attributes={"version": "latest"})
+    assert await backend.delete_entry(entry_id) is True
+    assert stub.dropped[0]["keys"] == [entry_id]
+
+
+@pytest.mark.asyncio
+async def test_aclose_is_a_noop_for_the_shared_instance():
+    # service.py closes its backend every turn; a memoized transport must not
+    # tear down connections the next turn still needs.
+    stub = StubCache()
+    await RedisVLBackend(cache=stub).aclose()
+    assert stub.check_calls == [] and stub.store_calls == []
+
+
+# -- construction / memoization ---------------------------------------------
+
+
+def test_cache_is_built_without_a_ttl(monkeypatch):
+    """acheck() refreshes the TTL of every hit it returns.
+
+    A cache-level TTL would therefore turn our fixed store-time TTLs into a
+    sliding window, so a popular "latest" answer -- deliberately short-lived
+    because it tracks a moving pointer -- would never expire. This pins the
+    invariant so adding ``ttl=`` fails here instead of silently in production.
+
+    Exercises the real ``_build_cache`` with redisvl's constructor and the
+    vectorizer patched out, so no Redis or OpenAI call happens.
+    """
+    import redisvl.extensions.cache.llm as llm_mod
+
+    import redis_sre_agent.core.semantic_cache.redisvl_backend as mod
+
+    captured = {}
+
+    class FakeSemanticCache:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+            self._ttl = kwargs.get("ttl")
+
+    monkeypatch.setattr(llm_mod, "SemanticCache", FakeSemanticCache)
+    monkeypatch.setattr(
+        "redis_sre_agent.core.vectorizer_helpers.create_vectorizer",
+        lambda cfg: object(),
+    )
+
+    cache = mod._build_cache(mod.global_settings)
+
+    assert "ttl" not in captured, "a cache-level TTL makes every read slide the TTL"
+    assert cache._ttl is None
+    # The filterable fields must reach the schema as plain dicts.
+    assert captured["filterable_fields"] == _FILTERABLE_FIELDS
+    assert captured["name"] == mod.INDEX_NAME
+
+
+def test_backend_is_built_once_per_process(monkeypatch):
+    """Construction is expensive and blocking, so it must be memoized.
+
+    Patches the builder rather than the real constructor so this test makes no
+    Redis or OpenAI call.
+    """
+    import redis_sre_agent.core.semantic_cache.redisvl_backend as mod
+
+    calls = []
+
+    def _fake_build(cfg):
+        calls.append(cfg)
+        return StubCache()
+
+    monkeypatch.setattr(mod, "_build_cache", _fake_build)
+    reset_backend_cache()
+
+    first = get_redisvl_backend()
+    second = get_redisvl_backend()
+
+    assert first is second
+    assert len(calls) == 1
+    reset_backend_cache()
+
+
+def test_distinct_settings_get_distinct_backends(monkeypatch):
+    import redis_sre_agent.core.semantic_cache.redisvl_backend as mod
+    from redis_sre_agent.core.config import settings as live_settings
+
+    monkeypatch.setattr(mod, "_build_cache", lambda cfg: StubCache())
+    reset_backend_cache()
+
+    other = live_settings.model_copy(update={"embedding_model": "some-other-model"})
+    assert get_redisvl_backend(live_settings) is not get_redisvl_backend(other)
+    reset_backend_cache()
+
+
+def test_construction_failure_degrades_to_no_cache_and_is_not_memoized(monkeypatch):
+    import redis_sre_agent.core.semantic_cache.redisvl_backend as mod
+
+    attempts = []
+
+    def _boom(cfg):
+        attempts.append(cfg)
+        raise RuntimeError("no redis")
+
+    monkeypatch.setattr(mod, "_build_cache", _boom)
+    reset_backend_cache()
+
+    assert get_redisvl_backend() is None
+    # Not cached, so a transient failure is retried on the next turn.
+    assert get_redisvl_backend() is None
+    assert len(attempts) == 2
+    reset_backend_cache()

--- a/tests/unit/core/semantic_cache/test_redisvl_backend.py
+++ b/tests/unit/core/semantic_cache/test_redisvl_backend.py
@@ -6,7 +6,7 @@ so the mapping code runs for real with no Redis, no vectorizer and no network.
 
 import pytest
 
-from redis_sre_agent.core.semantic_cache.backend import NO_ENTITY, CacheBackend
+from redis_sre_agent.core.semantic_cache.backend import NO_ENTITY
 from redis_sre_agent.core.semantic_cache.redisvl_backend import (
     _FILTERABLE_FIELDS,
     RedisVLBackend,
@@ -195,10 +195,6 @@ def test_hit_tolerates_missing_optional_fields():
 # -- transport ---------------------------------------------------------------
 
 
-def test_backend_satisfies_the_protocol():
-    assert isinstance(RedisVLBackend(cache=StubCache()), CacheBackend)
-
-
 @pytest.mark.asyncio
 async def test_search_passes_converted_threshold_and_filter():
     stub = StubCache(hits=[_hit()])
@@ -230,7 +226,7 @@ async def test_search_fails_open_on_error():
 
 @pytest.mark.asyncio
 async def test_search_handles_none_hits():
-    stub = StubCache(hits=None)
+    stub = StubCache()
     stub.hits = None
     assert await RedisVLBackend(cache=stub).search("q", similarity_threshold=0.9) == []
 
@@ -364,32 +360,43 @@ def test_backend_is_built_once_per_process(monkeypatch):
     reset_backend_cache()
 
 
-def test_distinct_settings_get_distinct_backends(monkeypatch):
+def test_construction_failure_degrades_to_no_cache(monkeypatch):
     import redis_sre_agent.core.semantic_cache.redisvl_backend as mod
-    from redis_sre_agent.core.config import settings as live_settings
 
-    monkeypatch.setattr(mod, "_build_cache", lambda cfg: StubCache())
+    monkeypatch.setattr(mod, "_build_cache", lambda cfg: (_ for _ in ()).throw(RuntimeError("x")))
     reset_backend_cache()
 
-    other = live_settings.model_copy(update={"embedding_model": "some-other-model"})
-    assert get_redisvl_backend(live_settings) is not get_redisvl_backend(other)
-    reset_backend_cache()
+    assert get_redisvl_backend() is None
 
 
-def test_construction_failure_degrades_to_no_cache_and_is_not_memoized(monkeypatch):
+def test_construction_failure_is_attempted_only_once(monkeypatch):
+    """Regression: a permanent failure must not be retried on every turn.
+
+    The realistic failure -- an index-schema mismatch after changing
+    ``filterable_fields`` or ``embedding_model`` -- never resolves on its own, and
+    every retry pays the uncached blocking OpenAI dimension probe again. Because
+    service.py builds a cache twice per turn, retrying turned a dead cache into
+    two blocking OpenAI calls per request, on the event loop, forever.
+    """
     import redis_sre_agent.core.semantic_cache.redisvl_backend as mod
 
     attempts = []
 
     def _boom(cfg):
         attempts.append(cfg)
-        raise RuntimeError("no redis")
+        raise ValueError("Existing index schema does not match. Use overwrite=True")
 
     monkeypatch.setattr(mod, "_build_cache", _boom)
     reset_backend_cache()
 
-    assert get_redisvl_backend() is None
-    # Not cached, so a transient failure is retried on the next turn.
+    # Ten construction requests == five agent turns.
+    for _ in range(10):
+        assert get_redisvl_backend() is None
+
+    assert len(attempts) == 1, f"permanent failure retried {len(attempts)} times"
+
+    # A restart (or an explicit reset) is the recovery path.
+    reset_backend_cache()
     assert get_redisvl_backend() is None
     assert len(attempts) == 2
     reset_backend_cache()

--- a/tests/unit/core/semantic_cache/test_service.py
+++ b/tests/unit/core/semantic_cache/test_service.py
@@ -5,7 +5,8 @@ import json
 import fakeredis.aioredis
 import pytest
 
-from redis_sre_agent.core.semantic_cache.client import LangCacheEntry
+from redis_sre_agent.core.semantic_cache.backend import NO_ENTITY
+from redis_sre_agent.core.semantic_cache.client import CacheEntry
 from redis_sre_agent.core.semantic_cache.provenance import ProvenanceStore, path_hash_for_source
 from redis_sre_agent.core.semantic_cache.service import (
     SemanticCache,
@@ -14,7 +15,16 @@ from redis_sre_agent.core.semantic_cache.service import (
 )
 
 
-class FakeLangCache:
+class FakeBackend:
+    """Programmable ``CacheBackend`` double for exercising *strategy*.
+
+    Implements exactly the Protocol's four methods, which is what makes the tests
+    below evidence that service.py is transport-agnostic. Real-backend mapping is
+    covered separately in ``test_backend_contract.py``; the error hooks here
+    (``search_exc``, ``delete_fail``) exist to drive fail-open paths that are
+    awkward to force through a real transport.
+    """
+
     def __init__(self):
         self.search_result = []
         self.search_exc = None
@@ -92,7 +102,7 @@ def _make_cache(client, provenance):
 
 
 def _entry(response_payload, *, similarity=0.97, attributes=None, strategy="semantic"):
-    return LangCacheEntry(
+    return CacheEntry(
         id="a" * 32,
         prompt="q",
         response=json.dumps(response_payload),
@@ -107,7 +117,7 @@ def _entry(response_payload, *, similarity=0.97, attributes=None, strategy="sema
 
 @pytest.mark.asyncio
 async def test_lookup_hit_reconstructs_response_and_sources():
-    client = FakeLangCache()
+    client = FakeBackend()
     client.search_result = [
         _entry({"response": "cached answer", "search_results": [{"title": "Doc"}]})
     ]
@@ -121,7 +131,7 @@ async def test_lookup_hit_reconstructs_response_and_sources():
 
 @pytest.mark.asyncio
 async def test_lookup_miss_returns_none():
-    client = FakeLangCache()
+    client = FakeBackend()
     client.search_result = []
     cache = _make_cache(client, FakeProvenance())
     assert await cache.lookup("anything") is None
@@ -129,7 +139,7 @@ async def test_lookup_miss_returns_none():
 
 @pytest.mark.asyncio
 async def test_lookup_below_threshold_rejected():
-    client = FakeLangCache()
+    client = FakeBackend()
     client.search_result = [_entry({"response": "x"}, similarity=0.5)]
     cache = _make_cache(client, FakeProvenance())
     assert await cache.lookup("anything") is None
@@ -137,7 +147,7 @@ async def test_lookup_below_threshold_rejected():
 
 @pytest.mark.asyncio
 async def test_lookup_post_filter_rejects_entity_mismatch():
-    client = FakeLangCache()
+    client = FakeBackend()
     # Candidate is for RET-9999 but query asks about RET-4421.
     client.search_result = [
         _entry({"response": "wrong ticket"}, attributes={"entity_id": "RET-9999"})
@@ -152,7 +162,7 @@ async def test_lookup_post_filter_rejects_entity_mismatch():
 
 @pytest.mark.asyncio
 async def test_lookup_post_filter_accepts_entity_match():
-    client = FakeLangCache()
+    client = FakeBackend()
     client.search_result = [
         _entry({"response": "right ticket"}, attributes={"entity_id": "RET-4421"})
     ]
@@ -162,8 +172,100 @@ async def test_lookup_post_filter_accepts_entity_match():
 
 
 @pytest.mark.asyncio
+async def test_lookup_general_query_rejects_ticket_scoped_entry():
+    """The other direction of the scope check: general question, ticket answer.
+
+    Both sides of the comparison must be normalized. Comparing a stored
+    ``entity_id`` against a raw ``None`` scope would make this pass by accident
+    while the *general* case below silently rejected everything.
+    """
+    client = FakeBackend()
+    client.search_result = [
+        _entry({"response": "ticket answer"}, attributes={"entity_id": "RET-4421"})
+    ]
+    cache = _make_cache(client, FakeProvenance())
+
+    assert await cache.lookup("how do I tune maxmemory?") is None
+    # A general query still filters on entity_id, using the explicit sentinel.
+    assert client.search_calls[0]["attributes"]["entity_id"] == NO_ENTITY
+
+
+@pytest.mark.asyncio
+async def test_lookup_general_query_accepts_general_entry():
+    client = FakeBackend()
+    client.search_result = [
+        _entry({"response": "general answer"}, attributes={"entity_id": NO_ENTITY})
+    ]
+    cache = _make_cache(client, FakeProvenance())
+
+    result = await cache.lookup("how do I tune maxmemory?")
+    assert result is not None and result.response == "general answer"
+
+
+@pytest.mark.asyncio
+async def test_lookup_serves_entry_behind_an_out_of_scope_top_hit():
+    """Regression: an out-of-scope top hit must not manufacture a miss.
+
+    Taking ``entries[0]`` unconditionally meant a ticket-scoped entry ranking
+    first would be rejected and reported as a miss, even with a perfectly good
+    general answer right behind it.
+    """
+    client = FakeBackend()
+    client.search_result = [
+        _entry({"response": "ticket answer"}, attributes={"entity_id": "RET-4421"}),
+        _entry({"response": "general answer"}, attributes={"entity_id": NO_ENTITY}),
+    ]
+    cache = _make_cache(client, FakeProvenance())
+
+    result = await cache.lookup("how do I tune maxmemory?")
+    assert result is not None and result.response == "general answer"
+
+
+@pytest.mark.asyncio
+async def test_lookup_skips_below_threshold_entry_to_reach_valid_one():
+    client = FakeBackend()
+    client.search_result = [
+        _entry({"response": "too weak"}, attributes={"entity_id": NO_ENTITY}, similarity=0.4),
+        _entry({"response": "strong enough"}, attributes={"entity_id": NO_ENTITY}),
+    ]
+    cache = _make_cache(client, FakeProvenance())
+
+    result = await cache.lookup("how do I tune maxmemory?")
+    assert result is not None and result.response == "strong enough"
+
+
+@pytest.mark.asyncio
+async def test_lookup_accepts_legacy_entry_without_entity_attribute():
+    """Entries stored before the sentinel existed carry no entity_id at all.
+
+    The read path normalizes a missing attribute to the sentinel, so a general
+    query still serves them rather than treating the whole pre-existing cache as
+    out of scope.
+    """
+    client = FakeBackend()
+    client.search_result = [_entry({"response": "legacy answer"}, attributes={})]
+    cache = _make_cache(client, FakeProvenance())
+
+    result = await cache.lookup("how do I tune maxmemory?")
+    assert result is not None and result.response == "legacy answer"
+
+
+@pytest.mark.asyncio
+async def test_store_writes_entity_sentinel_for_general_query():
+    client = FakeBackend()
+    cache = _make_cache(client, FakeProvenance())
+
+    await cache.store(
+        "how do I tune maxmemory?",
+        "answer",
+        [{"source_document_path": "docs/a.md"}],
+    )
+    assert client.set_calls[0]["attributes"]["entity_id"] == NO_ENTITY
+
+
+@pytest.mark.asyncio
 async def test_lookup_fails_open_on_client_error():
-    client = FakeLangCache()
+    client = FakeBackend()
     client.search_exc = RuntimeError("langcache down")
     cache = _make_cache(client, FakeProvenance())
     assert await cache.lookup("anything") is None
@@ -174,7 +276,7 @@ async def test_lookup_fails_open_on_client_error():
 
 @pytest.mark.asyncio
 async def test_store_grounded_writes_entry_and_index():
-    client = FakeLangCache()
+    client = FakeBackend()
     prov = FakeProvenance()
     cache = _make_cache(client, prov)
 
@@ -205,7 +307,7 @@ async def test_store_reuses_supplied_rewritten_key_without_calling_nano(monkeypa
 
     monkeypatch.setattr(service_mod, "rewrite_query", _boom)
 
-    client = FakeLangCache()
+    client = FakeBackend()
     cache = _make_cache(client, FakeProvenance())
     entry_id = await cache.store(
         "follow up?",
@@ -220,7 +322,7 @@ async def test_store_reuses_supplied_rewritten_key_without_calling_nano(monkeypa
 
 @pytest.mark.asyncio
 async def test_canonical_key_truncates_to_prompt_limit():
-    client = FakeLangCache()
+    client = FakeBackend()
     cache = _make_cache(client, FakeProvenance())
     key = await cache.canonical_key("x" * 5000, conversation_history=None)
     assert key == "x" * 1024
@@ -228,7 +330,7 @@ async def test_canonical_key_truncates_to_prompt_limit():
 
 @pytest.mark.asyncio
 async def test_store_ungrounded_skipped():
-    client = FakeLangCache()
+    client = FakeBackend()
     cache = _make_cache(client, FakeProvenance())
     entry_id = await cache.store("q", "answer", [])
     assert entry_id is None
@@ -237,7 +339,7 @@ async def test_store_ungrounded_skipped():
 
 @pytest.mark.asyncio
 async def test_store_skipped_when_tombstone_present_before_write():
-    client = FakeLangCache()
+    client = FakeBackend()
     prov = FakeProvenance(tombstone_sequence=[True])  # fresh tombstone before store
     cache = _make_cache(client, prov)
     entry_id = await cache.store("q", "answer", [{"source_document_path": "a.md"}])
@@ -247,7 +349,7 @@ async def test_store_skipped_when_tombstone_present_before_write():
 
 @pytest.mark.asyncio
 async def test_store_undone_when_tombstone_appears_during_write():
-    client = FakeLangCache()
+    client = FakeBackend()
     # False before write, True on the post-SADD recheck.
     prov = FakeProvenance(tombstone_sequence=[False, True])
     cache = _make_cache(client, prov)
@@ -261,7 +363,7 @@ async def test_store_undone_when_tombstone_appears_during_write():
 
 @pytest.mark.asyncio
 async def test_store_pinned_version_uses_longer_ttl():
-    client = FakeLangCache()
+    client = FakeBackend()
     cache = _make_cache(client, FakeProvenance())
     await cache.store("what changed in 7.8?", "answer", [{"source_document_path": "a.md"}])
     assert client.set_calls[0]["ttl"] == 86_400_000
@@ -273,7 +375,7 @@ async def test_store_pinned_version_uses_longer_ttl():
 
 @pytest.mark.asyncio
 async def test_invalidate_deletes_entries_and_writes_tombstone():
-    client = FakeLangCache()
+    client = FakeBackend()
     redis_client = fakeredis.aioredis.FakeRedis()
     store = ProvenanceStore(redis_client)
     cache = _make_cache(client, store)
@@ -327,7 +429,7 @@ async def test_store_version_resolved_from_rewritten_key_not_raw_query():
     version in the raw text, but the nano rewrite resolves it (e.g. 7.2). The
     stored entry must carry version=7.2 (+ pinned TTL), not latest.
     """
-    client = FakeLangCache()
+    client = FakeBackend()
     cache = _make_cache(client, FakeProvenance())
     await cache.store(
         "what about that version?",
@@ -342,7 +444,7 @@ async def test_store_version_resolved_from_rewritten_key_not_raw_query():
 
 @pytest.mark.asyncio
 async def test_lookup_version_resolved_from_rewritten_key():
-    client = FakeLangCache()
+    client = FakeBackend()
     client.search_result = []
     cache = _make_cache(client, FakeProvenance())
     await cache.lookup(
@@ -364,7 +466,7 @@ def test_path_hashes_ignores_source_fallback():
 
 @pytest.mark.asyncio
 async def test_store_without_source_document_path_records_no_reverse_index():
-    client = FakeLangCache()
+    client = FakeBackend()
     prov = FakeProvenance()
     cache = _make_cache(client, prov)
     entry_id = await cache.store("q", "answer", [{"source": "configuration", "title": "X"}])
@@ -375,7 +477,7 @@ async def test_store_without_source_document_path_records_no_reverse_index():
 @pytest.mark.asyncio
 async def test_lookup_rejects_ticket_entry_for_general_query():
     """A general query (no entity_id) must not be served a ticket-scoped entry."""
-    client = FakeLangCache()
+    client = FakeBackend()
     client.search_result = [
         _entry({"response": "ticket-scoped answer"}, attributes={"entity_id": "RET-4421"})
     ]
@@ -388,7 +490,7 @@ async def test_lookup_rejects_ticket_entry_for_general_query():
 async def test_meta_provenance_path_hashes_align_with_mixed_citations():
     """cache_meta provenance must pair each result with ITS OWN path_hash, even
     when some cited rows lack source_document_path (would misalign under zip)."""
-    client = FakeLangCache()
+    client = FakeBackend()
     prov = FakeProvenance()
     cache = _make_cache(client, prov)
     await cache.store(
@@ -413,7 +515,7 @@ async def test_meta_provenance_path_hashes_align_with_mixed_citations():
 async def test_store_rolls_back_when_provenance_recording_fails():
     """If reverse-index recording fails, the LangCache entry must be rolled back
     so it can't linger un-invalidatable (only TTL would reach it)."""
-    client = FakeLangCache()
+    client = FakeBackend()
     prov = FakeProvenance(record_ok=False)
     cache = _make_cache(client, prov)
     entry_id = await cache.store("q", "answer", [{"source_document_path": "a.md"}])
@@ -426,7 +528,7 @@ async def test_store_rolls_back_when_provenance_recording_fails():
 async def test_store_no_paths_not_rolled_back_on_meta_only_failure():
     """An entry with no source paths is TTL-only by design; a meta-only record
     failure should NOT delete an otherwise-servable entry."""
-    client = FakeLangCache()
+    client = FakeBackend()
     prov = FakeProvenance(record_ok=False)
     cache = _make_cache(client, prov)
     entry_id = await cache.store("q", "answer", [{"source": "configuration"}])
@@ -438,7 +540,7 @@ async def test_store_no_paths_not_rolled_back_on_meta_only_failure():
 async def test_invalidate_keeps_reverse_index_for_failed_deletes():
     """A failed LangCache delete must NOT drop its reverse-index link — the row
     may still exist and needs to stay invalidatable on a later retry."""
-    client = FakeLangCache()
+    client = FakeBackend()
     client.delete_fail = {"e_fail"}
     redis_client = fakeredis.aioredis.FakeRedis()
     store = ProvenanceStore(redis_client)
@@ -477,7 +579,7 @@ async def test_aclose_never_raises():
 async def test_invalidate_multi_path_shared_entry_clears_all_links():
     """An entry cited by several changed paths must be deleted once and have its
     link cleared from EVERY path's reverse-index set (no orphan on later paths)."""
-    client = FakeLangCache()
+    client = FakeBackend()
     redis_client = fakeredis.aioredis.FakeRedis()
     store = ProvenanceStore(redis_client)
     cache = _make_cache(client, store)
@@ -495,7 +597,7 @@ async def test_invalidate_multi_path_shared_entry_clears_all_links():
 
 @pytest.mark.asyncio
 async def test_lookup_skips_multi_entity_query():
-    client = FakeLangCache()
+    client = FakeBackend()
     client.search_result = [_entry({"response": "x"})]
     cache = _make_cache(client, FakeProvenance())
     result = await cache.lookup("compare RET-4421 and RET-4422")
@@ -505,7 +607,7 @@ async def test_lookup_skips_multi_entity_query():
 
 @pytest.mark.asyncio
 async def test_store_skips_multi_entity_query():
-    client = FakeLangCache()
+    client = FakeBackend()
     cache = _make_cache(client, FakeProvenance())
     entry_id = await cache.store(
         "compare RET-4421 and RET-4422", "answer", [{"source_document_path": "a.md"}]


### PR DESCRIPTION
Adds a `redisvl`-backed transport for the semantic answer cache alongside the existing LangCache one, selected by a new `semantic_cache_backend` setting (default `redisvl`). The redisvl backend runs on the service's own Redis and needs no external provisioning, so the cache is now usable without a LangCache account. `semantic_cache_enabled` remains off by default.

Both transports sit behind a single `CacheBackend` protocol, so the strategy layer — rewrite, scope resolution, cacheability, provenance, tombstones, invalidation — is shared unchanged. The contract keeps LangCache's units (similarity, milliseconds); redisvl converts to cosine distance and seconds at its own boundary.

Also fixes a latent bug in that shared layer: general queries sent no `entity_id` filter and only the top hit was considered, so a ticket-scoped entry ranking first produced a cache miss even when a valid general answer sat behind it. `entity_id` is now always written using a sentinel value, and lookup scans for the first in-scope candidate.

Known differences on the redisvl backend, documented in `docs/how-to/semantic-cache.md`: no server-side exact-match tier, client-side embeddings (so a novel query pays an embedding round trip before the miss is known), TTL-refresh-on-read deliberately disabled, deterministic entry ids that overwrite in place, and schema changes requiring the index to be dropped.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the knowledge-agent answer cache path (hits/misses, invalidation IDs) and adds blocking redisvl/OpenAI init on the event loop if misconfigured; behavior is fail-open but wrong scope matching would serve wrong answers.
> 
> **Overview**
> Introduces a **redisvl** semantic cache transport (default) on the service’s own Redis, so the knowledge-agent cache can run without LangCache credentials. **`semantic_cache_backend`** selects `redisvl` or `langcache`; shared strategy (rewrite, scope, provenance, tombstones, invalidation) stays in `SemanticCache` behind a **`CacheBackend`** protocol with a backend-neutral **`CacheEntry`**.
> 
> The **redisvl** path adds client-side embeddings, similarity↔cosine-distance and ms↔s TTL mapping, memoized one-shot construction (with permanent failure latch), delete-by-full-Redis-key, and no cache-level TTL so reads don’t slide expiry. Docs describe backend tradeoffs and operational divergences.
> 
> **Lookup/store fix (both backends):** `entity_id` is always stored and filtered using the **`_none`** sentinel for general queries; lookup **scans** ranked candidates for the first in-scope hit above threshold instead of trusting only the top result—avoiding false misses when a ticket-scoped near-miss ranks first.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a0a92ac71709bc3aa2bf6bb95198037ffbb9ae6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->