### PR TITLE
[fix] Prevent truncation of instance IDs in CLI output

### DIFF
--- a/redis_sre_agent/cli/instance.py
+++ b/redis_sre_agent/cli/instance.py
@@ -43,11 +43,11 @@ def _print_instances_table(items: List[core_instances.RedisInstance], limit: int
 
     console = Console()
     table = Table(title="Redis Instances", show_lines=False)
-    table.add_column("ID", no_wrap=True)
+    table.add_column("ID", overflow="fold")
     table.add_column("Name")
-    table.add_column("Env", no_wrap=True)
-    table.add_column("Type", no_wrap=True)
-    table.add_column("Cluster ID", no_wrap=True)
+    table.add_column("Env")
+    table.add_column("Type")
+    table.add_column("Cluster ID")
     table.add_column("URL (masked)")
 
     for inst in items[:limit]:

--- a/tests/unit/cli/test_cli_instances.py
+++ b/tests/unit/cli/test_cli_instances.py
@@ -2,9 +2,11 @@
 
 import logging
 import os
+from io import StringIO
 from unittest.mock import AsyncMock, patch
 
 from click.testing import CliRunner
+from rich.console import Console as RichConsole
 
 from redis_sre_agent.cli.instance import instance
 from redis_sre_agent.core import clusters as core_clusters
@@ -52,6 +54,37 @@ def test_instances_list_json_with_item():
     assert result.exit_code == 0
     assert "redis-dev-123" in result.output
     assert "dev-cache" in result.output
+
+
+def test_instances_list_pretty_output_does_not_truncate_id():
+    runner = CliRunner()
+    instance_id = "redis-development-01KT8TD0C4NWSP02TBSK461ABC"
+    item = core_instances.RedisInstance(
+        id=instance_id,
+        name="dev-cache",
+        connection_url="redis://localhost:6380/0",
+        environment="development",
+        usage="cache",
+        description="Dev cache",
+        instance_type="unknown",
+    )
+
+    for width in (40, 60, 80):
+        output = StringIO()
+        console = RichConsole(file=output, width=width, color_system=None)
+        with (
+            patch.object(core_instances, "get_instances", new=AsyncMock(return_value=[item])),
+            patch("redis_sre_agent.cli.instance.Console", return_value=console),
+        ):
+            result = runner.invoke(instance, ["list"])
+
+        assert result.exit_code == 0
+        rendered_id = "".join(
+            line.split("│")[1].strip()
+            for line in output.getvalue().splitlines()
+            if line.startswith("│")
+        )
+        assert rendered_id == instance_id, f"ID was truncated at console width {width}"
 
 
 def test_instances_create_logs_exception_trace_when_debug_enabled(caplog):


### PR DESCRIPTION
Fixes #204

- Allow instance IDs and secondary columns to fold on narrow terminals.
- Cover exact ID preservation at 40, 60, and 80 columns.

Post-fix:

```
[INFO] Configured instances:
WARN[0000] The "GITHUB_PERSONAL_ACCESS_TOKEN" variable is not set. Defaulting to a blank string.
                                Redis Instances
┏━━━━━━━━━━━━━━━━━┳━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━┓
┃ ID              ┃ Name ┃ Env         ┃ Type    ┃ Cluster ID ┃ URL (masked)   ┃
┡━━━━━━━━━━━━━━━━━╇━━━━━━╇━━━━━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━┩
│ redis-developme │ demo │ development │ unknown │ -          │ redis://redis… │
│ nt-01M0AGVATNYK │      │             │         │            │                │
│ 0TXQS98XHJ5P6H  │      │             │         │            │                │
└─────────────────┴──────┴─────────────┴─────────┴────────────┴────────────────┘
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only Rich table formatting for the instance list command; no data, auth, or API behavior changes.
> 
> **Overview**
> Fixes **truncated instance IDs** in `instance list` pretty output on narrow terminals by changing Rich table column overflow behavior in `_print_instances_table`.
> 
> The **ID** column now uses `overflow="fold"` instead of `no_wrap=True`, and **Env**, **Type**, and **Cluster ID** drop `no_wrap` so they can wrap with the table. Long ULID-style IDs should remain fully visible (wrapped) rather than ellipsized.
> 
> Adds **`test_instances_list_pretty_output_does_not_truncate_id`**, which patches `Console` at widths 40/60/80 and asserts the rendered ID matches the full string.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd0b3eff2c37c2a50329bab5512dd5620bffab49. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->